### PR TITLE
fix: do not use bootstrap list with kademlia

### DIFF
--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -17,7 +17,6 @@ use libp2p::{
         store::{MemoryStore, MemoryStoreConfig},
     },
     mdns::tokio::Behaviour as Mdns,
-    multiaddr::Protocol,
     ping::Behaviour as Ping,
     relay,
     swarm::behaviour::toggle::Toggle,
@@ -158,17 +157,11 @@ where
                 // Provider records are re-published via the [`crate::publisher::Publisher`].
                 .set_provider_publication_interval(None);
 
-            let mut kademlia = kad::Behaviour::with_config(pub_key.to_peer_id(), store, kad_config);
-            for multiaddr in &config.bootstrap_peers {
-                // TODO: move parsing into config
-                let mut addr = multiaddr.to_owned();
-                if let Some(Protocol::P2p(peer_id)) = addr.pop() {
-                    kademlia.add_address(&peer_id, addr);
-                } else {
-                    warn!("Could not parse bootstrap addr {}", multiaddr);
-                }
-            }
-            Some(kademlia)
+            Some(kad::Behaviour::with_config(
+                pub_key.to_peer_id(),
+                store,
+                kad_config,
+            ))
         } else {
             None
         }

--- a/p2p/src/behaviour/peer_manager.rs
+++ b/p2p/src/behaviour/peer_manager.rs
@@ -133,7 +133,9 @@ impl NetworkBehaviour for PeerManager {
                             self.info.remove(&peer_id);
                         }
                     }
-                    self.bootstrap_peer_manager.handle_dial_failure(&peer_id)
+                    if !matches!(event.error, DialError::DialPeerConditionFalse(_)) {
+                        self.bootstrap_peer_manager.handle_dial_failure(&peer_id)
+                    }
                 }
             }
             // Not interested in any other events


### PR DESCRIPTION
Prior to the peer_manager connecting to bootstrap peers we relied on
kademlia to connect to them. Now not only is it not necessary but the
peer_manager applies an appropriate backoff for redials where kademlia
does not. There should be no change in external behavior except that we
no longer spam dials to disconnected bootstrap peers.