### PR TITLE
chore: only lint single commit or PR title

### DIFF
--- a/.github/workflows/pr-semantic-message.yml
+++ b/.github/workflows/pr-semantic-message.yml
@@ -8,3 +8,8 @@ on:
 jobs:
   semantic:
     uses: influxdata/validate-semantic-github-messages/.github/workflows/semantic.yml@main
+    with:
+      # When true:
+      #   If there is one commit, only validate its commit message (and not the PR title).
+      #   Else validate PR title only (and skip commit messages).
+      CHECK_PR_TITLE_OR_ONE_COMMIT: true


### PR DESCRIPTION
Instead of linting all commits we will now lint the commit message if it is the only commit in the PR otherwise we will lint the PR title.