### PR TITLE
feat: updated release workflow

### DIFF
--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -1,10 +1,13 @@
 name: Continuous Deployment to Infra
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [ "main" ]
+  # Trigger on all release events until we can figure out the optimal selection
   release:
-    types: [created, published, edited, prereleased, released]
 
 env:
   AWS_REGION: ${{ secrets.AWS_REGION }}
@@ -37,7 +40,8 @@ jobs:
       run: |
         SHA_TAG=$(echo ${{ github.SHA }} | head -c 12)
         DEPLOY_TAG=$SHA_TAG
-        if [[ ${{ contains(github.event.head_commit.message, 'chore: Release') }} == 'true' ]]; then
+        COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+        if [[ $(echo "$COMMIT_MESSAGE" | grep 'chore: version v') ]]; then
           RELEASE_TAG=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
           # Use the release tag to deploy, if one is available.
           DEPLOY_TAG=$RELEASE_TAG
@@ -60,7 +64,17 @@ jobs:
           echo "Workflow triggered by: ${{ github.event_name }}"
           if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "Release action: ${{ github.event.action }}"
-            if [[ "${{ github.event.action }}" == "prereleased" ]]; then
+            # For some reason, GitHub won't trigger the "created" or "prereleased" events when a pre-release is created
+            # from the "publish-release.yml" workflow. This is despite using a PAT to create the pre-release, which is
+            # the recommended way to trigger one workflow from another.
+            #
+            # This would imply that there was some issue with the repo or workflow configuration but GitHub does trigger
+            # the "published" workflow. Because of this, we're detecting pre-releases through the "published" event and
+            # its "prerelease" flag.
+            #
+            # Strangely enough, the "edited" and "released" events are triggered when promoting the pre-release to a
+            # release through the GitHub console (╯°□°)╯︵ ┻━┻ 
+            if [[ "${{ github.event.action }}" == "published" && "${{ github.event.release.prerelease }}" == "true" ]]; then
               DEPLOY_ENV="tnet"
             elif [[ "${{ github.event.action }}" == "released" ]]; then
               DEPLOY_ENV="prod"
@@ -68,7 +82,7 @@ jobs:
           else
             DEPLOY_ENV="qa"
           fi
+          echo "DEPLOY_ENV is $DEPLOY_ENV"
           if [[ -n "$DEPLOY_ENV" ]]; then
             make DEPLOY_ENV="$DEPLOY_ENV" DEPLOY_TAG=${{ needs.publish.outputs.deploy_tag }} schedule-k8s-deployment
           fi
-          echo "DEPLOY_ENV is $DEPLOY_ENV"

--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -69,8 +69,8 @@ jobs:
             # the recommended way to trigger one workflow from another.
             #
             # This would imply that there was some issue with the repo or workflow configuration but GitHub does trigger
-            # the "published" workflow. Because of this, we're detecting pre-releases through the "published" event and
-            # its "prerelease" flag.
+            # the "published" event. Because of this, we're detecting pre-releases through the "published" event and its
+            # "prerelease" flag.
             #
             # Strangely enough, the "edited" and "released" events are triggered when promoting the pre-release to a
             # release through the GitHub console (╯°□°)╯︵ ┻━┻ 

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -1,5 +1,5 @@
-# Create a release from the latest tag
-name: Publish Release
+# Create a prerelease from the latest tag
+name: Publish Prerelease
 
 permissions:
   contents: write

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,10 +11,10 @@ on:
       - 'Cargo.toml'
 
 jobs:
-  # Build and packages all the things
+  # Build and package all the things
   build-binaries:
     if: |
-      contains(github.event.head_commit.message, 'chore: Release')
+      contains(github.event.head_commit.message, 'chore: version v')
     strategy:
       matrix:
         # For these target platforms
@@ -82,8 +82,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PAT }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -100,4 +100,8 @@ jobs:
         run: |
           export TAG=$(cargo metadata --format-version=1 --no-deps | jq '.packages[0].version' | tr -d '"')
           echo "Releasing "$TAG
-          gh release create "v${TAG}" -n "Release of ${TAG}" -t "v${TAG}" --latest artifacts/**/*.tar.gz
+          # Generate a GitHub pre-release. This will trigger the "published" event that will deploy to Clay. When the
+          # pre-release is promoted to a release from the GitHub console, the "released" event will trigger and deploy
+          # to Prod.
+          current_branch=$(git rev-parse --abbrev-ref HEAD)
+          gh release create "v${TAG}" -t "v${TAG}" --target "$current_branch" --generate-notes --prerelease artifacts/**/*.tar.gz

--- a/ci-scripts/release_pr.sh
+++ b/ci-scripts/release_pr.sh
@@ -63,16 +63,17 @@ cargo update -p ceramic-api-server
 # Commit the specified packages
 # `cargo release commit` currently fails to build a good commit message.
 # Using git commit directly for now
-branch="release-v${version}"
-git checkout -b "$branch"
-msg="chore: release version v${version}"
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+pr_branch="version-v${version}"
+git checkout -b "$pr_branch"
+msg="chore: version v${version}"
 git commit -am "$msg"
-git push --set-upstream origin $branch
+git push --set-upstream origin "$pr_branch"
 
-# Create a PR
+# Create a PR against the branch this workflow is running on
 gh pr create \
-    --base main \
-    --head "$branch" \
+    --base "$current_branch" \
+    --head "$pr_branch" \
     --label release \
     --title "$msg" \
     --body "$release_notes"


### PR DESCRIPTION
Based on @samika98's [PR](https://github.com/ceramicnetwork/rust-ceramic/pull/219) with some minor changes. More comments than actual code changes 😄 

We've retained the release PR process to bump the TOML version. This ensures that a release is not only a manual action but one that _requires approval_ from at least one other team member.

A workflow that could create a release directly would also have been fine but requiring approval seems like a better approach in principle.

The process for creating (pre)releases and their relationship to deployments is as follows:
- Create release PR bumping TOML version (e.g. v0.10.0).
- Merge of PR creates a GH pre-release with tag v0.10.0.
	- This generates the `published` trigger that causes a deployment to `tnet`.
- Repeat as many times as needed to get a stable pre-release.
- Once stable, someone toggles the `latest` flag from the GitHub UI to promote the pre-release to a release.
	- This generates the `released` trigger that causes a deployment to `prod`.
