### PR TITLE
fix: update deploy workflows for k8s

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,30 +1,22 @@
-name: Deploy Release or Commit
+name: Deploy to Durable Infra
 
 on:
   workflow_dispatch:
     inputs:
       environment:
         type: choice
-        description: Infrastructure environment to deploy to
+        description: Durable environment to deploy to
         required: true
-        default: dev
         options:
           - dev
           - qa
           - tnet
           - prod
-      type:
-        type: choice
-        description: Release or Commit
-        required: true
-        default: release
-        options:
-          - release
-          - commit
       tag:
         type: string
         description: Tag to deploy
         required: true
+        default: latest
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -38,23 +30,8 @@ jobs:
       -
         uses: actions/checkout@v3
       -
-        name: Schedule ECS deployment
-        run: |
-          deploy_env="${{ github.event.inputs.environment }}"
-          deploy_target="release"
-          deploy_tag="${{ github.event.inputs.tag }}"
-          if [[ ${{ github.event.inputs.type == 'commit' }} == 'true' ]]; then
-            # For commit deployments, the target is the same as the tag (i.e. the commit hash).
-            deploy_target="$deploy_tag"
-          fi
-          make DEPLOY_ENV="$deploy_env" DEPLOY_TARGET="$deploy_target" DEPLOY_TAG="$deploy_tag" MANUAL_DEPLOY="true" schedule-ecs-deployment
-      -
         name: Schedule k8s deployment
-        run: |
-          deploy_env="${{ github.event.inputs.environment }}"
-          deploy_tag="${{ github.event.inputs.tag }}"
-          # If this workflow was run for a release, indicate that this is a release deployment.
-          if [[ ${{ contains(github.event.head_commit.message, 'chore: Release') }} == 'true' ]]; then
-            deploy_tag=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
-          fi
-          make DEPLOY_ENV="$deploy_env" DEPLOY_TAG="$deploy_tag" schedule-k8s-deployment
+        env:
+          DEPLOY_ENV: ${{ github.event.inputs.environment }}
+          DEPLOY_TAG: ${{ github.event.inputs.tag }}
+        run: make schedule-k8s-deployment

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish and Deploy Image
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -12,6 +13,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      deploy_tag: ${{ steps.build.outputs.deploy_tag }}
     steps:
     -
       uses: actions/checkout@v3
@@ -29,42 +32,28 @@ jobs:
         AWS_REGION: us-east-1
     -
       name: Build and Publish
+      id: build
       run: |
         SHA_TAG=$(echo ${{ github.SHA }} | head -c 12)
+        DEPLOY_TAG=$SHA_TAG
         if [[ ${{ contains(github.event.head_commit.message, 'chore: Release') }} == 'true' ]]; then
           RELEASE_TAG=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
+          # Use the release tag to deploy, if one is available.
+          DEPLOY_TAG=$RELEASE_TAG
         fi
         make SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" publish-docker
+        echo "Deploy tag:"
+        echo ${DEPLOY_TAG}
+        echo "deploy_tag=${DEPLOY_TAG}" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest
     needs:
       - publish
-    strategy:
-      fail-fast: false
-      matrix:
-        network: [dev, qa]
     steps:
       -
         uses: actions/checkout@v3
       -
-        name: Schedule ECS deployment
-        run: |
-          deploy_target="latest"
-          deploy_tag=$(echo ${{ github.SHA }} | head -c 12)
-          # If this workflow was run for a release, indicate that this is a release deployment.
-          if [[ ${{ contains(github.event.head_commit.message, 'chore: Release') }} == 'true' ]]; then
-            deploy_target="release"
-            deploy_tag=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
-          fi
-          make DEPLOY_ENV="${{ matrix.network }}" DEPLOY_TARGET="$deploy_target" DEPLOY_TAG="$deploy_tag" schedule-ecs-deployment
-
-      -
+        # TODO: Update this when we have multiple branches and a pre/release workflow
         name: Schedule k8s deployment
-        run: |
-          deploy_tag=$(echo ${{ github.SHA }} | head -c 12)
-          # If this workflow was run for a release, indicate that this is a release deployment.
-          if [[ ${{ contains(github.event.head_commit.message, 'chore: Release') }} == 'true' ]]; then
-            deploy_tag=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
-          fi
-          make DEPLOY_ENV="${{ matrix.network }}" DEPLOY_TAG="$deploy_tag" schedule-k8s-deployment
+        run: make DEPLOY_ENV="qa" DEPLOY_TAG=${{ needs.publish.outputs.deploy_tag }} schedule-k8s-deployment


### PR DESCRIPTION
This PR allows manual deployments to any of our 4 k8s envs. The CD workflow on pushes to main has been minimally updated so we can test CD and will need to be expanded once we have the additional branch and pre/release workflow updates.