### PR TITLE
feat: use standard error response body for API 

### DIFF
--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -3,6 +3,7 @@
 Cargo.toml
 README.md
 api/openapi.yaml
+docs/ErrorResponse.md
 docs/Event.md
 docs/EventFeed.md
 docs/EventsGet.md

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T14:39:13.517876304Z[Etc/UTC]
+- Build date: 2024-03-19T10:03:40.368742-06:00[America/Denver]
 
 
 
@@ -112,6 +112,7 @@ Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [ErrorResponse](docs/ErrorResponse.md)
  - [Event](docs/Event.md)
  - [EventFeed](docs/EventFeed.md)
  - [EventsGet](docs/EventsGet.md)

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -15,6 +15,12 @@ paths:
       responses:
         "200":
           description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Test the liveness of the Ceramic node
   /version:
     post:
@@ -25,6 +31,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Version'
           description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Get the version of the Ceramic node
   /events:
     post:
@@ -39,6 +51,12 @@ paths:
               schema:
                 type: string
           description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Creates a new event
   /events/{event_id}:
     get:
@@ -64,6 +82,12 @@ paths:
               schema:
                 type: string
           description: Event not found
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Get event data
   /interests/{sort_key}/{sort_value}:
     post:
@@ -103,6 +127,12 @@ paths:
       responses:
         "204":
           description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Register interest for a sort key
   /events/{sort_key}/{sort_value}:
     get:
@@ -163,6 +193,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/EventsGet'
           description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Get events matching the interest stored on the node
   /feed/events:
     get:
@@ -197,6 +233,12 @@ paths:
               schema:
                 type: string
           description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
       summary: Get all new event keys since resume token
 components:
   requestBodies:
@@ -293,5 +335,15 @@ components:
       - isComplete
       - resumeOffset
       title: Information about multiple events.
+      type: object
+    ErrorResponse:
+      description: Error response
+      properties:
+        message:
+          description: Error message
+          type: string
+      required:
+      - message
+      title: Error response
       type: object
 

--- a/api-server/docs/ErrorResponse.md
+++ b/api-server/docs/ErrorResponse.md
@@ -1,0 +1,10 @@
+# ErrorResponse
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**message** | **String** | Error message | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -168,7 +168,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -190,7 +190,7 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
- - **Accept**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -471,6 +471,19 @@ where
                 let body = body.to_string();
                 Ok(EventsEventIdGetResponse::EventNotFound(body))
             }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(EventsEventIdGetResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -571,6 +584,19 @@ where
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
                 Ok(EventsPostResponse::BadRequest(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(EventsPostResponse::InternalServerError(body))
             }
             code => {
                 let headers = response.headers().clone();
@@ -678,6 +704,19 @@ where
                 })?;
                 Ok(EventsSortKeySortValueGetResponse::Success(body))
             }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(EventsSortKeySortValueGetResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -782,6 +821,19 @@ where
                 })?;
                 Ok(FeedEventsGetResponse::BadRequest(body))
             }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(FeedEventsGetResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -868,6 +920,21 @@ where
 
         match response.status().as_u16() {
             204 => Ok(InterestsSortKeySortValuePostResponse::Success),
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(InterestsSortKeySortValuePostResponse::InternalServerError(
+                    body,
+                ))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -936,6 +1003,19 @@ where
 
         match response.status().as_u16() {
             200 => Ok(LivenessGetResponse::Success),
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(LivenessGetResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -1015,6 +1095,19 @@ where
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
                 Ok(VersionPostResponse::Success(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(VersionPostResponse::InternalServerError(body))
             }
             code => {
                 let headers = response.headers().clone();

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -29,6 +29,8 @@ pub enum EventsEventIdGetResponse {
     Success(models::Event),
     /// Event not found
     EventNotFound(String),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -38,12 +40,17 @@ pub enum EventsPostResponse {
     Success,
     /// bad request
     BadRequest(String),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum EventsSortKeySortValueGetResponse {
     /// success
     Success(models::EventsGet),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -53,24 +60,35 @@ pub enum FeedEventsGetResponse {
     Success(models::EventFeed),
     /// bad request
     BadRequest(String),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum InterestsSortKeySortValuePostResponse {
     /// success
     Success,
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum LivenessGetResponse {
     /// success
     Success,
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum VersionPostResponse {
     /// success
     Success(models::Version),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
 }
 
 /// API

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -7,6 +7,139 @@ use validator::Validate;
 use crate::header;
 use crate::models;
 
+/// Error response
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct ErrorResponse {
+    /// Error message
+    #[serde(rename = "message")]
+    pub message: String,
+}
+
+impl ErrorResponse {
+    #[allow(clippy::new_without_default)]
+    pub fn new(message: String) -> ErrorResponse {
+        ErrorResponse { message }
+    }
+}
+
+/// Converts the ErrorResponse value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for ErrorResponse {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> =
+            vec![Some("message".to_string()), Some(self.message.to_string())];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a ErrorResponse value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for ErrorResponse {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub message: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing ErrorResponse".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "message" => intermediate_rep.message.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing ErrorResponse".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(ErrorResponse {
+            message: intermediate_rep
+                .message
+                .into_iter()
+                .next()
+                .ok_or_else(|| "message missing in ErrorResponse".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<ErrorResponse> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<ErrorResponse>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<ErrorResponse>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for ErrorResponse - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<ErrorResponse> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <ErrorResponse as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into ErrorResponse - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// A Ceramic event as part of a Ceramic Stream
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -243,6 +243,17 @@ where
                                 let body_content = body;
                                 *response.body_mut() = Body::from(body_content);
                             }
+                            EventsEventIdGetResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_EVENT_ID_GET_INTERNAL_SERVER_ERROR"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
                         },
                         Err(_) => {
                             // Application code returned an error. This should not happen, as the implementation should
@@ -318,6 +329,17 @@ where
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_str("application/json")
                                                             .expect("Unable to create Content-Type header for EVENTS_POST_BAD_REQUEST"));
+                                                    let body_content = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body_content);
+                                                },
+                                                EventsPostResponse::InternalServerError
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(500).expect("Unable to turn 500 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_POST_INTERNAL_SERVER_ERROR"));
                                                     let body_content = serde_json::to_string(&body).expect("impossible to fail to serialize");
                                                     *response.body_mut() = Body::from(body_content);
                                                 },
@@ -494,6 +516,17 @@ where
                                     .expect("impossible to fail to serialize");
                                 *response.body_mut() = Body::from(body_content);
                             }
+                            EventsSortKeySortValueGetResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_SORT_KEY_SORT_VALUE_GET_INTERNAL_SERVER_ERROR"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
                         },
                         Err(_) => {
                             // Application code returned an error. This should not happen, as the implementation should
@@ -586,6 +619,17 @@ where
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_str("application/json")
                                                             .expect("Unable to create Content-Type header for FEED_EVENTS_GET_BAD_REQUEST"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                            FeedEventsGetResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for FEED_EVENTS_GET_INTERNAL_SERVER_ERROR"));
                                 let body_content = serde_json::to_string(&body)
                                     .expect("impossible to fail to serialize");
                                 *response.body_mut() = Body::from(body_content);
@@ -712,6 +756,17 @@ where
                                 *response.status_mut() = StatusCode::from_u16(204)
                                     .expect("Unable to turn 204 into a StatusCode");
                             }
+                            InterestsSortKeySortValuePostResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for INTERESTS_SORT_KEY_SORT_VALUE_POST_INTERNAL_SERVER_ERROR"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
                         },
                         Err(_) => {
                             // Application code returned an error. This should not happen, as the implementation should
@@ -745,6 +800,17 @@ where
                             LivenessGetResponse::Success => {
                                 *response.status_mut() = StatusCode::from_u16(200)
                                     .expect("Unable to turn 200 into a StatusCode");
+                            }
+                            LivenessGetResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for LIVENESS_GET_INTERNAL_SERVER_ERROR"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
                             }
                         },
                         Err(_) => {
@@ -783,6 +849,17 @@ where
                                                         CONTENT_TYPE,
                                                         HeaderValue::from_str("application/json")
                                                             .expect("Unable to create Content-Type header for VERSION_POST_SUCCESS"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                            VersionPostResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for VERSION_POST_INTERNAL_SERVER_ERROR"));
                                 let body_content = serde_json::to_string(&body)
                                     .expect("impossible to fail to serialize");
                                 *response.body_mut() = Body::from(body_content);

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -21,6 +21,12 @@ paths:
       responses:
         "200":
           description: success
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /version:
     post:
       summary: Get the version of the Ceramic node
@@ -29,23 +35,34 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Version'
+                $ref: "#/components/schemas/Version"
           description: success
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /events:
     post:
       summary: Creates a new event
       requestBody:
-        $ref: '#/components/requestBodies/Event'
+        $ref: "#/components/requestBodies/Event"
       responses:
-        '204':
+        "204":
           description: success
-        '400':
+        "400":
           description: bad request
           content:
             application/json:
               schema:
                 type: string
-
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /events/{event_id}:
     get:
       summary: Get event data
@@ -57,19 +74,25 @@ paths:
             type: string
           required: true
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Event'
-        '404':
+                $ref: "#/components/schemas/Event"
+        "404":
           description: Event not found
           content:
             text/plain:
               schema:
                 type: string
-  '/interests/{sort_key}/{sort_value}':
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  "/interests/{sort_key}/{sort_value}":
     post:
       summary: Register interest for a sort key
       parameters:
@@ -98,12 +121,18 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        "204":
           description: success
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-  '/events/{sort_key}/{sort_value}':
+  "/events/{sort_key}/{sort_value}":
     get:
-      summary: Get events matching the interest stored on the node 
+      summary: Get events matching the interest stored on the node
       parameters:
         - name: sort_key
           in: path
@@ -119,13 +148,13 @@ paths:
           required: true
         - name: controller
           in: query
-          description: the controller to filter 
+          description: the controller to filter
           required: false
           schema:
             type: string
         - name: streamId
           in: query
-          description: the stream to filter 
+          description: the stream to filter
           required: false
           schema:
             type: string
@@ -142,14 +171,20 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventsGet'
+                $ref: "#/components/schemas/EventsGet"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
-  '/feed/events':
+  "/feed/events":
     get:
       summary: Get all new event keys since resume token
       parameters:
@@ -166,25 +201,31 @@ paths:
           schema:
             type: integer
       responses:
-        '200':
+        "200":
           description: success
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/EventFeed'
-        '400':
+                $ref: "#/components/schemas/EventFeed"
+        "400":
           description: bad request
           content:
             application/json:
               schema:
                 type: string
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   requestBodies:
     Event:
       content:
         application/json:
           schema:
-              $ref: '#/components/schemas/Event'
+            $ref: "#/components/schemas/Event"
       description: Event to add to the node
       required: true
     Message:
@@ -228,13 +269,13 @@ components:
           type: array
           items:
             schema:
-            $ref: '#/components/schemas/Event'
+            $ref: "#/components/schemas/Event"
           description: An array of events. For now, the value is empty.
         resumeToken:
           type: string
           description: The token/highwater mark to used as resumeAt on a future request
     EventsGet:
-      title: Information about multiple events. 
+      title: Information about multiple events.
       description: Ceramic event keys as part of a Ceramic Stream
       type: object
       required:
@@ -246,7 +287,7 @@ components:
           type: array
           items:
             schema:
-            $ref: '#/components/schemas/Event'
+            $ref: "#/components/schemas/Event"
           description: An array of events
         resumeOffset:
           type: integer
@@ -254,3 +295,13 @@ components:
         isComplete:
           type: boolean
           description: A boolean specifying if there are more events to be fetched. Repeat with the resumeOffset to get next set.
+    ErrorResponse:
+      title: Error response
+      description: Error response
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Error message


### PR DESCRIPTION
Addresses WS1-1518.

All Recon API errors are now of the format `{"message": "some text"}` instead of just a string. In order to make sure I didn't miss anything, I moved all the logic inside the server struct impl, rather than the trait. This allows using `or_else(|err| Ok(resp::InternalServerError(err))`. We don't return the swagger ApiError struct in any cases. The diff looks a bit intimidating, but it's pretty much just moving some things around. The responses change from `<_,ApiError>` to `<_, ErrorResponse>` and the trait impl maps them.