### PR TITLE
fix: store metrics under own registry (not recon)

### DIFF
--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -60,7 +60,7 @@ impl Metrics {
     /// Register and construct Metrics
     pub fn register(registry: &mut Registry) -> Self {
         // TODO: a new sub registry that doesn't duplicate recon (need to match for now to keep tests passing)
-        let sub_registry = registry.sub_registry_with_prefix("recon");
+        let sub_registry = registry.sub_registry_with_prefix("ceramic_store");
 
         register!(
             key_insert_count,

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -59,7 +59,6 @@ pub struct Metrics {
 impl Metrics {
     /// Register and construct Metrics
     pub fn register(registry: &mut Registry) -> Self {
-        // TODO: a new sub registry that doesn't duplicate recon (need to match for now to keep tests passing)
         let sub_registry = registry.sub_registry_with_prefix("ceramic_store");
 
         register!(


### PR DESCRIPTION
The store/query metrics are now under their own subregistry (ceramic_store) rather than using recon. This makes sense based on the code layout, but was put off as it requires updating the performance tests as they look at this metric.