### PR TITLE
fix: block_put_post handle multipart bytes

### DIFF
--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.9.0
-- Build date: 2023-11-13T20:39:18.296854378Z[Etc/UTC]
+- Build date: 2023-11-15T16:13:27.108848Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -210,7 +210,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/_dag_put_post_request'
+              $ref: '#/components/schemas/_block_put_post_request'
       responses:
         "200":
           content:
@@ -557,6 +557,14 @@ components:
       required:
       - Cid
       - RemPath
+      type: object
+    _block_put_post_request:
+      properties:
+        file:
+          format: binary
+          type: string
+      required:
+      - file
       type: object
     _block_put_post_200_response:
       example:

--- a/kubo-rpc-server/examples/client/main.rs
+++ b/kubo-rpc-server/examples/client/main.rs
@@ -121,7 +121,7 @@ fn main() {
         }
         Some("BlockPutPost") => {
             let result = rt.block_on(client.block_put_post(
-                swagger::ByteArray(Vec::from("BYTE_ARRAY_DATA_HERE")),
+                swagger::ByteArray(Vec::from("BINARY_DATA_HERE")),
                 None,
                 None,
                 None,

--- a/kubo-rpc-server/src/server/mod.rs
+++ b/kubo-rpc-server/src/server/mod.rs
@@ -412,9 +412,19 @@ where
                                 let param_file = match field_file {
                                     Some(field) => {
                                         let mut reader = field[0].data.readable().expect("Unable to read field for file");
-                                        let mut data = vec![];
-                                        reader.read_to_end(&mut data).expect("Reading saved binary data should never fail");
-                                        swagger::ByteArray(data)
+                                        let mut data = String::new();
+                                        reader.read_to_string(&mut data).expect("Reading saved String should never fail");
+                                        let file_model: swagger::ByteArray = match serde_json::from_str(&data) {
+                                            Ok(model) => model,
+                                            Err(e) => {
+                                                return Ok(
+                                                    Response::builder()
+                                                    .status(StatusCode::BAD_REQUEST)
+                                                    .body(Body::from(format!("file data does not match API definition : {}", e)))
+                                                    .expect("Unable to create Bad Request due to missing required form parameter file"))
+                                            }
+                                        };
+                                        file_model
                                     },
                                     None => {
                                         return Ok(

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -257,7 +257,7 @@ paths:
               properties:
                 file:
                   type: string
-                  format: byte
+                  format: binary
       responses:
         '200':
           description: success


### PR DESCRIPTION
Code in Kubo rpc client use `read_to_string` handle file bytes, cause error like: `Unable to build body: stream did not contain valid UTF-8`. 
https://github.com/ceramicnetwork/rust-ceramic/blob/55dd5d868ef635da819c67601731da1205fce6f9/kubo-rpc-server/src/client/mod.rs#L582
This issue also reappear in official test case: https://github.com/ceramicnetwork/rust-ceramic/blob/55dd5d868ef635da819c67601731da1205fce6f9/kubo-rpc/src/http.rs#L814-L857.
Using `read_to_end` could handle raw bytes and work well with my environment (ceramic-one as Kubo server).