### PR TITLE
fix: use try_from on recon keys

### DIFF
--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -341,10 +341,11 @@ where
 }
 
 fn decode_event_id(value: &str) -> Result<EventId, ApiError> {
-    Ok(multibase::decode(value)
+    multibase::decode(value)
         .map_err(|err| ApiError(format!("multibase error: {err}")))?
         .1
-        .into())
+        .try_into()
+        .map_err(|err| ApiError(format!("invalid event id: {err}")))
 }
 fn decode_event_data(value: &str) -> Result<Vec<u8>, ApiError> {
     Ok(multibase::decode(value)

--- a/core/src/event_id.rs
+++ b/core/src/event_id.rs
@@ -29,6 +29,9 @@ use unsigned_varint::{decode::u64 as de_varint, encode::u64 as varint};
 
 use crate::network::Network;
 
+const MIN_BYTES: [u8; 0] = [];
+const MAX_BYTES: [u8; 1] = [0xFF];
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 /// EventId is the event data as a recon key
 pub struct EventId(#[serde(with = "serde_bytes")] Vec<u8>);
@@ -212,14 +215,21 @@ struct EventIdParts<'a> {
 impl std::fmt::Debug for EventId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if f.alternate() {
-            f.debug_struct("EventId")
-                .field("network_id", &self.network_id())
-                .field("separator", &self.separator().map(hex::encode))
-                .field("controller", &self.controller().map(hex::encode))
-                .field("stream_id", &self.stream_id().map(hex::encode))
-                .field("event_height", &self.event_height())
-                .field("cid", &self.cid().map(|cid| cid.to_string()))
-                .finish()
+            if self.0 == MIN_BYTES {
+                f.debug_struct("EventId").field("bytes", &"MIN").finish()
+            } else if self.0 == MAX_BYTES {
+                f.debug_struct("EventId").field("bytes", &"MAX").finish()
+            } else {
+                f.debug_struct("EventId")
+                    .field("bytes", &hex::encode(&self.0))
+                    .field("network_id", &self.network_id())
+                    .field("separator", &self.separator().map(hex::encode))
+                    .field("controller", &self.controller().map(hex::encode))
+                    .field("stream_id", &self.stream_id().map(hex::encode))
+                    .field("event_height", &self.event_height())
+                    .field("cid", &self.cid().map(|cid| cid.to_string()))
+                    .finish()
+            }
         } else {
             write!(f, "{}", hex::encode_upper(self.as_slice()))
         }
@@ -232,22 +242,31 @@ impl Display for EventId {
     }
 }
 
-impl From<&[u8]> for EventId {
-    fn from(bytes: &[u8]) -> Self {
-        EventId(bytes.to_owned())
+impl TryFrom<Vec<u8>> for EventId {
+    type Error = InvalidEventId;
+    fn try_from(bytes: Vec<u8>) -> Result<Self, Self::Error> {
+        let event_id = Self(bytes);
+        if event_id.0 == MIN_BYTES || event_id.0 == MAX_BYTES {
+            // We have a min or max event id which is valid but does not parse
+            Ok(event_id)
+        } else {
+            // Parse the event id to ensure its valid
+            event_id.as_parts().ok_or(InvalidEventId)?;
+            Ok(event_id)
+        }
     }
 }
 
-impl From<Vec<u8>> for EventId {
-    fn from(bytes: Vec<u8>) -> Self {
-        EventId(bytes)
+/// Error when constructing an event id
+#[derive(Debug)]
+pub struct InvalidEventId;
+
+impl std::fmt::Display for InvalidEventId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid event id bytes")
     }
 }
-impl From<&Vec<u8>> for EventId {
-    fn from(bytes: &Vec<u8>) -> Self {
-        EventId(bytes.to_owned())
-    }
-}
+impl std::error::Error for InvalidEventId {}
 
 fn sha256_digest(s: &str) -> [u8; 32] {
     let mut hasher = Sha2_256::default();
@@ -325,6 +344,14 @@ pub struct WithEvent {
 impl BuilderState for WithEvent {}
 
 impl Builder<Init> {
+    /// Builds the minimum possible EventId
+    pub fn build_min_fencepost(self) -> EventId {
+        EventId(MIN_BYTES.into())
+    }
+    /// Builds the maximum possible EventId
+    pub fn build_max_fencepost(self) -> EventId {
+        EventId(MAX_BYTES.into())
+    }
     /// Specify the network of the event
     pub fn with_network(self, network: &Network) -> Builder<WithNetwork> {
         // Maximum EventId size is 72.
@@ -602,6 +629,7 @@ mod tests {
         println!("{:?}, {:?}", &received, &cid);
         expect![[r#"
             EventId {
+                bytes: "ce0105007e710e217fa0e25945cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86",
                 network_id: Some(
                     0,
                 ),
@@ -699,6 +727,7 @@ mod tests {
         );
         expect![[r#"
             EventId {
+                bytes: "ce0105017e710e217fa0e25945cc7c072ff729ea683b751718ff01711220f4ef7ec208944d257025408bb647949e6b72930520bc80f34d8bfbafd2643d86",
                 network_id: Some(
                     1,
                 ),

--- a/core/src/interest.rs
+++ b/core/src/interest.rs
@@ -1,3 +1,4 @@
+//! Interest is a structure that declares a range of data in which a node is interested.
 use anyhow::Result;
 use cid::multihash::{Hasher, Sha2_256};
 use minicbor::{Decoder, Encoder};
@@ -8,6 +9,9 @@ use std::{fmt::Display, str::FromStr};
 pub use libp2p_identity::PeerId;
 
 use crate::RangeOpen;
+
+const MIN_BYTES: [u8; 0] = [];
+const MAX_BYTES: [u8; 1] = [0xFF];
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 /// Interest declares an interest in a keyspace for a given peer.
@@ -27,79 +31,87 @@ impl Interest {
     }
 
     /// Report the sort key
-    pub fn sort_key_hash(&self) -> Result<&[u8]> {
-        let mut decoder = Decoder::new(&self.0);
-        Ok(decoder.bytes()?)
+    pub fn sort_key_hash(&self) -> Option<&[u8]> {
+        Some(self.as_parts()?.sort_key_hash)
     }
 
     /// Report the PeerId value
-    pub fn peer_id(&self) -> Result<PeerId> {
-        let mut decoder = Decoder::new(&self.0);
-        // Skip sort key
-        decoder.skip()?;
-        let peer_id_bytes = decoder.bytes();
-        Ok(PeerId::from_bytes(peer_id_bytes?)?)
+    pub fn peer_id(&self) -> Option<PeerId> {
+        PeerId::from_bytes(self.as_parts()?.peer_id).ok()
     }
 
     /// Report the range value.
-    ///
-    /// Returns an error when the Interest is invalid.
-    /// Returns Ok(None) when the Interest does not contain a range.
-    pub fn range(&self) -> Result<Option<RangeOpen<Vec<u8>>>> {
-        let mut decoder = Decoder::new(&self.0);
-        // Skip sort key
-        decoder.skip()?;
-        // Skip peer_id
-        decoder.skip()?;
-        let indicator = decoder.u8()?;
-        if indicator != 1 {
-            // No range encoded
-            Ok(None)
-        } else {
-            let start = decoder.bytes()?.to_vec();
-            let end = decoder.bytes()?.to_vec();
-            Ok(Some(RangeOpen { start, end }))
-        }
+    /// Returns None if no range can be decoded.
+    pub fn range(&self) -> Option<RangeOpen<Vec<u8>>> {
+        self.as_parts()?.range.map(|(start, end)| RangeOpen {
+            start: start.to_vec(),
+            end: end.to_vec(),
+        })
     }
 
     /// Report the not after value
-    pub fn not_after(&self) -> Result<u64> {
-        let mut decoder = Decoder::new(&self.0);
-        // Skip sort key
-        decoder.skip()?;
-        // Skip peer_id
-        decoder.skip()?;
-        // Skip start_key indicator
-        decoder.skip()?;
-        // Skip start_key
-        decoder.skip()?;
-        // Skip end_key
-        decoder.skip()?;
-
-        Ok(decoder.u64()?)
+    pub fn not_after(&self) -> Option<u64> {
+        self.as_parts()?.not_after
     }
 
     /// Return the interest as a slice of bytes.
     pub fn as_slice(&self) -> &[u8] {
         self.0.as_slice()
     }
+
+    // Parses the interest into its parts
+    // A valid interest may not contain all parts.
+    // However a None from this method indicates an invalid interest.
+    fn as_parts(&self) -> Option<InterestParts<'_>> {
+        let mut decoder = Decoder::new(&self.0);
+        let sort_key_hash = decoder.bytes().ok()?;
+        let peer_id = decoder.bytes().ok()?;
+        let indicator = decoder.u8().ok()?;
+        let (range, not_after) = if indicator != 1 {
+            (None, None)
+        } else {
+            (
+                Some((decoder.bytes().ok()?, decoder.bytes().ok()?)),
+                Some(decoder.u64().ok()?),
+            )
+        };
+        Some(InterestParts {
+            sort_key_hash,
+            peer_id,
+            range,
+            not_after,
+        })
+    }
+}
+
+struct InterestParts<'a> {
+    sort_key_hash: &'a [u8],
+    peer_id: &'a [u8],
+    range: Option<(&'a [u8], &'a [u8])>,
+    not_after: Option<u64>,
 }
 
 impl std::fmt::Debug for Interest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if f.alternate() {
-            f.debug_struct("Interest")
-                .field("bytes", &hex::encode(&self.0))
-                .field(
-                    "sort_key_hash",
-                    &hex::encode(self.sort_key_hash().map_err(|_| std::fmt::Error)?),
-                )
-                .field("peer_id", &self.peer_id().map_err(|_| std::fmt::Error)?)
-                .field("range", &self.range().map_err(|_| std::fmt::Error)?)
-                .field("not_after", &self.not_after().map_err(|_| std::fmt::Error)?)
-                .finish()
+            if self.0 == MIN_BYTES {
+                f.debug_struct("Interest").field("bytes", &"MIN").finish()
+            } else if self.0 == MAX_BYTES {
+                f.debug_struct("Interest").field("bytes", &"MAX").finish()
+            } else {
+                f.debug_struct("Interest")
+                    .field("bytes", &hex::encode(&self.0))
+                    .field(
+                        "sort_key_hash",
+                        &hex::encode(self.sort_key_hash().ok_or(std::fmt::Error)?),
+                    )
+                    .field("peer_id", &self.peer_id().ok_or(std::fmt::Error)?)
+                    .field("range", &self.range().ok_or(std::fmt::Error)?)
+                    .field("not_after", &self.not_after().ok_or(std::fmt::Error)?)
+                    .finish()
+            }
         } else {
-            write!(f, "{}", hex::encode_upper(self.as_slice()))
+            write!(f, "{}", dbg!(hex::encode_upper(self.as_slice())))
         }
     }
 }
@@ -157,6 +169,15 @@ pub struct WithNotAfter {
 impl BuilderState for WithNotAfter {}
 
 impl Builder<Init> {
+    /// Builds the minimum possible Interest
+    pub fn build_min_fencepost(self) -> Interest {
+        Interest(MIN_BYTES.into())
+    }
+    /// Builds the maximum possible Interest
+    pub fn build_max_fencepost(self) -> Interest {
+        Interest(MAX_BYTES.into())
+    }
+    /// Builds an interest starting with a specific sort key.
     pub fn with_sort_key(self, sort_key: &str) -> Builder<WithSortKey> {
         // A typical interest contains:
         //
@@ -185,6 +206,7 @@ impl Builder<Init> {
     }
 }
 impl Builder<WithSortKey> {
+    /// Builds interest with specific peer id.
     pub fn with_peer_id(mut self, peer_id: &PeerId) -> Builder<WithPeerId> {
         self.state
             .encoder
@@ -198,6 +220,7 @@ impl Builder<WithSortKey> {
     }
 }
 impl Builder<WithPeerId> {
+    /// Builds interest with minimum possible range.
     pub fn with_min_range(mut self) -> Builder<WithRange> {
         self.state.encoder.u8(0).expect("min range should encode");
         Builder {
@@ -206,6 +229,7 @@ impl Builder<WithPeerId> {
             },
         }
     }
+    /// Builds interest with max possible range.
     pub fn with_max_range(mut self) -> Builder<WithRange> {
         self.state.encoder.u8(2).expect("min range should encode");
         Builder {
@@ -214,6 +238,7 @@ impl Builder<WithPeerId> {
             },
         }
     }
+    /// Builds interest with specific range.
     pub fn with_range<'a>(mut self, range: impl Into<RangeOpen<&'a [u8]>>) -> Builder<WithRange> {
         let range = range.into();
         self.state
@@ -232,9 +257,11 @@ impl Builder<WithPeerId> {
     }
 }
 impl Builder<WithRange> {
+    /// Builds interest as fencepost.
     pub fn build_fencepost(self) -> Interest {
         Interest(self.state.encoder.into_writer())
     }
+    /// Builds interest with specific not_after value
     pub fn with_not_after(mut self, not_after: u64) -> Builder<WithNotAfter> {
         self.state
             .encoder
@@ -249,27 +276,38 @@ impl Builder<WithRange> {
 }
 
 impl Builder<WithNotAfter> {
+    /// Builds a complete interest.
     pub fn build(self) -> Interest {
         Interest(self.state.encoder.into_writer())
     }
 }
 
-impl From<&[u8]> for Interest {
-    fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_owned())
+impl TryFrom<Vec<u8>> for Interest {
+    type Error = InvalidInterest;
+
+    fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+        let interest = Self(value);
+        if interest.0 == MIN_BYTES || interest.0 == MAX_BYTES {
+            // We have a min or max interest which is valid but does not parse
+            Ok(interest)
+        } else {
+            // Parse the interest to ensure its valid
+            interest.as_parts().ok_or(InvalidInterest)?;
+            Ok(interest)
+        }
     }
 }
 
-impl From<Vec<u8>> for Interest {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+/// Error when constructing an interest
+#[derive(Debug)]
+pub struct InvalidInterest;
+
+impl std::fmt::Display for InvalidInterest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid interest bytes")
     }
 }
-impl From<&Vec<u8>> for Interest {
-    fn from(bytes: &Vec<u8>) -> Self {
-        Self(bytes.to_owned())
-    }
-}
+impl std::error::Error for InvalidInterest {}
 
 #[cfg(test)]
 mod tests {
@@ -313,20 +351,18 @@ mod tests {
         "#]]
         .assert_debug_eq(&interest.peer_id().unwrap().to_string());
         expect![[r#"
-            Some(
-                RangeOpen {
-                    start: [
-                        0,
-                        1,
-                        2,
-                    ],
-                    end: [
-                        0,
-                        1,
-                        9,
-                    ],
-                },
-            )
+            RangeOpen {
+                start: [
+                    0,
+                    1,
+                    2,
+                ],
+                end: [
+                    0,
+                    1,
+                    9,
+                ],
+            }
         "#]]
         .assert_debug_eq(&interest.range().unwrap());
         expect![[r#"

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -3,7 +3,7 @@
 #![warn(missing_docs)]
 mod bytes;
 pub mod event_id;
-mod interest;
+pub mod interest;
 mod jwk;
 mod jws;
 mod network;

--- a/core/src/range.rs
+++ b/core/src/range.rs
@@ -48,4 +48,11 @@ where
             None
         }
     }
+    /// Map a RangeOpen<T> to a RangeOpen<U>
+    pub fn map<U>(self, f: impl Fn(T) -> U) -> RangeOpen<U> {
+        RangeOpen {
+            start: f(self.start),
+            end: f(self.end),
+        }
+    }
 }

--- a/store/src/sqlite/interest.rs
+++ b/store/src/sqlite/interest.rs
@@ -664,8 +664,16 @@ mod interest_tests {
                         "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
                     ),
                     range: RangeOpen {
-                        start: [],
-                        end: [],
+                        start: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
+                        end: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
                     },
                     not_after: 42,
                 },
@@ -676,8 +684,16 @@ mod interest_tests {
                         "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
                     ),
                     range: RangeOpen {
-                        start: [],
-                        end: [],
+                        start: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
+                        end: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
                     },
                     not_after: 42,
                 },
@@ -717,8 +733,16 @@ mod interest_tests {
                         "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
                     ),
                     range: RangeOpen {
-                        start: [],
-                        end: [],
+                        start: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
+                        end: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
                     },
                     not_after: 42,
                 },
@@ -729,8 +753,16 @@ mod interest_tests {
                         "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
                     ),
                     range: RangeOpen {
-                        start: [],
-                        end: [],
+                        start: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
+                        end: Ok(
+                            EventId {
+                                bytes: "MIN",
+                            },
+                        ),
                     },
                     not_after: 43,
                 },

--- a/store/src/sqlite/interest.rs
+++ b/store/src/sqlite/interest.rs
@@ -37,6 +37,8 @@ where
     }
 }
 
+type InterestError = <Interest as TryFrom<Vec<u8>>>::Error;
+
 impl<H> InterestStore<H>
 where
     H: AssociativeHash + std::convert::From<[u32; 8]>,
@@ -146,11 +148,14 @@ where
             .bind(offset as i64)
             .fetch_all(self.pool.reader())
             .await?;
-        //debug!(count = rows.len(), "rows");
-        Ok(Box::new(rows.into_iter().map(|row| {
-            let bytes: Vec<u8> = row.get(0);
-            Interest::from(bytes)
-        })))
+        let rows = rows
+            .into_iter()
+            .map(|row| {
+                let bytes: Vec<u8> = row.get(0);
+                Interest::try_from(bytes)
+            })
+            .collect::<Result<Vec<Interest>, InterestError>>()?;
+        Ok(Box::new(rows.into_iter()))
     }
 }
 
@@ -348,10 +353,13 @@ where
             .bind(right_fencepost.as_bytes())
             .fetch_all(self.pool.reader())
             .await?;
-        Ok(rows.first().map(|row| {
-            let bytes: Vec<u8> = row.get(0);
-            Interest::from(bytes)
-        }))
+        Ok(rows
+            .first()
+            .map(|row| {
+                let bytes: Vec<u8> = row.get(0);
+                Interest::try_from(bytes)
+            })
+            .transpose()?)
     }
 
     #[instrument(skip(self))]
@@ -379,10 +387,13 @@ where
             .bind(right_fencepost.as_bytes())
             .fetch_all(self.pool.reader())
             .await?;
-        Ok(rows.first().map(|row| {
-            let bytes: Vec<u8> = row.get(0);
-            Interest::from(bytes)
-        }))
+        Ok(rows
+            .first()
+            .map(|row| {
+                let bytes: Vec<u8> = row.get(0);
+                Interest::try_from(bytes)
+            })
+            .transpose()?)
     }
 
     #[instrument(skip(self))]
@@ -424,8 +435,8 @@ where
         if let Some(row) = rows.first() {
             let f_bytes: Vec<u8> = row.get(0);
             let l_bytes: Vec<u8> = row.get(1);
-            let first = Interest::from(f_bytes);
-            let last = Interest::from(l_bytes);
+            let first = Interest::try_from(f_bytes)?;
+            let last = Interest::try_from(l_bytes)?;
             Ok(Some((first, last)))
         } else {
             Ok(None)
@@ -448,13 +459,51 @@ where
 
 #[cfg(test)]
 mod interest_tests {
+    use std::{collections::BTreeSet, str::FromStr};
+
     use super::*;
 
     use ceramic_api::AccessInterestStore;
+    use ceramic_core::{
+        interest::{Builder, WithPeerId},
+        PeerId,
+    };
+    use rand::{thread_rng, Rng};
     use recon::{AssociativeHash, Key, ReconItem, Sha256a, Store};
 
     use expect_test::expect;
     use test_log::test;
+
+    const SORT_KEY: &str = "model";
+    const PEER_ID: &str = "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ";
+
+    // Return an builder for an event with the same network,model,controller,stream.
+    pub(crate) fn interest_builder() -> Builder<WithPeerId> {
+        Interest::builder()
+            .with_sort_key(SORT_KEY)
+            .with_peer_id(&PeerId::from_str(PEER_ID).unwrap())
+    }
+
+    // Generate an event for the same network,model,controller,stream
+    // The event and height are random when when its None.
+    pub(crate) fn random_interest<'a>(
+        range: Option<(&'a [u8], &'a [u8])>,
+        not_after: Option<u64>,
+    ) -> Interest {
+        let rand_range = (&[0u8][..], &[thread_rng().gen::<u8>()][..]);
+        interest_builder()
+            .with_range(range.unwrap_or(rand_range))
+            .with_not_after(not_after.unwrap_or_else(|| thread_rng().gen()))
+            .build()
+    }
+    // The EventId that is the minumum of all possible random event ids
+    pub(crate) fn random_interest_min() -> Interest {
+        interest_builder().with_min_range().build_fencepost()
+    }
+    // The EventId that is the maximum of all possible random event ids
+    pub(crate) fn random_interest_max() -> Interest {
+        interest_builder().with_max_range().build_fencepost()
+    }
 
     async fn new_store() -> InterestStore<Sha256a> {
         let conn = SqlitePool::connect("sqlite::memory:").await.unwrap();
@@ -465,25 +514,27 @@ mod interest_tests {
     // This is the same as the recon::Store range test, but with the interest store (hits all its methods)
     async fn access_interest_model() {
         let store = new_store().await;
-        let hello_interest = Interest::from("hello".as_bytes());
-        let world_interest = Interest::from("world".as_bytes());
-        AccessInterestStore::insert(&store, hello_interest.clone())
+        let interest_0 = random_interest(None, None);
+        let interest_1 = random_interest(None, None);
+        AccessInterestStore::insert(&store, interest_0.clone())
             .await
             .unwrap();
-        AccessInterestStore::insert(&store, world_interest.clone())
+        AccessInterestStore::insert(&store, interest_1.clone())
             .await
             .unwrap();
         let interests = AccessInterestStore::range(
             &store,
-            b"a".as_slice().into(),
-            b"z".as_slice().into(),
+            random_interest_min(),
+            random_interest_max(),
             0,
             usize::MAX,
         )
         .await
         .unwrap();
-        assert_eq!(2, interests.len());
-        assert_eq!(vec![hello_interest, world_interest], interests);
+        assert_eq!(
+            BTreeSet::from_iter([interest_0, interest_1]),
+            BTreeSet::from_iter(interests)
+        );
     }
 
     #[test(tokio::test)]
@@ -491,102 +542,76 @@ mod interest_tests {
         let mut store = new_store().await;
         recon::Store::insert(
             &mut store,
-            ReconItem::new_key(&Interest::from("hello".as_bytes())),
+            ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(42))),
         )
         .await
         .unwrap();
         recon::Store::insert(
             &mut store,
-            ReconItem::new_key(&Interest::from("world".as_bytes())),
+            ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(24))),
         )
         .await
         .unwrap();
         let hash_cnt = store
-            .hash_range(&b"a".as_slice().into(), &b"z".as_slice().into())
+            .hash_range(&random_interest_min(), &random_interest_max())
             .await
             .unwrap();
-        expect![[r#"7460F21C83815F5EDC682F7A4154BC09AA3A0AE5DD1A2DEDCD709888A12751CC"#]]
+        expect!["D6C3CBCCE02E4AF2900ACF7FC84BE91168A42A0B1164534C426C782057E13BBC"]
             .assert_eq(&hash_cnt.hash().to_hex());
     }
 
     #[test(tokio::test)]
     async fn test_range_query() {
         let mut store = new_store().await;
-        let hello_interest = Interest::from("hello".as_bytes());
-        let world_interest = Interest::from("world".as_bytes());
-        recon::Store::insert(&mut store, ReconItem::new_key(&hello_interest))
+        let interest_0 = random_interest(None, None);
+        let interest_1 = random_interest(None, None);
+        recon::Store::insert(&mut store, ReconItem::new_key(&interest_0))
             .await
             .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new_key(&world_interest))
+        recon::Store::insert(&mut store, ReconItem::new_key(&interest_1))
             .await
             .unwrap();
         let ids = recon::Store::range(
             &mut store,
-            &b"a".as_slice().into(),
-            &b"z".as_slice().into(),
+            &random_interest_min(),
+            &random_interest_max(),
             0,
             usize::MAX,
         )
         .await
         .unwrap();
-        let interests = ids.collect::<Vec<Interest>>();
-        assert_eq!(2, interests.len());
-        assert_eq!(vec![hello_interest, world_interest], interests);
-        // TODO: need to fix bug in interests format impl and regenerate/fix these expects
-        // expect![[r#"
-        // [
-        //     Bytes(
-        //         "hello",
-        //     ),
-        //     Bytes(
-        //         "world",
-        //     ),
-        // ]
-        // "#]]
-        // .assert_debug_eq(&ids.collect::<Vec<Interest>>());
+        let interests = ids.collect::<BTreeSet<Interest>>();
+        assert_eq!(BTreeSet::from_iter([interest_0, interest_1]), interests);
     }
 
     #[test(tokio::test)]
     async fn test_range_with_values_query() {
         let mut store = new_store().await;
-        let hello_interest = Interest::from("hello".as_bytes());
-        let world_interest = Interest::from("world".as_bytes());
-        recon::Store::insert(&mut store, ReconItem::new_key(&hello_interest))
-            .await
-            .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new_key(&world_interest))
-            .await
-            .unwrap();
+        let interest_0 = random_interest(None, None);
+        let interest_1 = random_interest(None, None);
+        store.insert(interest_0.clone()).await.unwrap();
+        store.insert(interest_1.clone()).await.unwrap();
         let ids = store
             .range_with_values(
-                &b"a".as_slice().into(),
-                &b"z".as_slice().into(),
+                &random_interest_min(),
+                &random_interest_max(),
                 0,
                 usize::MAX,
             )
             .await
             .unwrap();
-        let interests = ids.into_iter().map(|(i, _v)| i).collect::<Vec<Interest>>();
-        assert_eq!(2, interests.len());
-        assert_eq!(vec![hello_interest, world_interest], interests);
-        // TODO: need to fix bug in interests format impl and regenerate/fix these expects
-        // expect![[r#"
-        // [
-        //     Bytes(
-        //         "hello",
-        //     ),
-        //     Bytes(
-        //         "world",
-        //     ),
-        // ]
-        // "#]]
-        // .assert_debug_eq(&ids.collect::<Vec<Interest>>());
+        let interests = ids
+            .into_iter()
+            .map(|(i, _v)| i)
+            .collect::<BTreeSet<Interest>>();
+        assert_eq!(BTreeSet::from_iter([interest_0, interest_1]), interests);
     }
 
     #[test(tokio::test)]
     async fn test_double_insert() {
         let mut store = new_store().await;
 
+        let interest = random_interest(None, None);
         // do take the first one
         expect![
             r#"
@@ -595,13 +620,7 @@ mod interest_tests {
         )
         "#
         ]
-        .assert_debug_eq(
-            &recon::Store::insert(
-                &mut store,
-                ReconItem::new_key(&Interest::from("hello".as_bytes())),
-            )
-            .await,
-        );
+        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&interest)).await);
 
         // reject the second insert of same key
         expect![
@@ -611,58 +630,66 @@ mod interest_tests {
         )
         "#
         ]
-        .assert_debug_eq(
-            &recon::Store::insert(
-                &mut store,
-                ReconItem::new_key(&Interest::from("hello".as_bytes())),
-            )
-            .await,
-        );
+        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&interest)).await);
     }
 
     #[test(tokio::test)]
     async fn test_first_and_last() {
         let mut store = new_store().await;
-        let hello_interest = Interest::from("hello".as_bytes());
-        let world_interest = Interest::from("world".as_bytes());
-        recon::Store::insert(&mut store, ReconItem::new_key(&hello_interest))
+        let interest_0 = random_interest(Some((&[], &[])), Some(42));
+        let interest_1 = random_interest(Some((&[], &[])), Some(43));
+        recon::Store::insert(&mut store, ReconItem::new_key(&interest_0))
             .await
             .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new_key(&world_interest))
+        recon::Store::insert(&mut store, ReconItem::new_key(&interest_1))
             .await
             .unwrap();
 
-        // Only one key in range
+        // Only one key in range, we expect to get the same key as first and last
         let ret = store
             .first_and_last(
-                &Interest::from("a".as_bytes()),
-                &Interest::from("j".as_bytes()),
+                &random_interest(Some((&[], &[])), Some(40)),
+                &random_interest(Some((&[], &[])), Some(43)),
             )
             .await
             .unwrap()
             .unwrap();
 
-        assert_eq!(hello_interest, ret.0);
-        assert_eq!(hello_interest, ret.1);
-        // expect![[r#"
-        //     Some(
-        //         (
-        //             Bytes(
-        //                 "hello",
-        //             ),
-        //             Bytes(
-        //                 "hello",
-        //             ),
-        //         ),
-        //     )
-        // "#]]
-        // .assert_debug_eq(&ret);
+        expect![[r#"
+            (
+                Interest {
+                    bytes: "480f70d652b6b825e4582200206ce9f954100188eb6e7939dbf45ac845d3399dba29da4e0b6ef1fdd8636a326b014040182a",
+                    sort_key_hash: "0f70d652b6b825e4",
+                    peer_id: PeerId(
+                        "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
+                    ),
+                    range: RangeOpen {
+                        start: [],
+                        end: [],
+                    },
+                    not_after: 42,
+                },
+                Interest {
+                    bytes: "480f70d652b6b825e4582200206ce9f954100188eb6e7939dbf45ac845d3399dba29da4e0b6ef1fdd8636a326b014040182a",
+                    sort_key_hash: "0f70d652b6b825e4",
+                    peer_id: PeerId(
+                        "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
+                    ),
+                    range: RangeOpen {
+                        start: [],
+                        end: [],
+                    },
+                    not_after: 42,
+                },
+            )
+        "#]]
+        .assert_debug_eq(&ret);
 
         // No keys in range
         let ret = store
             .first_and_last(
-                &Interest::from("j".as_bytes()),
-                &Interest::from("p".as_bytes()),
+                &random_interest(Some((&[], &[])), Some(50)),
+                &random_interest(Some((&[], &[])), Some(53)),
             )
             .await
             .unwrap();
@@ -674,36 +701,50 @@ mod interest_tests {
         // Two keys in range
         let ret = store
             .first_and_last(
-                &Interest::from("a".as_bytes()),
-                &Interest::from("z".as_bytes()),
+                &random_interest(Some((&[], &[])), Some(40)),
+                &random_interest(Some((&[], &[])), Some(50)),
             )
             .await
             .unwrap()
             .unwrap();
         // both keys exist
-        assert_eq!(hello_interest, ret.0);
-        assert_eq!(world_interest, ret.1);
-        // expect![[r#"
-        //     Some(
-        //         (
-        //             Bytes(
-        //                 "hello",
-        //             ),
-        //             Bytes(
-        //                 "world",
-        //             ),
-        //         ),
-        //     )
-        // "#]]
-        // .assert_debug_eq(&ret);
+        expect![[r#"
+            (
+                Interest {
+                    bytes: "480f70d652b6b825e4582200206ce9f954100188eb6e7939dbf45ac845d3399dba29da4e0b6ef1fdd8636a326b014040182a",
+                    sort_key_hash: "0f70d652b6b825e4",
+                    peer_id: PeerId(
+                        "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
+                    ),
+                    range: RangeOpen {
+                        start: [],
+                        end: [],
+                    },
+                    not_after: 42,
+                },
+                Interest {
+                    bytes: "480f70d652b6b825e4582200206ce9f954100188eb6e7939dbf45ac845d3399dba29da4e0b6ef1fdd8636a326b014040182b",
+                    sort_key_hash: "0f70d652b6b825e4",
+                    peer_id: PeerId(
+                        "1AdgHpWeBKTU3F2tUkAQqL2Y2Geh4QgHJwcWMPuiY1qiRQ",
+                    ),
+                    range: RangeOpen {
+                        start: [],
+                        end: [],
+                    },
+                    not_after: 43,
+                },
+            )
+        "#]]
+        .assert_debug_eq(&ret);
     }
 
     #[test(tokio::test)]
     #[should_panic(expected = "Interests do not support values! Invalid request.")]
     async fn test_store_value_for_key_error() {
         let mut store = new_store().await;
-        let key = Interest::from("hello".as_bytes());
-        let store_value = Interest::from("world".as_bytes());
+        let key = random_interest(None, None);
+        let store_value = random_interest(None, None);
         recon::Store::insert(
             &mut store,
             ReconItem::new_with_value(&key, store_value.as_slice()),
@@ -715,7 +756,7 @@ mod interest_tests {
     #[test(tokio::test)]
     async fn test_keys_with_missing_value() {
         let mut store = new_store().await;
-        let key = Interest::from("hello".as_bytes());
+        let key = random_interest(None, None);
         recon::Store::insert(&mut store, ReconItem::new(&key, None))
             .await
             .unwrap();
@@ -744,7 +785,7 @@ mod interest_tests {
     #[test(tokio::test)]
     async fn test_value_for_key() {
         let mut store = new_store().await;
-        let key = Interest::from("hello".as_bytes());
+        let key = random_interest(None, None);
         recon::Store::insert(&mut store, ReconItem::new(&key, None))
             .await
             .unwrap();


### PR DESCRIPTION
This changes the recon::Key trait to use TryFrom<Vec<u8>> instead of simply From<_> in order to allow for validation of the bytes. Now it _should_ be impossible to construct either an Interest or an EventId that is not valid. Remembering that a fencepost is considered valid.