### PR TITLE
feat: Modify recon storage tables, trait and sqlite config to improve throughput

### DIFF
--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -152,7 +152,7 @@ where
         self.model
             .store_value_for_key(event_id, &event_data)
             .await
-            .map_err(|err| ApiError(format!("failed to insert key: {err}")))?;
+            .map_err(|err| ApiError(format!("failed to insert value for key: {err}")))?;
         Ok(EventsPostResponse::Success)
     }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,7 +20,7 @@ pub use jws::{Jws, JwsSignature};
 pub use network::Network;
 pub use range::RangeOpen;
 pub use signer::{JwkSigner, Signer};
-pub use sql::SqlitePool;
+pub use sql::{DbTx, SqlitePool};
 pub use stream_id::{StreamId, StreamIdType};
 
 pub use cid::Cid;

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1247,7 +1247,7 @@ mod tests {
         type Key = K;
         type Hash = Sha256a;
 
-        async fn insert(&self, _key: Self::Key) -> Result<()> {
+        async fn insert(&self, _key: Self::Key, _value: Option<Vec<u8>>) -> Result<()> {
             unreachable!()
         }
 
@@ -1268,9 +1268,7 @@ mod tests {
         async fn value_for_key(&self, _key: Self::Key) -> Result<Option<Vec<u8>>> {
             Ok(None)
         }
-        async fn store_value_for_key(&self, _key: Self::Key, _value: &[u8]) -> Result<()> {
-            Ok(())
-        }
+
         async fn interests(&self) -> Result<Vec<RangeOpen<Self::Key>>> {
             unreachable!()
         }

--- a/recon/src/metrics.rs
+++ b/recon/src/metrics.rs
@@ -216,10 +216,12 @@ impl Metrics {
     }
 }
 
-pub(crate) struct KeyInsertEvent;
+pub(crate) struct KeyInsertEvent {
+    pub(crate) cnt: u64,
+}
 impl Recorder<KeyInsertEvent> for Metrics {
-    fn record(&self, _event: &KeyInsertEvent) {
-        self.key_insert_count.inc();
+    fn record(&self, event: &KeyInsertEvent) {
+        self.key_insert_count.inc_by(event.cnt);
     }
 }
 
@@ -237,10 +239,12 @@ impl Recorder<StoreQuery> for Metrics {
     }
 }
 
-pub(crate) struct ValueInsertEvent;
+pub(crate) struct ValueInsertEvent {
+    pub(crate) cnt: u64,
+}
 impl Recorder<ValueInsertEvent> for Metrics {
-    fn record(&self, _event: &ValueInsertEvent) {
-        self.value_insert_count.inc();
+    fn record(&self, event: &ValueInsertEvent) {
+        self.value_insert_count.inc_by(event.cnt);
     }
 }
 

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -243,7 +243,7 @@ where
         self.store.value_for_key(&key).await
     }
 
-    /// Insert many keys into the key space. Includes an optional value.
+    /// Insert key into the key space. Includes an optional value.
     /// Returns a boolean (true) indicating if the key was new.
     pub async fn insert(&mut self, item: ReconItem<'_, K>) -> Result<bool> {
         let new_val = item.value.is_some();

--- a/recon/src/recon/sqlitestore.rs
+++ b/recon/src/recon/sqlitestore.rs
@@ -1,10 +1,10 @@
 #![warn(missing_docs, missing_debug_implementations, clippy::all)]
 
-use super::HashCount;
+use super::{HashCount, InsertResult, ReconItem};
 use crate::{AssociativeHash, Key, Store};
 use anyhow::Result;
 use async_trait::async_trait;
-use ceramic_core::SqlitePool;
+use ceramic_core::{DbTx, SqlitePool};
 use sqlx::Row;
 use std::marker::PhantomData;
 use std::result::Result::Ok;
@@ -73,13 +73,97 @@ where
             PRIMARY KEY(sort_key, key)
         )";
 
-        sqlx::query(CREATE_RECON_TABLE)
-            .execute(self.pool.writer())
-            .await?;
+        let mut tx = self.pool.tx().await?;
+        sqlx::query(CREATE_RECON_TABLE).execute(&mut *tx).await?;
         sqlx::query(CREATE_RECON_VALUE_TABLE)
-            .execute(self.pool.writer())
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
         Ok(())
+    }
+
+    /// returns (new_key, new_val) tuple
+    async fn insert_item_int(
+        &mut self,
+        item: &ReconItem<'_, K>,
+        conn: &mut DbTx<'_>,
+    ) -> Result<(bool, bool)> {
+        // we insert the value first as it's possible we already have the key and can skip that step
+        // as it happens in a transaction, we'll roll back the value insert if the key insert fails and try again
+        if let Some(val) = item.value {
+            if self.insert_value_int(item.key, val, conn).await? {
+                return Ok((false, true));
+            }
+        }
+        let new_key = self.insert_key_int(item.key, conn).await?;
+        Ok((new_key, item.value.is_some()))
+    }
+
+    /// returns true if the key already exists in the recon table
+    async fn insert_value_int(&mut self, key: &K, val: &[u8], conn: &mut DbTx<'_>) -> Result<bool> {
+        let value_insert = sqlx::query(
+            r#"INSERT INTO recon_value (value, sort_key, key) 
+                VALUES (?, ?, ?) 
+            ON CONFLICT (sort_key, key) DO UPDATE 
+                SET value=excluded.value
+            RETURNING 
+                EXISTS(select 1 from recon where sort_key=? and key=?)"#,
+        );
+
+        let resp = value_insert
+            .bind(val)
+            .bind(&self.sort_key)
+            .bind(key.as_bytes())
+            .bind(&self.sort_key)
+            .bind(key.as_bytes())
+            .fetch_one(&mut **conn)
+            .await?;
+
+        let v = resp.get::<'_, bool, _>(0);
+        Ok(v)
+    }
+
+    async fn insert_key_int(&mut self, key: &K, conn: &mut DbTx<'_>) -> Result<bool> {
+        let key_insert = sqlx::query(
+            "INSERT INTO recon (
+                    sort_key, key,
+                    ahash_0, ahash_1, ahash_2, ahash_3,
+                    ahash_4, ahash_5, ahash_6, ahash_7,
+                    block_retrieved
+                ) VALUES (
+                    ?, ?,
+                    ?, ?, ?, ?,
+                    ?, ?, ?, ?,
+                    ?
+                );",
+        );
+
+        let hash = H::digest(key);
+        let resp = key_insert
+            .bind(&self.sort_key)
+            .bind(key.as_bytes())
+            .bind(hash.as_u32s()[0])
+            .bind(hash.as_u32s()[1])
+            .bind(hash.as_u32s()[2])
+            .bind(hash.as_u32s()[3])
+            .bind(hash.as_u32s()[4])
+            .bind(hash.as_u32s()[5])
+            .bind(hash.as_u32s()[6])
+            .bind(hash.as_u32s()[7])
+            .bind(false)
+            .execute(&mut **conn)
+            .await;
+        match resp {
+            std::result::Result::Ok(_rows) => Ok(true),
+            Err(sqlx::Error::Database(err)) => {
+                if err.is_unique_violation() {
+                    Ok(false)
+                } else {
+                    Err(sqlx::Error::Database(err).into())
+                }
+            }
+            Err(err) => Err(err.into()),
+        }
     }
 }
 
@@ -92,49 +176,37 @@ where
     type Key = K;
     type Hash = H;
 
-    // Ok(true): inserted the key
-    // Ok(false): did not insert the key ConstraintViolation
-    // Err(e): sql error
-    #[instrument(skip(self))]
-    async fn insert(&mut self, key: &Self::Key) -> Result<bool> {
-        let query = sqlx::query(
-            "INSERT INTO recon (
-                sort_key, key,
-                ahash_0, ahash_1, ahash_2, ahash_3,
-                ahash_4, ahash_5, ahash_6, ahash_7,
-                block_retrieved
-            ) VALUES (
-                ?, ?,
-                ?, ?, ?, ?,
-                ?, ?, ?, ?,
-                ?
-            );",
-        );
-        let hash = H::digest(key);
-        let resp = query
-            .bind(&self.sort_key)
-            .bind(key.as_bytes())
-            .bind(hash.as_u32s()[0])
-            .bind(hash.as_u32s()[1])
-            .bind(hash.as_u32s()[2])
-            .bind(hash.as_u32s()[3])
-            .bind(hash.as_u32s()[4])
-            .bind(hash.as_u32s()[5])
-            .bind(hash.as_u32s()[6])
-            .bind(hash.as_u32s()[7])
-            .bind(false)
-            .fetch_all(self.pool.writer())
-            .await;
-        match resp {
-            std::result::Result::Ok(_rows) => Ok(true),
-            Err(sqlx::Error::Database(err)) => {
-                if err.is_unique_violation() {
-                    Ok(false)
-                } else {
-                    Err(sqlx::Error::Database(err).into())
+    /// Returns true if the key was new. The value is always updated if included
+    async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+        let mut tx = self.pool.writer().begin().await?;
+        let (new_key, new_val) = self.insert_item_int(&item, &mut tx).await?;
+        tx.commit().await?;
+        Ok(new_key || new_val)
+    }
+
+    /// Insert new keys into the key space.
+    /// Returns true if a key did not previously exist.
+    async fn insert_many<'a, I>(&mut self, items: I) -> Result<InsertResult>
+    where
+        I: ExactSizeIterator<Item = ReconItem<'a, K>> + Send + Sync,
+    {
+        match items.len() {
+            0 => Ok(InsertResult::new(vec![], 0)),
+            _ => {
+                let mut results = vec![false; items.len()];
+                let mut new_val_cnt = 0;
+                let mut tx = self.pool.writer().begin().await?;
+
+                for (idx, item) in items.enumerate() {
+                    let (new_key, new_val) = self.insert_item_int(&item, &mut tx).await?;
+                    results[idx] = new_key;
+                    if new_val {
+                        new_val_cnt += 1;
+                    }
                 }
+                tx.commit().await?;
+                Ok(InsertResult::new(results, new_val_cnt))
             }
-            Err(err) => Err(err.into()),
         }
     }
 
@@ -370,23 +442,6 @@ where
     }
 
     #[instrument(skip(self))]
-    async fn store_value_for_key(&mut self, key: &Self::Key, value: &[u8]) -> Result<bool> {
-        let query = sqlx::query(
-            r#"INSERT INTO recon_value (value, sort_key, key) 
-            VALUES (?, ?, ?) 
-            ON CONFLICT (sort_key, key) DO UPDATE 
-            SET value=excluded.value;"#,
-        );
-        let resp = query
-            .bind(value)
-            .bind(&self.sort_key)
-            .bind(key.as_bytes())
-            .fetch_all(self.pool.writer())
-            .await?;
-        Ok(true)
-    }
-
-    #[instrument(skip(self))]
     async fn value_for_key(&mut self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
         let query = sqlx::query("SELECT value FROM recon_value WHERE sort_key=? AND key=?;");
         let row = query
@@ -402,6 +457,7 @@ where
 mod tests {
     use super::*;
 
+    use crate::recon::ReconItem;
     use crate::tests::AlphaNumBytes;
     use crate::Sha256a;
 
@@ -418,8 +474,14 @@ mod tests {
     #[test(tokio::test)]
     async fn test_hash_range_query() {
         let mut store = new_store().await;
-        store.insert(&AlphaNumBytes::from("hello")).await.unwrap();
-        store.insert(&AlphaNumBytes::from("world")).await.unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("hello")))
+            .await
+            .unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("world")))
+            .await
+            .unwrap();
         let hash: Sha256a = store
             .hash_range(&b"a".as_slice().into(), &b"z".as_slice().into())
             .await
@@ -432,8 +494,14 @@ mod tests {
     #[test(tokio::test)]
     async fn test_range_query() {
         let mut store = new_store().await;
-        store.insert(&AlphaNumBytes::from("hello")).await.unwrap();
-        store.insert(&AlphaNumBytes::from("world")).await.unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("hello")))
+            .await
+            .unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("world")))
+            .await
+            .unwrap();
         let ids = store
             .range(
                 &b"a".as_slice().into(),
@@ -468,7 +536,11 @@ mod tests {
         )
         "#
         ]
-        .assert_debug_eq(&store.insert(&AlphaNumBytes::from("hello")).await);
+        .assert_debug_eq(
+            &store
+                .insert(ReconItem::new_key(&AlphaNumBytes::from("hello")))
+                .await,
+        );
 
         // reject the second insert of same key
         expect![
@@ -478,14 +550,24 @@ mod tests {
         )
         "#
         ]
-        .assert_debug_eq(&store.insert(&AlphaNumBytes::from("hello")).await);
+        .assert_debug_eq(
+            &store
+                .insert(ReconItem::new_key(&AlphaNumBytes::from("hello")))
+                .await,
+        );
     }
 
     #[test(tokio::test)]
     async fn test_first_and_last() {
         let mut store = new_store().await;
-        store.insert(&AlphaNumBytes::from("hello")).await.unwrap();
-        store.insert(&AlphaNumBytes::from("world")).await.unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("hello")))
+            .await
+            .unwrap();
+        store
+            .insert(ReconItem::new_key(&AlphaNumBytes::from("world")))
+            .await
+            .unwrap();
 
         // Only one key in range
         let ret = store
@@ -541,9 +623,8 @@ mod tests {
         let mut store = new_store().await;
         let key = AlphaNumBytes::from("hello");
         let store_value = AlphaNumBytes::from("world");
-        store.insert(&key).await.unwrap();
         store
-            .store_value_for_key(&key, store_value.as_slice())
+            .insert(ReconItem::new_with_value(&key, store_value.as_slice()))
             .await
             .unwrap();
         let value = store.value_for_key(&key).await.unwrap().unwrap();

--- a/recon/src/recon/sqlitestore.rs
+++ b/recon/src/recon/sqlitestore.rs
@@ -179,9 +179,9 @@ where
     /// Returns true if the key was new. The value is always updated if included
     async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
         let mut tx = self.pool.writer().begin().await?;
-        let (new_key, new_val) = self.insert_item_int(&item, &mut tx).await?;
+        let (new_key, _new_val) = self.insert_item_int(&item, &mut tx).await?;
         tx.commit().await?;
-        Ok(new_key || new_val)
+        Ok(new_key)
     }
 
     /// Insert new keys into the key space.

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -1302,10 +1302,10 @@ async fn disjoint() {
             cat: [a: A, b: B, c: C, e: , f: , g: ]
         -> value_req(e)
             cat: [a: A, b: B, c: C, e: , f: , g: ]
-        <- value_resp(e: E)
-            dog: [a: A, b: B, c: C, e: E, f: F, g: G]
         -> value_req(f)
             cat: [a: A, b: B, c: C, e: , f: , g: ]
+        <- value_resp(e: E)
+            dog: [a: A, b: B, c: C, e: E, f: F, g: G]
         -> value_req(g)
             cat: [a: A, b: B, c: C, e: E, f: , g: ]
         <- value_resp(f: F)
@@ -1482,10 +1482,10 @@ async fn paper() {
             cat: [ape: APE, bee: BEE, cot: COT, doe: , eel: EEL, fox: FOX, gnu: GNU]
         <- range_resp({gnu h(hog)#1 𝛀 })
             dog: [ape: APE, bee: BEE, cot: COT, doe: DOE, eel: EEL, fox: FOX, gnu: GNU, hog: HOG]
-        -> listen_only
-            cat: [ape: APE, bee: BEE, cot: COT, doe: , eel: EEL, fox: FOX, gnu: GNU, hog: HOG]
         <- value_resp(doe: DOE)
             dog: [ape: APE, bee: BEE, cot: COT, doe: DOE, eel: EEL, fox: FOX, gnu: GNU, hog: HOG]
+        -> listen_only
+            cat: [ape: APE, bee: BEE, cot: COT, doe: , eel: EEL, fox: FOX, gnu: GNU, hog: HOG]
         <- listen_only
             dog: [ape: APE, bee: BEE, cot: COT, doe: DOE, eel: EEL, fox: FOX, gnu: GNU, hog: HOG]
         -> finished
@@ -1729,18 +1729,18 @@ async fn alternating() {
             cat: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: , v: V, w: , x: X, y: , z: Z]
         -> value_req(u)
             cat: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: , v: V, w: , x: X, y: , z: Z]
+        <- value_resp(u: U)
+            dog: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z]
         -> value_req(w)
             cat: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: , v: V, w: , x: X, y: , z: Z]
-        <- value_resp(u: U)
+        <- value_resp(w: W)
             dog: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z]
         -> value_req(y)
             cat: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: , x: X, y: , z: Z]
-        <- value_resp(w: W)
+        <- value_resp(y: Y)
             dog: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z]
         -> listen_only
             cat: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: , z: Z]
-        <- value_resp(y: Y)
-            dog: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z]
         <- listen_only
             dog: [a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, o: O, p: P, q: Q, r: R, s: S, t: T, u: U, v: V, w: W, x: X, y: Y, z: Z]
         -> finished
@@ -1959,10 +1959,10 @@ async fn subset_interest() {
             dog: [b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, r: ]
         -> value_req(i)
             cat: [b: , c: C, e: , f: F, g: G, i: , m: , n: N, r: R]
-        -> value_req(m)
-            cat: [b: , c: C, d: D, e: , f: F, g: G, i: , m: , n: N, r: R]
         <- range_resp({c h(d)#1 e})
             dog: [b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K, l: L, m: M, n: N, r: ]
+        -> value_req(m)
+            cat: [b: , c: C, d: D, e: , f: F, g: G, i: , m: , n: N, r: R]
         -> value_resp(r: R)
             cat: [b: , c: C, d: D, e: , f: F, g: G, i: , m: , n: N, r: R]
         <- range_resp({e 0 f})

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -40,7 +40,7 @@ use pretty::{Arena, DocAllocator, DocBuilder, Pretty};
 
 use crate::{
     protocol::{self, InitiatorMessage, ResponderMessage, ValueResponse},
-    recon::{FullInterests, HashCount, InterestProvider, Range},
+    recon::{FullInterests, HashCount, InterestProvider, Range, ReconItem},
     tests::AlphaNumBytes,
     AssociativeHash, BTreeStore, Client, Key, Metrics, Recon, Server, Sha256a, Store,
 };
@@ -569,10 +569,12 @@ async fn word_lists() {
         );
         for key in s.split([' ', '\n']).map(|s| s.to_string()) {
             if !s.is_empty() {
-                r.insert(&key.as_bytes().into()).await.unwrap();
-                r.store_value_for_key(key.as_bytes().into(), key.to_uppercase().as_bytes().into())
-                    .await
-                    .unwrap();
+                r.insert(ReconItem::new(
+                    &key.as_bytes().into(),
+                    key.to_uppercase().as_bytes().into(),
+                ))
+                .await
+                .unwrap();
             }
         }
         start_recon(r)


### PR DESCRIPTION
Linear WS1-1432.

Before making any changes, I was seeing about 400/100 rps keys added/synced. After these changes, we're able to push the incoming over 1k, and a steady workload targeting 300 completed with ~310/240 keys exchanged/sec. 

**Changes**: 

- I moved the recon values into their own table: `recon_value`. This doesn't have any real benefit up front, but as the table grows it will help. Eventually, a single table will pay during reads as scans will load a lot more data. The value is about 10x bigger and will explode row sizes: a key is ~80 bytes and the value is ~1KB. The initial change moved writes up and syncs down: 450/65.
  - In a POC, I left things in a single table and hit around 800/100 rps just changing the events_post insert to use a single statement. I expect we could push things higher than we are with that format, but eventually I would expect it to slow down while our multiple table approach should stay relatively consistent. 
  - All that to say, I think this is the right choice even though it reduces pure throughput potential initially.
- I refactored the recon traits (particularly storage) to handle inserting a key and value simultaneously. This allows us more control at the database layer about how we handle these writes (in a transaction, batched, etc). Re-using a single transaction for all the writes for a request improved throughput substantially (36%) to 600/85.
- I modified some sqlite config settings. Changing to `pragma synchronous = NORMAL` had a huge impact after the other changes. When I tried it originally, it made zero noticeable difference. After the batched write/transaction usage, it sped up another 80% to 1120/150.

**Follow ups**:
- Something seems wrong with the `hash_range` query (or rather, the indexes/table layout), after a certain point it begins it increase in duration linearly (seems like it's potentially a table scan as we add more rows).
- It's possible using `BEGIN IMMEDIATE` for transactions would be faster (not in sqlx currently, so would likely require a wrapper to make sure drop is called/things are rolled back, or updating to a single statement).
- Other settings like `mmap_size` or `temp_store = memory` might be worth changing, and possibly other pragma options. 
- We could also INSERT multiple rows in one statement. We currently insert a single key/value or at most 2 keys and values on all paths, but 2-4 round trips is probably quite a bit slower than one, even if it is a local file.
- I think our next bottlenecks may be in the recon client/server protocol loops. I need to prove that, but it appears we prioritize incoming writes and starve syncs (potentially a result of the `select!(biased)` usage). It's not necessarily a bad thing, but we may want to look at it.

-----
**Steady simulation results**:

I ran a simulation with the following spec and it almost hit 300 rps on both sides. One side was 280314 over 15m for 311 rps. The sync target was 217945 new keys for a rate of 242 rps. It took about 5 minutes for the recv to catch up, but it ended at 380313 keys (one short) 🤔 This seems like it may be a result of the hanging hash_range queries.

```yaml
apiVersion: "keramik.3box.io/v1alpha1"
kind: Simulation
metadata:
  name: event-ids
  # Must be the same namespace as the network to test
  namespace: keramik-small
spec:
  scenario: recon-event-sync
  devMode: true
  throttleRequests: 350
  successRequestTarget: 280
  users: 1
  runTime: 15
```

The SQL queries were quite consistent throughout and much more performant. Before these changes, the best I was seeing was 1.5m on inserts and upwards of 2.5m depending on the query setup. Here things stay about 0.7m on the high end, while most are much faster.

![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/06f9c525-3c5e-4afc-a848-61471072d9ac)

Difference between keys on both sides (logarithmic)
![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/ceeb9478-b607-4f79-a7ce-9a7719f3fe48)

Simulation sync rate
![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/5e442526-73f4-4611-930b-59b0a58a264b)

-------
**Stress test results**:

When adding keys much faster to one node, we see the `middle` and `hash_range` queries on the write side taking the longest. This is 5x what we were seeing above, but they do level out pretty quickly. The second spike resulted in a substantial dip in sync rate. Unfortunately, the result was 1008588 keys on one side and only 883593 on the other after 30 minutes and nothing was happening and the `hash_range` duration kept increasing (over 1s queries in the logs). 

![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/06fc567a-d0e9-46f5-8634-12c2837f1df7)

-------
**Botched metrics**:

Unfortunately, all of the values below are inflated due to counting value updates (existing key) as a new key. It is interesting compared to the corrected results, as it demonstrates how syncing the values for keys we already have is what is consuming most of the remaining distance between the new keys on the writer and our side. One side was 280395 req in 15 minutes for 311 rps and the other was 282165 (counting keys and new_keys || values), which shows the key + value follow up are going faster than the incoming requests, but just getting keys is not.

![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/4b5818fa-0795-4f66-a257-0742c8a78071)

![image](https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/9a400fd5-26bc-4e25-b96a-28bb1e564fbd)
