### PR TITLE
feat: support for set type documents

### DIFF
--- a/event/src/deterministic_init_event.rs
+++ b/event/src/deterministic_init_event.rs
@@ -5,14 +5,16 @@ use serde::Serialize;
 use std::fmt::Formatter;
 
 /// A deterministic init event, where it will always hash the same way
+#[derive(Serialize)]
 pub struct DeterministicInitEvent {
     /// The encoded event
+    #[serde(flatten)]
     pub encoded: DagCborEncoded,
 }
 
 impl DeterministicInitEvent {
     /// Create a deterministic init event from an unsigned event
-    pub fn new<T: Serialize>(evt: &UnsignedEvent<'_, T>) -> Result<Self> {
+    pub fn new(evt: &UnsignedEvent<()>) -> Result<Self> {
         let data = DagCborEncoded::new(&evt)?;
         Ok(Self { encoded: data })
     }

--- a/event/src/event.rs
+++ b/event/src/event.rs
@@ -19,8 +19,8 @@ pub struct Event {
 
 impl Event {
     /// Create a new event from an unsigned event, signer, and jwk
-    pub async fn new<'a, T: Serialize>(
-        unsigned: &'a UnsignedEvent<'a, T>,
+    pub async fn new<T: Serialize>(
+        unsigned: UnsignedEvent<T>,
         signer: &impl Signer,
     ) -> Result<Self> {
         // encode our event with dag cbor, hashing that to create cid


### PR DESCRIPTION
Adds support for documents that have a unique header but no data. Additionally reduces usage of lifetimes as they only add complexity.