### PR TITLE
fix: use PAT for create-release-pr workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -26,7 +26,7 @@ jobs:
       # See https://github.com/3box/rust-builder
       image: public.ecr.aws/r5b3e0r5/3box/rust-builder:latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PAT }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Use the existing `GH_TOKEN_PAT` for release creation as the GITHUB_TOKEN doesn't initiate actions.

Reference:
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.