### PR TITLE
fix: run publisher in its own task

### DIFF
--- a/metrics/src/macros.rs
+++ b/metrics/src/macros.rs
@@ -1,6 +1,16 @@
 #[allow(unused_imports)]
 use std::any::Any;
 
+/// Useful macro for registring a metric.
+/// Ensures that the metric name and identifier name are the same.
+#[macro_export]
+macro_rules! register {
+    ( $name:ident, $description:expr, $init:expr, $registry:expr) => {
+        let $name = $init;
+        $registry.register(stringify!($name), $description, $name.clone());
+    };
+}
+
 #[macro_export]
 macro_rules! record {
     ( $e:expr, $v:expr) => {

--- a/p2p/src/metrics.rs
+++ b/p2p/src/metrics.rs
@@ -1,4 +1,4 @@
-use ceramic_metrics::Recorder;
+use ceramic_metrics::{register, Recorder};
 use prometheus_client::{
     encoding::{EncodeLabelSet, EncodeLabelValue},
     metrics::{counter::Counter, family::Family, gauge::Gauge},
@@ -9,6 +9,9 @@ use prometheus_client::{
 #[derive(Clone)]
 pub struct Metrics {
     publish_results: Family<PublishResultsLabels, Counter>,
+
+    publisher_result_send_err_count: Counter,
+    publisher_batch_send_err_count: Counter,
 
     publisher_batch_new_count: Gauge,
     publisher_batch_repeat_count: Gauge,
@@ -40,48 +43,63 @@ impl Metrics {
     pub fn register(registry: &mut Registry) -> Self {
         let sub_registry = registry.sub_registry_with_prefix("p2p");
 
-        let publish_results = Family::<PublishResultsLabels, Counter>::default();
-        sub_registry.register(
-            "publish_results",
+        register!(
+            publish_results,
             "Number of provider records results",
-            publish_results.clone(),
+            Family::<PublishResultsLabels, Counter>::default(),
+            sub_registry
         );
 
-        let publisher_batch_new_count = Gauge::default();
-        sub_registry.register(
-            "publisher_batch_new_count",
+        register!(
+            publisher_result_send_err_count,
+            "Number of errors sending a result over the internal channel",
+            Counter::default(),
+            sub_registry
+        );
+        register!(
+            publisher_batch_send_err_count,
+            "Number of errors sending a batch over the internal channel",
+            Counter::default(),
+            sub_registry
+        );
+
+        register!(
+            publisher_batch_new_count,
             "Number of records in the batch that are new",
-            publisher_batch_new_count.clone(),
+            Gauge::default(),
+            sub_registry
         );
-        let publisher_batch_repeat_count = Gauge::default();
-        sub_registry.register(
-            "publisher_batch_repeat_count",
+        register!(
+            publisher_batch_repeat_count,
             "Number of records in the batch that are repeated from the previous batch",
-            publisher_batch_repeat_count.clone(),
+            Gauge::default(),
+            sub_registry
         );
 
-        let publisher_batch_max_retry_count = Gauge::default();
-        sub_registry.register(
-            "publisher_batch_max_retry_count",
+        register!(
+            publisher_batch_max_retry_count,
             "Maximum retry count for any record in the batch",
-            publisher_batch_max_retry_count.clone(),
+            Gauge::default(),
+            sub_registry
         );
 
-        let publisher_batches_finished = Counter::default();
-        sub_registry.register(
-            "publisher_batches_finished",
+        register!(
+            publisher_batches_finished,
             "Number of batches proccessed",
-            publisher_batches_finished.clone(),
+            Counter::default(),
+            sub_registry
         );
-        let publisher_lag_ratio = Gauge::default();
-        sub_registry.register(
-            "publisher_lag_ratio",
+        register!(
+            publisher_lag_ratio,
             "Ratio of estimated_needed_time / remaining_time",
-            publish_results.clone(),
+            Gauge::default(),
+            sub_registry
         );
 
         Self {
             publish_results,
+            publisher_result_send_err_count,
+            publisher_batch_send_err_count,
             publisher_batch_new_count,
             publisher_batch_repeat_count,
             publisher_batch_max_retry_count,
@@ -93,37 +111,44 @@ impl Metrics {
 
 pub enum PublisherEvent {
     Result(PublishResult),
+    ResultSendErr,
     BatchStarted {
         new_count: i64,
         repeat_count: i64,
         max_retry_count: i64,
     },
+    BatchSendErr,
     BatchFinished {
         lag_ratio: f64,
     },
 }
 
-impl Recorder<Option<PublisherEvent>> for Metrics {
-    fn record(&self, event: &Option<PublisherEvent>) {
+impl Recorder<PublisherEvent> for Metrics {
+    fn record(&self, event: &PublisherEvent) {
         match event {
-            Some(PublisherEvent::Result(result)) => {
+            PublisherEvent::Result(result) => {
                 let labels = result.into();
                 self.publish_results.get_or_create(&labels).inc();
             }
-            Some(PublisherEvent::BatchStarted {
+            PublisherEvent::ResultSendErr => {
+                self.publisher_result_send_err_count.inc();
+            }
+            PublisherEvent::BatchStarted {
                 new_count,
                 repeat_count,
                 max_retry_count,
-            }) => {
+            } => {
                 self.publisher_batch_new_count.set(*new_count);
                 self.publisher_batch_repeat_count.set(*repeat_count);
                 self.publisher_batch_max_retry_count.set(*max_retry_count);
             }
-            Some(PublisherEvent::BatchFinished { lag_ratio }) => {
+            PublisherEvent::BatchFinished { lag_ratio } => {
                 self.publisher_batches_finished.inc();
                 self.publisher_lag_ratio.set(*lag_ratio);
             }
-            None => {}
+            PublisherEvent::BatchSendErr => {
+                self.publisher_batch_send_err_count.inc();
+            }
         }
     }
 }

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -186,6 +186,7 @@ where
             Swarm::listen_on(&mut swarm, addr.clone())?;
             listen_addrs.push(addr.clone());
         }
+
         let publisher = Publisher::new(
             libp2p_config
                 .kademlia_provider_publication_interval


### PR DESCRIPTION
This change makes the Publisher logic run in its own task. This is to relieve CPU pressure from the swarm task.