### PR TITLE
feat: create GET endpoint to return events for an interest range

### DIFF
--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -6,6 +6,7 @@ api/openapi.yaml
 docs/Event.md
 docs/EventDeprecated.md
 docs/EventFeed.md
+docs/EventsGet.md
 docs/EventsPostRequest.md
 docs/Version.md
 docs/default_api.md

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.11.0
-- Build date: 2024-02-12T14:25:37.570843794Z[Etc/UTC]
+- Build date: 2024-02-14T13:01:15.078464-07:00[America/Denver]
 
 
 
@@ -63,6 +63,7 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example client EventsEventIdGet
+cargo run --example client EventsSortKeySortValueGet
 cargo run --example client FeedEventsGet
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
@@ -103,6 +104,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [****](docs/default_api.md#) | **GET** /events/{event_id} | Get event data
 [****](docs/default_api.md#) | **POST** /events | Creates a new event
+[****](docs/default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
 [****](docs/default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
@@ -115,6 +117,7 @@ Method | HTTP request | Description
  - [Event](docs/Event.md)
  - [EventDeprecated](docs/EventDeprecated.md)
  - [EventFeed](docs/EventFeed.md)
+ - [EventsGet](docs/EventsGet.md)
  - [EventsPostRequest](docs/EventsPostRequest.md)
  - [Version](docs/Version.md)
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -166,6 +166,66 @@ paths:
         "204":
           description: success
       summary: Register interest for a sort key
+  /events/{sort_key}/{sort_value}:
+    get:
+      parameters:
+      - description: name of the sort_key e.g. 'model'
+        explode: false
+        in: path
+        name: sort_key
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: value associated with the sort key e.g. model ID
+        explode: false
+        in: path
+        name: sort_value
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: the controller to filter
+        explode: true
+        in: query
+        name: controller
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: the stream to filter
+        explode: true
+        in: query
+        name: streamId
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: "token that designates the point to resume from, that is find\
+          \ keys added after this point"
+        explode: true
+        in: query
+        name: offset
+        required: false
+        schema:
+          type: integer
+        style: form
+      - description: "the maximum number of events to return, default is 10000."
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          type: integer
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsGet'
+          description: success
+      summary: Get events matching the interest stored on the node
   /feed/events:
     get:
       parameters:
@@ -288,6 +348,36 @@ components:
       - events
       - resumeToken
       title: Ceramic Event feed data
+      type: object
+    EventsGet:
+      description: Ceramic event keys as part of a Ceramic Stream
+      example:
+        resumeOffset: 0
+        events:
+        - data: data
+          id: id
+        - data: data
+          id: id
+        isComplete: true
+      properties:
+        events:
+          description: An array of events
+          items:
+            $ref: '#/components/schemas/Event'
+          type: array
+        resumeOffset:
+          description: An integer specifying where to resume the request. Only works
+            correctly for the same input parameters.
+          type: integer
+        isComplete:
+          description: A boolean specifying if there are more events to be fetched.
+            Repeat with the resumeOffset to get next set.
+          type: boolean
+      required:
+      - events
+      - isComplete
+      - resumeOffset
+      title: Information about multiple events.
       type: object
     _events_post_request:
       description: "Event to add to the node. Temp while we transition to id/data\

--- a/api-server/docs/EventsGet.md
+++ b/api-server/docs/EventsGet.md
@@ -1,0 +1,12 @@
+# EventsGet
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**events** | [**Vec<models::Event>**](Event.md) | An array of events | 
+**resume_offset** | **i32** | An integer specifying where to resume the request. Only works correctly for the same input parameters. | 
+**is_complete** | **bool** | A boolean specifying if there are more events to be fetched. Repeat with the resumeOffset to get next set. | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -6,6 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 ****](default_api.md#) | **GET** /events/{event_id} | Get event data
 ****](default_api.md#) | **POST** /events | Creates a new event
+****](default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
 ****](default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
@@ -59,6 +60,45 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: application/json
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::EventsGet (sort_key, sort_value, optional)
+Get events matching the interest stored on the node
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **sort_key** | **String**| name of the sort_key e.g. 'model' | 
+  **sort_value** | **String**| value associated with the sort key e.g. model ID | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **sort_key** | **String**| name of the sort_key e.g. 'model' | 
+ **sort_value** | **String**| value associated with the sort key e.g. model ID | 
+ **controller** | **String**| the controller to filter | 
+ **stream_id** | **String**| the stream to filter | 
+ **offset** | **i32**| token that designates the point to resume from, that is find keys added after this point | 
+ **limit** | **i32**| the maximum number of events to return, default is 10000. | 
+
+### Return type
+
+[**models::EventsGet**](EventsGet.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -3,8 +3,9 @@
 #[allow(unused_imports)]
 use ceramic_api_server::{
     models, Api, ApiNoContext, Client, ContextWrapperExt, EventsEventIdGetResponse,
-    EventsPostResponse, FeedEventsGetResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, SubscribeSortKeySortValueGetResponse, VersionPostResponse,
+    EventsPostResponse, EventsSortKeySortValueGetResponse, FeedEventsGetResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    SubscribeSortKeySortValueGetResponse, VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -35,6 +36,7 @@ fn main() {
                 .help("Sets the operation to run")
                 .possible_values(&[
                     "EventsEventIdGet",
+                    "EventsSortKeySortValueGet",
                     "FeedEventsGet",
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
@@ -111,6 +113,21 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
+        Some("EventsSortKeySortValueGet") => {
+            let result = rt.block_on(client.events_sort_key_sort_value_get(
+                "sort_key_example".to_string(),
+                "sort_value_example".to_string(),
+                Some("controller_example".to_string()),
+                Some("stream_id_example".to_string()),
+                Some(56),
+                Some(56),
+            ));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("FeedEventsGet") => {
             let result = rt
                 .block_on(client.feed_events_get(Some("resume_at_example".to_string()), Some(56)));

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -101,8 +101,8 @@ impl<C> Server<C> {
 
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
-    Api, EventsEventIdGetResponse, EventsPostResponse, FeedEventsGetResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
+    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
     SubscribeSortKeySortValueGetResponse, VersionPostResponse,
 };
 use std::error::Error;
@@ -138,6 +138,21 @@ where
             events_post_request,
             context.get().0.clone()
         );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Get events matching the interest stored on the node
+    async fn events_sort_key_sort_value_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
+        info!("events_sort_key_sort_value_get(\"{}\", \"{}\", {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", sort_key, sort_value, controller, stream_id, offset, limit, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
 

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -42,8 +42,8 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
 const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
-    Api, EventsEventIdGetResponse, EventsPostResponse, FeedEventsGetResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
+    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
     SubscribeSortKeySortValueGetResponse, VersionPostResponse,
 };
 
@@ -572,6 +572,112 @@ where
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
                 Ok(EventsPostResponse::BadRequest(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn events_sort_key_sort_value_get(
+        &self,
+        param_sort_key: String,
+        param_sort_value: String,
+        param_controller: Option<String>,
+        param_stream_id: Option<String>,
+        param_offset: Option<i32>,
+        param_limit: Option<i32>,
+        context: &C,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/ceramic/events/{sort_key}/{sort_value}",
+            self.base_path,
+            sort_key = utf8_percent_encode(&param_sort_key.to_string(), ID_ENCODE_SET),
+            sort_value = utf8_percent_encode(&param_sort_value.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            if let Some(param_controller) = param_controller {
+                query_string.append_pair("controller", &param_controller);
+            }
+            if let Some(param_stream_id) = param_stream_id {
+                query_string.append_pair("streamId", &param_stream_id);
+            }
+            if let Some(param_offset) = param_offset {
+                query_string.append_pair("offset", &param_offset.to_string());
+            }
+            if let Some(param_limit) = param_limit {
+                query_string.append_pair("limit", &param_limit.to_string());
+            }
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::EventsGet>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(EventsSortKeySortValueGetResponse::Success(body))
             }
             code => {
                 let headers = response.headers().clone();

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -41,6 +41,12 @@ pub enum EventsPostResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum EventsSortKeySortValueGetResponse {
+    /// success
+    Success(models::EventsGet),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum FeedEventsGetResponse {
     /// success
@@ -97,6 +103,18 @@ pub trait Api<C: Send + Sync> {
         events_post_request: models::EventsPostRequest,
         context: &C,
     ) -> Result<EventsPostResponse, ApiError>;
+
+    /// Get events matching the interest stored on the node
+    async fn events_sort_key_sort_value_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -157,6 +175,17 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         events_post_request: models::EventsPostRequest,
     ) -> Result<EventsPostResponse, ApiError>;
+
+    /// Get events matching the interest stored on the node
+    async fn events_sort_key_sort_value_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -233,6 +262,24 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     ) -> Result<EventsPostResponse, ApiError> {
         let context = self.context().clone();
         self.api().events_post(events_post_request, &context).await
+    }
+
+    /// Get events matching the interest stored on the node
+    async fn events_sort_key_sort_value_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api()
+            .events_sort_key_sort_value_get(
+                sort_key, sort_value, controller, stream_id, offset, limit, &context,
+            )
+            .await
     }
 
     /// Get all new event keys since resume token

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -469,6 +469,178 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
+/// Ceramic event keys as part of a Ceramic Stream
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct EventsGet {
+    /// An array of events
+    #[serde(rename = "events")]
+    pub events: Vec<models::Event>,
+
+    /// An integer specifying where to resume the request. Only works correctly for the same input parameters.
+    #[serde(rename = "resumeOffset")]
+    pub resume_offset: i32,
+
+    /// A boolean specifying if there are more events to be fetched. Repeat with the resumeOffset to get next set.
+    #[serde(rename = "isComplete")]
+    pub is_complete: bool,
+}
+
+impl EventsGet {
+    #[allow(clippy::new_without_default)]
+    pub fn new(events: Vec<models::Event>, resume_offset: i32, is_complete: bool) -> EventsGet {
+        EventsGet {
+            events,
+            resume_offset,
+            is_complete,
+        }
+    }
+}
+
+/// Converts the EventsGet value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for EventsGet {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> = vec![
+            // Skipping events in query parameter serialization
+            Some("resumeOffset".to_string()),
+            Some(self.resume_offset.to_string()),
+            Some("isComplete".to_string()),
+            Some(self.is_complete.to_string()),
+        ];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a EventsGet value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for EventsGet {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub events: Vec<Vec<models::Event>>,
+            pub resume_offset: Vec<i32>,
+            pub is_complete: Vec<bool>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing EventsGet".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    "events" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in EventsGet"
+                                .to_string(),
+                        )
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "resumeOffset" => intermediate_rep.resume_offset.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "isComplete" => intermediate_rep.is_complete.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing EventsGet".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(EventsGet {
+            events: intermediate_rep
+                .events
+                .into_iter()
+                .next()
+                .ok_or_else(|| "events missing in EventsGet".to_string())?,
+            resume_offset: intermediate_rep
+                .resume_offset
+                .into_iter()
+                .next()
+                .ok_or_else(|| "resumeOffset missing in EventsGet".to_string())?,
+            is_complete: intermediate_rep
+                .is_complete
+                .into_iter()
+                .next()
+                .ok_or_else(|| "isComplete missing in EventsGet".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<EventsGet> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<EventsGet>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<EventsGet>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for EventsGet - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<EventsGet> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <EventsGet as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into EventsGet - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// Event to add to the node. Temp while we transition to id/data style, at which time we can swap this out for the Event schema.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -22,8 +22,8 @@ pub use crate::context;
 type ServiceFuture = BoxFuture<'static, Result<Response<Body>, crate::ServiceError>>;
 
 use crate::{
-    Api, EventsEventIdGetResponse, EventsPostResponse, FeedEventsGetResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
+    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
     SubscribeSortKeySortValueGetResponse, VersionPostResponse,
 };
 
@@ -34,6 +34,7 @@ mod paths {
         pub static ref GLOBAL_REGEX_SET: regex::RegexSet = regex::RegexSet::new(vec![
             r"^/ceramic/events$",
             r"^/ceramic/events/(?P<event_id>[^/?#]*)$",
+            r"^/ceramic/events/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
             r"^/ceramic/feed/events$",
             r"^/ceramic/interests/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
             r"^/ceramic/liveness$",
@@ -50,8 +51,15 @@ mod paths {
             regex::Regex::new(r"^/ceramic/events/(?P<event_id>[^/?#]*)$")
                 .expect("Unable to create regex for EVENTS_EVENT_ID");
     }
-    pub(crate) static ID_FEED_EVENTS: usize = 2;
-    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 3;
+    pub(crate) static ID_EVENTS_SORT_KEY_SORT_VALUE: usize = 2;
+    lazy_static! {
+        pub static ref REGEX_EVENTS_SORT_KEY_SORT_VALUE: regex::Regex =
+            #[allow(clippy::invalid_regex)]
+            regex::Regex::new(r"^/ceramic/events/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$")
+                .expect("Unable to create regex for EVENTS_SORT_KEY_SORT_VALUE");
+    }
+    pub(crate) static ID_FEED_EVENTS: usize = 3;
+    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 4;
     lazy_static! {
         pub static ref REGEX_INTERESTS_SORT_KEY_SORT_VALUE: regex::Regex =
             #[allow(clippy::invalid_regex)]
@@ -60,8 +68,8 @@ mod paths {
             )
             .expect("Unable to create regex for INTERESTS_SORT_KEY_SORT_VALUE");
     }
-    pub(crate) static ID_LIVENESS: usize = 4;
-    pub(crate) static ID_SUBSCRIBE_SORT_KEY_SORT_VALUE: usize = 5;
+    pub(crate) static ID_LIVENESS: usize = 5;
+    pub(crate) static ID_SUBSCRIBE_SORT_KEY_SORT_VALUE: usize = 6;
     lazy_static! {
         pub static ref REGEX_SUBSCRIBE_SORT_KEY_SORT_VALUE: regex::Regex =
             #[allow(clippy::invalid_regex)]
@@ -70,7 +78,7 @@ mod paths {
             )
             .expect("Unable to create regex for SUBSCRIBE_SORT_KEY_SORT_VALUE");
     }
-    pub(crate) static ID_VERSION: usize = 6;
+    pub(crate) static ID_VERSION: usize = 7;
 }
 
 pub struct MakeService<T, C>
@@ -339,6 +347,173 @@ where
                                                 .body(Body::from(format!("Couldn't read body parameter EventsPostRequest: {}", e)))
                                                 .expect("Unable to create Bad Request response due to unable to read body parameter EventsPostRequest")),
                         }
+                }
+
+                // EventsSortKeySortValueGet - GET /events/{sort_key}/{sort_value}
+                hyper::Method::GET if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => {
+                    // Path parameters
+                    let path: &str = uri.path();
+                    let path_params =
+                    paths::REGEX_EVENTS_SORT_KEY_SORT_VALUE
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE EVENTS_SORT_KEY_SORT_VALUE in set but failed match against \"{}\"", path, paths::REGEX_EVENTS_SORT_KEY_SORT_VALUE.as_str())
+                    );
+
+                    let param_sort_key = match percent_encoding::percent_decode(path_params["sort_key"].as_bytes()).decode_utf8() {
+                    Ok(param_sort_key) => match param_sort_key.parse::<String>() {
+                        Ok(param_sort_key) => param_sort_key,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter sort_key: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["sort_key"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                    let param_sort_value = match percent_encoding::percent_decode(path_params["sort_value"].as_bytes()).decode_utf8() {
+                    Ok(param_sort_value) => match param_sort_value.parse::<String>() {
+                        Ok(param_sort_value) => param_sort_value,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter sort_value: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["sort_value"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                    // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
+                    let query_params =
+                        form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+                            .collect::<Vec<_>>();
+                    let param_controller = query_params
+                        .iter()
+                        .filter(|e| e.0 == "controller")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_controller = match param_controller {
+                        Some(param_controller) => {
+                            let param_controller =
+                                <String as std::str::FromStr>::from_str(&param_controller);
+                            match param_controller {
+                            Ok(param_controller) => Some(param_controller),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter controller - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter controller")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_stream_id = query_params
+                        .iter()
+                        .filter(|e| e.0 == "streamId")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_stream_id = match param_stream_id {
+                        Some(param_stream_id) => {
+                            let param_stream_id =
+                                <String as std::str::FromStr>::from_str(&param_stream_id);
+                            match param_stream_id {
+                            Ok(param_stream_id) => Some(param_stream_id),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter streamId - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter streamId")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_offset = query_params
+                        .iter()
+                        .filter(|e| e.0 == "offset")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_offset = match param_offset {
+                        Some(param_offset) => {
+                            let param_offset = <i32 as std::str::FromStr>::from_str(&param_offset);
+                            match param_offset {
+                            Ok(param_offset) => Some(param_offset),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter offset - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter offset")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_limit = query_params
+                        .iter()
+                        .filter(|e| e.0 == "limit")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_limit = match param_limit {
+                        Some(param_limit) => {
+                            let param_limit = <i32 as std::str::FromStr>::from_str(&param_limit);
+                            match param_limit {
+                            Ok(param_limit) => Some(param_limit),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter limit - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter limit")),
+                        }
+                        }
+                        None => None,
+                    };
+
+                    let result = api_impl
+                        .events_sort_key_sort_value_get(
+                            param_sort_key,
+                            param_sort_value,
+                            param_controller,
+                            param_stream_id,
+                            param_offset,
+                            param_limit,
+                            &context,
+                        )
+                        .await;
+                    let mut response = Response::new(Body::empty());
+                    response.headers_mut().insert(
+                        HeaderName::from_static("x-span-id"),
+                        HeaderValue::from_str(
+                            (&context as &dyn Has<XSpanIdString>)
+                                .get()
+                                .0
+                                .clone()
+                                .as_str(),
+                        )
+                        .expect("Unable to create X-Span-ID header value"),
+                    );
+
+                    match result {
+                        Ok(rsp) => match rsp {
+                            EventsSortKeySortValueGetResponse::Success(body) => {
+                                *response.status_mut() = StatusCode::from_u16(200)
+                                    .expect("Unable to turn 200 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_SORT_KEY_SORT_VALUE_GET_SUCCESS"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                        },
+                        Err(_) => {
+                            // Application code returned an error. This should not happen, as the implementation should
+                            // return a valid response.
+                            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                            *response.body_mut() = Body::from("An internal error occurred");
+                        }
+                    }
+
+                    Ok(response)
                 }
 
                 // FeedEventsGet - GET /feed/events
@@ -803,6 +978,7 @@ where
 
                 _ if path.matched(paths::ID_EVENTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_EVENTS_EVENT_ID) => method_not_allowed(),
+                _ if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
                 _ if path.matched(paths::ID_FEED_EVENTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_INTERESTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
                 _ if path.matched(paths::ID_LIVENESS) => method_not_allowed(),
@@ -830,6 +1006,10 @@ impl<T> RequestParser<T> for ApiRequestParser {
             }
             // EventsPost - POST /events
             hyper::Method::POST if path.matched(paths::ID_EVENTS) => Some("EventsPost"),
+            // EventsSortKeySortValueGet - GET /events/{sort_key}/{sort_value}
+            hyper::Method::GET if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => {
+                Some("EventsSortKeySortValueGet")
+            }
             // FeedEventsGet - GET /feed/events
             hyper::Method::GET if path.matched(paths::ID_FEED_EVENTS) => Some("FeedEventsGet"),
             // InterestsSortKeySortValuePost - POST /interests/{sort_key}/{sort_value}

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -150,6 +150,54 @@ paths:
         '204':
           description: success
 
+  '/events/{sort_key}/{sort_value}':
+    get:
+      summary: Get events matching the interest stored on the node 
+      parameters:
+        - name: sort_key
+          in: path
+          description: name of the sort_key e.g. 'model'
+          schema:
+            type: string
+          required: true
+        - name: sort_value
+          in: path
+          description: value associated with the sort key e.g. model ID
+          schema:
+            type: string
+          required: true
+        - name: controller
+          in: query
+          description: the controller to filter 
+          required: false
+          schema:
+            type: string
+        - name: streamId
+          in: query
+          description: the stream to filter 
+          required: false
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: token that designates the point to resume from, that is find keys added after this point
+          schema:
+            type: integer
+          required: false
+        - name: limit
+          in: query
+          description: the maximum number of events to return, default is 10000.
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsGet'
+
   '/feed/events':
     get:
       summary: Get all new event keys since resume token
@@ -268,3 +316,24 @@ components:
         resumeToken:
           type: string
           description: The token/highwater mark to used as resumeAt on a future request
+    EventsGet:
+      title: Information about multiple events. 
+      description: Ceramic event keys as part of a Ceramic Stream
+      type: object
+      required:
+        - events
+        - resumeOffset
+        - isComplete
+      properties:
+        events:
+          type: array
+          items:
+            schema:
+            $ref: '#/components/schemas/Event'
+          description: An array of events
+        resumeOffset:
+          type: integer
+          description: An integer specifying where to resume the request. Only works correctly for the same input parameters.
+        isComplete:
+          type: boolean
+          description: A boolean specifying if there are more events to be fetched. Repeat with the resumeOffset to get next set.

--- a/api/src/metrics/api.rs
+++ b/api/src/metrics/api.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ceramic_api_server::{
-    models, Api, EventsEventIdGetResponse, EventsPostResponse, FeedEventsGetResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    models, Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
+    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
     SubscribeSortKeySortValueGetResponse, VersionPostResponse,
 };
 use ceramic_metrics::Recorder;
@@ -69,6 +69,26 @@ where
             "/feed/events",
             self.api
                 .feed_events_get(param_resume_at, param_limit, context),
+        )
+        .await
+    }
+
+    /// Get events for a stream
+    async fn events_sort_key_sort_value_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
+        self.record(
+            "/events",
+            self.api.events_sort_key_sort_value_get(
+                sort_key, sort_value, controller, stream_id, offset, limit, context,
+            ),
         )
         .await
     }


### PR DESCRIPTION
`GET /events/{sort_key}/{sort_value}?controller={did}&streamId={sId}&limit={int}&offset={int}`

Returns a response like
```json 
{
    "events": [{"id": "", "data": ""}],
    "resumeOffset": "int",
    "isComplete": "bool"
}
```

I considered reusing the EventFeed response, but used something different to make the "resume" semantics clear. Feed supports the token in all cases, whereas the `resumeOffset` is only "valid" (that is, useful) with the same parameters. It also may not be a permanent endpoint, or we may want to evolve it separately, so they only share the Event body currently.

I made some small refactors to the server.rs code to build the response objects in one place (that is, consolidate the encoding), and to build the start/end range as a function so we can share between this and the interest endpoint.