### PR TITLE
fix: resume token should return previous (not 0) when nothing found

### DIFF
--- a/store/src/sqlite/model.rs
+++ b/store/src/sqlite/model.rs
@@ -429,7 +429,7 @@ where
         let row_id: i64 = rows
             .first()
             .and_then(|r| r.get("new_highwater_mark"))
-            .unwrap_or(0);
+            .unwrap_or(row_id);
         let rows = rows
             .into_iter()
             .map(|row| {
@@ -1365,7 +1365,11 @@ mod test {
 
         let (hw, res) = store.new_keys_since_value_rowid(hw, 1).await.unwrap();
         assert_eq!(1, res.len());
-        assert_eq!(22, hw); // see comment in prep_highwater_tests
+        assert_eq!(22, hw);
         assert_eq!([key_c], res.as_slice());
+
+        let (hw, res) = store.new_keys_since_value_rowid(hw, 1).await.unwrap();
+        assert_eq!(0, res.len());
+        assert_eq!(22, hw); // previously returned 0
     }
 }


### PR DESCRIPTION
I returned 0 as the default rowid, which is great the _first_ time but a bug when there actually had been data previously. Now we use the previous rowid (i.e. resume token) if nothing was found. We don't want to go back to the beginning when there isn't anything new as the client polls for this information currently and this is expected to happen frequently.

We could query the max(rowid) from the database to guarantee we're at the current resume token, if for some reason the client sent us 10000 but it's actually 1000. I don't think there's really a point to do that, as we trust our clients and there's no reason that should happen (famous last words?). I can change this if anyone disagrees.