### PR TITLE
fix: pass job labels to designate notification channels

### DIFF
--- a/ci-scripts/schedule_k8s_deploy.sh
+++ b/ci-scripts/schedule_k8s_deploy.sh
@@ -30,6 +30,7 @@ docker run --rm -i \
         \"repo\":     {\"S\": \"ceramic-infra\"},           \
         \"ref\":      {\"S\": \"$branch\"},                 \
         \"workflow\": {\"S\": \"update_image.yml\"},        \
+        \"labels\":   {\"L\": [{\"S\": \"deploy\"}]},       \
         \"inputs\":   {                                     \
           \"M\": {                                          \
             \"ceramic_one_image\": {\"S\": \"$image\"},     \

--- a/ci-scripts/schedule_tests.sh
+++ b/ci-scripts/schedule_tests.sh
@@ -32,6 +32,7 @@ docker run --rm -i \
         \"repo\":     {\"S\": \"ceramic-tests\"},           \
         \"ref\":      {\"S\": \"main\"},                    \
         \"workflow\": {\"S\": \"run-durable.yml\"},         \
+        \"labels\":   {\"L\": [{\"S\": \"test\"}]},         \
         \"inputs\":   {                                     \
           \"M\": {                                          \
             \"test_selector\": {\"S\": \"$test_selector\"}  \


### PR DESCRIPTION
Using the new `labels` field enabled via [this](https://github.com/3box/pipeline-tools/pull/58) PR.