### PR TITLE
feat: support new id/data event payload for event creation (POST /events)

### DIFF
--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -6,6 +6,7 @@ api/openapi.yaml
 docs/Event.md
 docs/EventDeprecated.md
 docs/EventFeed.md
+docs/EventsPostRequest.md
 docs/Version.md
 docs/default_api.md
 examples/ca.pem

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.10.1
-- Build date: 2024-02-09T12:36:59.242763-07:00[America/Denver]
+- Build date: 2024-02-09T13:10:42.872308-07:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.10.1
-- Build date: 2024-02-08T16:59:26.485961797Z[Etc/UTC]
+- Build date: 2024-02-09T12:36:59.242763-07:00[America/Denver]
 
 
 
@@ -115,6 +115,7 @@ Method | HTTP request | Description
  - [Event](docs/Event.md)
  - [EventDeprecated](docs/EventDeprecated.md)
  - [EventFeed](docs/EventFeed.md)
+ - [EventsPostRequest](docs/EventsPostRequest.md)
  - [Version](docs/Version.md)
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -91,10 +91,16 @@ paths:
   /events:
     post:
       requestBody:
-        $ref: '#/components/requestBodies/Event'
+        $ref: '#/components/requestBodies/EventTemp'
       responses:
         "204":
           description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                type: string
+          description: bad request
       summary: Creates a new event
   /events/{event_id}:
     get:
@@ -196,11 +202,17 @@ paths:
       summary: Get all new event keys since resume token
 components:
   requestBodies:
+    EventTemp:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/_events_post_request'
+      required: true
     Event:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EventDeprecated'
+            $ref: '#/components/schemas/Event'
       description: Event to add to the node
       required: true
     Message:
@@ -276,5 +288,22 @@ components:
       - events
       - resumeToken
       title: Ceramic Event feed data
+      type: object
+    _events_post_request:
+      description: "Event to add to the node. Temp while we transition to id/data\
+        \ style, at which time we can swap this out for the Event schema."
+      properties:
+        id:
+          description: Multibase encoding of event id bytes.
+          type: string
+        data:
+          description: Multibase encoding of event data.
+          type: string
+        event_id:
+          description: Multibase encoding of event id bytes.
+          type: string
+        event_data:
+          description: Multibase encoding of event data.
+          type: string
       type: object
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -299,10 +299,10 @@ components:
         data:
           description: Multibase encoding of event data.
           type: string
-        event_id:
+        eventId:
           description: Multibase encoding of event id bytes.
           type: string
-        event_data:
+        eventData:
           description: Multibase encoding of event data.
           type: string
       type: object

--- a/api-server/docs/EventsPostRequest.md
+++ b/api-server/docs/EventsPostRequest.md
@@ -1,0 +1,13 @@
+# EventsPostRequest
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **String** | Multibase encoding of event id bytes. | [optional] [default to None]
+**data** | **String** | Multibase encoding of event data. | [optional] [default to None]
+**event_id** | **String** | Multibase encoding of event id bytes. | [optional] [default to None]
+**event_data** | **String** | Multibase encoding of event data. | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -39,14 +39,14 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> (event_deprecated)
+> (events_post_request)
 Creates a new event
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-  **event_deprecated** | [**EventDeprecated**](EventDeprecated.md)| Event to add to the node | 
+  **events_post_request** | [**EventsPostRequest**](EventsPostRequest.md)|  | 
 
 ### Return type
 
@@ -59,7 +59,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/json
- - **Accept**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -130,12 +130,12 @@ where
     /// Creates a new event
     async fn events_post(
         &self,
-        event_deprecated: models::EventDeprecated,
+        events_post_request: models::EventsPostRequest,
         context: &C,
     ) -> Result<EventsPostResponse, ApiError> {
         info!(
             "events_post({:?}) - X-Span-ID: {:?}",
-            event_deprecated,
+            events_post_request,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -32,9 +32,12 @@ pub enum EventsEventIdGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum EventsPostResponse {
     /// success
     Success,
+    /// bad request
+    BadRequest(String),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -91,7 +94,7 @@ pub trait Api<C: Send + Sync> {
     /// Creates a new event
     async fn events_post(
         &self,
-        event_deprecated: models::EventDeprecated,
+        events_post_request: models::EventsPostRequest,
         context: &C,
     ) -> Result<EventsPostResponse, ApiError>;
 
@@ -152,7 +155,7 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Creates a new event
     async fn events_post(
         &self,
-        event_deprecated: models::EventDeprecated,
+        events_post_request: models::EventsPostRequest,
     ) -> Result<EventsPostResponse, ApiError>;
 
     /// Get all new event keys since resume token
@@ -226,10 +229,10 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     /// Creates a new event
     async fn events_post(
         &self,
-        event_deprecated: models::EventDeprecated,
+        events_post_request: models::EventsPostRequest,
     ) -> Result<EventsPostResponse, ApiError> {
         let context = self.context().clone();
-        self.api().events_post(event_deprecated, &context).await
+        self.api().events_post(events_post_request, &context).await
     }
 
     /// Get all new event keys since resume token

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -469,6 +469,190 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
+/// Event to add to the node. Temp while we transition to id/data style, at which time we can swap this out for the Event schema.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct EventsPostRequest {
+    /// Multibase encoding of event id bytes.
+    #[serde(rename = "id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    /// Multibase encoding of event data.
+    #[serde(rename = "data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+
+    /// Multibase encoding of event id bytes.
+    #[serde(rename = "event_id")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_id: Option<String>,
+
+    /// Multibase encoding of event data.
+    #[serde(rename = "event_data")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_data: Option<String>,
+}
+
+impl EventsPostRequest {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> EventsPostRequest {
+        EventsPostRequest {
+            id: None,
+            data: None,
+            event_id: None,
+            event_data: None,
+        }
+    }
+}
+
+/// Converts the EventsPostRequest value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for EventsPostRequest {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> = vec![
+            self.id
+                .as_ref()
+                .map(|id| ["id".to_string(), id.to_string()].join(",")),
+            self.data
+                .as_ref()
+                .map(|data| ["data".to_string(), data.to_string()].join(",")),
+            self.event_id
+                .as_ref()
+                .map(|event_id| ["event_id".to_string(), event_id.to_string()].join(",")),
+            self.event_data
+                .as_ref()
+                .map(|event_data| ["event_data".to_string(), event_data.to_string()].join(",")),
+        ];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a EventsPostRequest value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for EventsPostRequest {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub id: Vec<String>,
+            pub data: Vec<String>,
+            pub event_id: Vec<String>,
+            pub event_data: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing EventsPostRequest".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "id" => intermediate_rep.id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "data" => intermediate_rep.data.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "event_id" => intermediate_rep.event_id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "event_data" => intermediate_rep.event_data.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing EventsPostRequest".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(EventsPostRequest {
+            id: intermediate_rep.id.into_iter().next(),
+            data: intermediate_rep.data.into_iter().next(),
+            event_id: intermediate_rep.event_id.into_iter().next(),
+            event_data: intermediate_rep.event_data.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<EventsPostRequest> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<EventsPostRequest>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<EventsPostRequest>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for EventsPostRequest - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<EventsPostRequest>
+{
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <EventsPostRequest as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into EventsPostRequest - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// Version of the Ceramic node in semver format, e.g. 2.1.0
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -484,12 +484,12 @@ pub struct EventsPostRequest {
     pub data: Option<String>,
 
     /// Multibase encoding of event id bytes.
-    #[serde(rename = "event_id")]
+    #[serde(rename = "eventId")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
 
     /// Multibase encoding of event data.
-    #[serde(rename = "event_data")]
+    #[serde(rename = "eventData")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_data: Option<String>,
 }
@@ -520,10 +520,10 @@ impl std::string::ToString for EventsPostRequest {
                 .map(|data| ["data".to_string(), data.to_string()].join(",")),
             self.event_id
                 .as_ref()
-                .map(|event_id| ["event_id".to_string(), event_id.to_string()].join(",")),
+                .map(|event_id| ["eventId".to_string(), event_id.to_string()].join(",")),
             self.event_data
                 .as_ref()
-                .map(|event_data| ["event_data".to_string(), event_data.to_string()].join(",")),
+                .map(|event_data| ["eventData".to_string(), event_data.to_string()].join(",")),
         ];
 
         params.into_iter().flatten().collect::<Vec<_>>().join(",")
@@ -575,11 +575,11 @@ impl std::str::FromStr for EventsPostRequest {
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
-                    "event_id" => intermediate_rep.event_id.push(
+                    "eventId" => intermediate_rep.event_id.push(
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
-                    "event_data" => intermediate_rep.event_data.push(
+                    "eventData" => intermediate_rep.event_data.push(
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     _ => {

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -266,31 +266,31 @@ where
                     match result {
                             Ok(body) => {
                                 let mut unused_elements = Vec::new();
-                                let param_event_deprecated: Option<models::EventDeprecated> = if !body.is_empty() {
+                                let param_events_post_request: Option<models::EventsPostRequest> = if !body.is_empty() {
                                     let deserializer = &mut serde_json::Deserializer::from_slice(&body);
                                     match serde_ignored::deserialize(deserializer, |path| {
                                             warn!("Ignoring unknown field in body: {}", path);
                                             unused_elements.push(path.to_string());
                                     }) {
-                                        Ok(param_event_deprecated) => param_event_deprecated,
+                                        Ok(param_events_post_request) => param_events_post_request,
                                         Err(e) => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
-                                                        .body(Body::from(format!("Couldn't parse body parameter EventDeprecated - doesn't match schema: {}", e)))
-                                                        .expect("Unable to create Bad Request response for invalid body parameter EventDeprecated due to schema")),
+                                                        .body(Body::from(format!("Couldn't parse body parameter EventsPostRequest - doesn't match schema: {}", e)))
+                                                        .expect("Unable to create Bad Request response for invalid body parameter EventsPostRequest due to schema")),
                                     }
                                 } else {
                                     None
                                 };
-                                let param_event_deprecated = match param_event_deprecated {
-                                    Some(param_event_deprecated) => param_event_deprecated,
+                                let param_events_post_request = match param_events_post_request {
+                                    Some(param_events_post_request) => param_events_post_request,
                                     None => return Ok(Response::builder()
                                                         .status(StatusCode::BAD_REQUEST)
-                                                        .body(Body::from("Missing required body parameter EventDeprecated"))
-                                                        .expect("Unable to create Bad Request response for missing body parameter EventDeprecated")),
+                                                        .body(Body::from("Missing required body parameter EventsPostRequest"))
+                                                        .expect("Unable to create Bad Request response for missing body parameter EventsPostRequest")),
                                 };
 
                                 let result = api_impl.events_post(
-                                            param_event_deprecated,
+                                            param_events_post_request,
                                         &context
                                     ).await;
                                 let mut response = Response::new(Body::empty());
@@ -312,6 +312,17 @@ where
                                                 => {
                                                     *response.status_mut() = StatusCode::from_u16(204).expect("Unable to turn 204 into a StatusCode");
                                                 },
+                                                EventsPostResponse::BadRequest
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_POST_BAD_REQUEST"));
+                                                    let body_content = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body_content);
+                                                },
                                             },
                                             Err(_) => {
                                                 // Application code returned an error. This should not happen, as the implementation should
@@ -325,8 +336,8 @@ where
                             },
                             Err(e) => Ok(Response::builder()
                                                 .status(StatusCode::BAD_REQUEST)
-                                                .body(Body::from(format!("Couldn't read body parameter EventDeprecated: {}", e)))
-                                                .expect("Unable to create Bad Request response due to unable to read body parameter EventDeprecated")),
+                                                .body(Body::from(format!("Couldn't read body parameter EventsPostRequest: {}", e)))
+                                                .expect("Unable to create Bad Request response due to unable to read body parameter EventsPostRequest")),
                         }
                 }
 

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -84,10 +84,16 @@ paths:
     post:
       summary: Creates a new event
       requestBody:
-        $ref: '#/components/requestBodies/Event'
+        $ref: '#/components/requestBodies/EventTemp'
       responses:
         '204':
           description: success
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
 
   /events/{event_id}:
     get:
@@ -175,11 +181,31 @@ paths:
                 type: string
 components:
   requestBodies:
+    EventTemp:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                description: Multibase encoding of event id bytes.
+              data:
+                type: string
+                description: Multibase encoding of event data.
+              event_id:
+                type: string
+                description: Multibase encoding of event id bytes.
+              event_data:
+                type: string
+                description: Multibase encoding of event data.
+            description: Event to add to the node. Temp while we transition to id/data style, at which time we can swap this out for the Event schema.
+      required: true
     Event:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EventDeprecated'
+              $ref: '#/components/schemas/Event'
       description: Event to add to the node
       required: true
     Message:

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -193,10 +193,10 @@ components:
               data:
                 type: string
                 description: Multibase encoding of event data.
-              event_id:
+              eventId:
                 type: string
                 description: Multibase encoding of event id bytes.
-              event_data:
+              eventData:
                 type: string
                 description: Multibase encoding of event data.
             description: Event to add to the node. Temp while we transition to id/data style, at which time we can swap this out for the Event schema.

--- a/api/src/metrics/api.rs
+++ b/api/src/metrics/api.rs
@@ -45,7 +45,7 @@ where
     /// Creates a new event
     async fn events_post(
         &self,
-        event: models::EventDeprecated,
+        event: models::EventsPostRequest,
         context: &C,
     ) -> Result<EventsPostResponse, ApiError> {
         self.record("/events", self.api.events_post(event, context))


### PR DESCRIPTION
I renamed the fields on the Event schema to save bytes but only supported that in responses to avoid breaking changes, but there was a path forward to support both for inputs without breaking anything. We do this for now, and can update callers to `id/data` instead of `event_id/event_data` and simplify the input validation at that time. 

We prefer `id/data` over `event_id/event_data` and don't allow mixing. I was going to allow either `id` field and either `data` field, but this ensures people are using either style correctly and completely, rather than a hybrid.

The implementation is ugly, as using `oneOf` schema generation doesn't work quite right. It generated 4 required fields on one struct, rather than an enum with 2 variants with 2 required fields each. So instead I crate a new type that is dedicated to parsing this input 😞.

Note: I skipped the subscribe endpoint as it's deprecated and interests should be used instead.