### PR TITLE
feat: synchronize value for synchronized ranges

### DIFF
--- a/core/src/interest.rs
+++ b/core/src/interest.rs
@@ -99,12 +99,7 @@ impl std::fmt::Debug for Interest {
                 .field("not_after", &self.not_after().map_err(|_| std::fmt::Error)?)
                 .finish()
         } else {
-            let bytes = self.as_slice();
-            if bytes.len() < 6 {
-                write!(f, "{}", hex::encode_upper(bytes))
-            } else {
-                write!(f, "{}", hex::encode_upper(&bytes[bytes.len() - 6..]))
-            }
+            write!(f, "{}", hex::encode_upper(self.as_slice()))
         }
     }
 }

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1268,7 +1268,12 @@ mod tests {
         async fn value_for_key(&self, _key: Self::Key) -> Result<Option<Vec<u8>>> {
             Ok(None)
         }
-
+        async fn keys_with_missing_values(
+            &self,
+            _range: RangeOpen<Self::Key>,
+        ) -> Result<Vec<Self::Key>> {
+            unreachable!()
+        }
         async fn interests(&self) -> Result<Vec<RangeOpen<Self::Key>>> {
             unreachable!()
         }

--- a/recon/src/recon/parser.lalrpop
+++ b/recon/src/recon/parser.lalrpop
@@ -29,13 +29,13 @@ Interest: RangeOpen<AlphaNumBytes> = {
     "(" <start:Word> "," <end:Word> ")" => (start, end).into()
 };
 
-State: BTreeMap<AlphaNumBytes, AlphaNumBytes> = {
+State: BTreeMap<AlphaNumBytes, Option<AlphaNumBytes>> = {
     "[" <StateInner> "]" => <>
 };
 
-StateInner: BTreeMap<AlphaNumBytes, AlphaNumBytes> = {
+StateInner: BTreeMap<AlphaNumBytes, Option<AlphaNumBytes>> = {
     <first:KeyValue?> <rest:("," <KeyValue>)*> => {
-        let mut state = BTreeMap::<AlphaNumBytes, AlphaNumBytes>::new();
+        let mut state = BTreeMap::<AlphaNumBytes, Option<AlphaNumBytes>>::new();
         state.extend(rest.into_iter());
         if let Some(first) = first {
             state.insert(first.0, first.1);
@@ -44,8 +44,9 @@ StateInner: BTreeMap<AlphaNumBytes, AlphaNumBytes> = {
     }
 };
 
-KeyValue: (AlphaNumBytes, AlphaNumBytes) = {
-    <key:Word> ":" <value:Word> => (key.clone(), value),
+KeyValue: (AlphaNumBytes, Option<AlphaNumBytes>) = {
+    <key:Word> ":" <value:Word> => (key.clone(), Some(value)),
+    <key:Word> ":" "∅" => (key.clone(), None),
 }
 
 Word : AlphaNumBytes = {

--- a/recon/src/recon/store_metrics.rs
+++ b/recon/src/recon/store_metrics.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use ceramic_core::RangeOpen;
 use ceramic_metrics::Recorder;
 use futures::Future;
 use tokio::time::Instant;
@@ -84,6 +85,21 @@ where
             "range",
             self.store
                 .range(left_fencepost, right_fencepost, offset, limit),
+        )
+        .await
+    }
+    async fn range_with_values(
+        &mut self,
+        left_fencepost: &Self::Key,
+        right_fencepost: &Self::Key,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
+        StoreMetricsMiddleware::<S>::record(
+            self.metrics.clone(),
+            "range_with_values",
+            self.store
+                .range_with_values(left_fencepost, right_fencepost, offset, limit),
         )
         .await
     }
@@ -173,6 +189,17 @@ where
             self.metrics.clone(),
             "value_for_key",
             self.store.value_for_key(key),
+        )
+        .await
+    }
+    async fn keys_with_missing_values(
+        &mut self,
+        range: RangeOpen<Self::Key>,
+    ) -> Result<Vec<Self::Key>> {
+        StoreMetricsMiddleware::<S>::record(
+            self.metrics.clone(),
+            "keys_with_missing_values",
+            self.store.keys_with_missing_values(range),
         )
         .await
     }


### PR DESCRIPTION
This change updates the Recon protocol to check for any missing values when a synchronized range of keys is discovered. This way as nodes are synchronized they ensure they also have all values for their known keys.

TODO 
- [ ] The recon split changes need to merge first