### PR TITLE
fix: do not use bootstrap list with kademlia

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -70,15 +70,15 @@ struct DaemonOpts {
     )]
     swarm_addresses: Vec<String>,
 
-    /// Extra bootstrap peer addresses to be used in addition to the official bootstrap addresses.
+    /// Extra addresses of peers that participate in the Ceramic network.
     /// A best-effort attempt will be made to maintain a connection to these addresses.
     #[arg(
         long,
         use_value_delimiter = true,
         value_delimiter = ',',
-        env = "CERAMIC_ONE_EXTRA_BOOTSTRAP_ADDRESSES"
+        env = "CERAMIC_ONE_EXTRA_CERAMIC_PEER_ADDRESSES"
     )]
-    extra_bootstrap_addresses: Vec<String>,
+    extra_ceramic_peer_addresses: Vec<String>,
 
     /// Path to storage directory
     #[arg(short, long, env = "CERAMIC_ONE_STORE_DIR")]
@@ -373,14 +373,13 @@ impl Daemon {
             max_conns_pending_in: opts.max_conns_pending_in,
             max_conns_per_peer: opts.max_conns_per_peer,
             idle_connection_timeout: Duration::from_millis(opts.idle_conns_timeout_ms),
-            // Add extra bootstrap addresses to the list of official bootstrap addresses, so that our bootstrap nodes
-            // are always included.
-            bootstrap_peers: opts
+            // Add extra ceramic peer addresses to the list of official ceramic peer addresses.
+            ceramic_peers: opts
                 .network
                 .bootstrap_addresses()
                 .into_iter()
                 .chain(
-                    opts.extra_bootstrap_addresses
+                    opts.extra_ceramic_peer_addresses
                         .iter()
                         .map(|addr| addr.parse())
                         .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?,

--- a/p2p/src/behaviour/ceramic_peer_manager.rs
+++ b/p2p/src/behaviour/ceramic_peer_manager.rs
@@ -63,7 +63,7 @@ impl CeramicPeerManager {
     pub fn new(ceramic_peers: &[Multiaddr], metrics: Metrics) -> Result<Self> {
         let ceramic_peers = ceramic_peers
             .iter()
-            // Extract peer id from mutliaddr
+            // Extract peer id from multiaddr
             .map(|multiaddr| {
                 if let Some(peer) = multiaddr.iter().find_map(|proto| match proto {
                     Protocol::P2p(peer_id) => {

--- a/p2p/src/behaviour/event.rs
+++ b/p2p/src/behaviour/event.rs
@@ -1,7 +1,7 @@
 use iroh_bitswap::BitswapEvent;
 use libp2p::{autonat, dcutr, gossipsub, identify, kad, mdns, ping, relay};
 
-use super::peer_manager::PeerManagerEvent;
+use super::ceramic_peer_manager::PeerManagerEvent;
 
 /// Event type which is emitted from the [`NodeBehaviour`].
 ///

--- a/p2p/src/config.rs
+++ b/p2p/src/config.rs
@@ -36,8 +36,8 @@ pub struct Libp2pConfig {
     pub external_multiaddrs: Vec<Multiaddr>,
     /// Local address.
     pub listening_multiaddrs: Vec<Multiaddr>,
-    /// Bootstrap peer list.
-    pub bootstrap_peers: Vec<Multiaddr>,
+    /// Ceramic peer list.
+    pub ceramic_peers: Vec<Multiaddr>,
     /// Mdns discovery enabled.
     pub mdns: bool,
     /// Bitswap server mode enabled.
@@ -113,7 +113,7 @@ impl Default for Libp2pConfig {
                 "/ip4/0.0.0.0/tcp/4444".parse().unwrap(),
                 "/ip4/0.0.0.0/udp/4445/quic-v1".parse().unwrap(),
             ],
-            bootstrap_peers: vec![],
+            ceramic_peers: vec![],
             mdns: false,
             kademlia: true,
             autonat: true,


### PR DESCRIPTION
Prior to the peer_manager connecting to bootstrap peers we relied on kademlia to connect to them. Now not only is it not necessary but the peer_manager applies an appropriate backoff for redials where kademlia does not. There should be no change in external behavior except that we no longer spam dials to disconnected bootstrap peers.

Now the peer_manager (renamed to ceramic_peer_manager) can report of a peer id is a ceramic peer. If we connect to a ceramic peer we add it to the kademlia routing table regardless of its reported protocols. This is because we discovered that peers sometimes do not report they support the kademlia protocol.

We (@smrz2001  and I ) decided that renaming bootstrap peers to ceramic peers was best because it communicates the role the peers play as opposed to what we are doing with the peers. We may in the future change how we bootstrap with ceramic peers, however we will always need to know about some ceramic peers to bootstrap the network.