### PR TITLE
fix: trickle publisher keys to swarm

### DIFF
--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -271,11 +271,9 @@ where
                 }
                 provide_records = self.publisher.next() => {
                     if let Some(kad) = self.swarm.behaviour_mut().kad.as_mut() {
-                        if let Some(provide_records) = provide_records {
-                            for record in provide_records {
-                                if let Err(err) = kad.start_providing(record.clone()) {
-                                    warn!(key=hex::encode(record.to_vec()), %err,"failed to provide record");
-                                }
+                        if let Some(key) = provide_records {
+                            if let Err(err) = kad.start_providing(key.clone()) {
+                                warn!(key=hex::encode(key.to_vec()), %err,"failed to provide record");
                             }
                         }
                     }


### PR DESCRIPTION
Instead of sending all 1000 keys in a batch in one iteration of the swarm loop send one. This way the swarm can continue to process other concurrent work. Tests show this is still fast enough to send out all publish queries within a few seconds.