### PR TITLE
chore: version v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,62 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2024-01-23
+
+### Bug Fixes
+
+- Check limits first before other behaviours (#183)
+- Panic with divide by zero duration math (#184)
+- Fix JSON log format errors (#185)
+- Update comment to pass clippy (#189)
+- Run publisher in its own task (#188)
+- Trickle publisher keys to swarm (#191)
+- Use AIMD for publisher batch size (#195)
+- Do not use bootstrap list with kademlia (#199)
+- Simplify the publisher (#200)
+- Always collect metrics (#202)
+- Typo (#203)
+- Upgrade to libp2p 0.53 (#205)
+- Clippy accessing first element with first (#212)
+- Update deploy workflows for k8s (#216)
+- Rename workflows (#223)
+
+### Features
+
+- Continously publish provider records (#175)
+- Add publisher batch metrics (#187)
+- Add config for republish_max_concurrent (#192)
+- Add peering support (#194)
+- Add tokio metrics (#206)
+- Merge migration script with ceramic-one (#190)
+- Add metrics to api and recon (#208)
+- Schedule_k8s_deploy github action (#213)
+- Recon-over-http (#168)
+- Remove all usage of gossipsub (#209)
+- Stop publishing CIDs to DHT on write (#211)
+- On tag publish deploy to envs (#220)
+- Add sqlite read/write pool split (#218)
+- Add recon store metrics (#221)
+- Updated release workflow
+
+### Refactor
+
+- Update bitswap logs to use structured logging (#193)
+
 ## [0.9.0] - 2023-11-13
 
 ### Bug Fixes
 
 - Rename iroh to ceramic-one in agent (#181)
 
+### Features
+
+- Add control over autonat (#176)
+
 ### Miscellaneous Tasks
 
 - Pass manual flag through in deployment job (#180)
+- Release version v0.9.0 (#182)
 
 ## [0.8.3] - 2023-11-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ceramic-core",
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1210,7 +1210,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "built",
  "project-root",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash 0.8.6",
  "anyhow",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cid 0.10.1",
  "futures",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3827,7 +3827,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bytes 1.5.0",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cid 0.10.1",
  "nix 0.26.4",
@@ -6941,7 +6941,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ xtaskops = "0.3"
 zeroize = "1.4"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.9.0
-- Build date: 2023-11-13T20:39:15.118815608Z[Etc/UTC]
+- API version: 0.10.0
+- Build date: 2024-01-23T00:12:23.899353555Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.9.0
+  version: 0.10.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.9.0";
+pub const API_VERSION: &str = "0.10.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum EventsPostResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.9.0
+  version: 0.10.0
   title: Ceramic API
     #license:
     #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.9.0
-- Build date: 2023-12-22T09:16:10.851194724-07:00[America/Denver]
+- API version: 0.10.0
+- Build date: 2024-01-23T00:12:27.269942694Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.9.0
+  version: 0.10.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.9.0";
+pub const API_VERSION: &str = "0.10.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.9.0
+  version: 0.10.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.10.0] - 2024-01-23

### Bug Fixes

- Check limits first before other behaviours (#183)
- Panic with divide by zero duration math (#184)
- Fix JSON log format errors (#185)
- Update comment to pass clippy (#189)
- Run publisher in its own task (#188)
- Trickle publisher keys to swarm (#191)
- Use AIMD for publisher batch size (#195)
- Do not use bootstrap list with kademlia (#199)
- Simplify the publisher (#200)
- Always collect metrics (#202)
- Typo (#203)
- Upgrade to libp2p 0.53 (#205)
- Clippy accessing first element with first (#212)
- Update deploy workflows for k8s (#216)
- Rename workflows (#223)

### Features

- Continously publish provider records (#175)
- Add publisher batch metrics (#187)
- Add config for republish_max_concurrent (#192)
- Add peering support (#194)
- Add tokio metrics (#206)
- Merge migration script with ceramic-one (#190)
- Add metrics to api and recon (#208)
- Schedule_k8s_deploy github action (#213)
- Recon-over-http (#168)
- Remove all usage of gossipsub (#209)
- Stop publishing CIDs to DHT on write (#211)
- On tag publish deploy to envs (#220)
- Add sqlite read/write pool split (#218)
- Add recon store metrics (#221)
- Updated release workflow

### Refactor

- Update bitswap logs to use structured logging (#193)