### PR TITLE
feat: add POST interests route that accepts body instead of path/query parameters

### DIFF
--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -8,6 +8,7 @@ docs/ErrorResponse.md
 docs/Event.md
 docs/EventFeed.md
 docs/EventsGet.md
+docs/Interest.md
 docs/Version.md
 docs/default_api.md
 examples/ca.pem

--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -3,6 +3,7 @@
 Cargo.toml
 README.md
 api/openapi.yaml
+docs/BadRequestResponse.md
 docs/ErrorResponse.md
 docs/Event.md
 docs/EventFeed.md

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:12:55.935129-06:00[America/Denver]
+- Build date: 2024-03-19T10:13:54.622422-06:00[America/Denver]
 
 
 
@@ -105,6 +105,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **POST** /events | Creates a new event
 [****](docs/default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
 [****](docs/default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
+[****](docs/default_api.md#) | **POST** /interests | Register interest for a sort key
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 [****](docs/default_api.md#) | **POST** /version | Get the version of the Ceramic node
@@ -117,6 +118,7 @@ Method | HTTP request | Description
  - [Event](docs/Event.md)
  - [EventFeed](docs/EventFeed.md)
  - [EventsGet](docs/EventsGet.md)
+ - [Interest](docs/Interest.md)
  - [Version](docs/Version.md)
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:13:54.622422-06:00[America/Denver]
+- Build date: 2024-03-19T10:14:35.778106-06:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:03:40.368742-06:00[America/Denver]
+- Build date: 2024-03-19T10:12:55.935129-06:00[America/Denver]
 
 
 
@@ -112,6 +112,7 @@ Method | HTTP request | Description
 
 ## Documentation For Models
 
+ - [BadRequestResponse](docs/BadRequestResponse.md)
  - [ErrorResponse](docs/ErrorResponse.md)
  - [Event](docs/Event.md)
  - [EventFeed](docs/EventFeed.md)

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -49,7 +49,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/BadRequestResponse'
           description: bad request
         "500":
           content:
@@ -127,6 +127,12 @@ paths:
       responses:
         "204":
           description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
         "500":
           content:
             application/json:
@@ -193,6 +199,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/EventsGet'
           description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
         "500":
           content:
             application/json:
@@ -231,7 +243,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/BadRequestResponse'
           description: bad request
         "500":
           content:
@@ -266,6 +278,16 @@ components:
         version:
           description: Version of the Ceramic node
           type: string
+    BadRequestResponse:
+      description: Bad request (input error)
+      properties:
+        message:
+          description: Message describing the error
+          type: string
+      required:
+      - message
+      title: Response to a bad request (400)
+      type: object
     Event:
       description: A Ceramic event as part of a Ceramic Stream
       example:

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -140,6 +140,26 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Register interest for a sort key
+  /interests:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/Interest'
+      responses:
+        "204":
+          description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Register interest for a sort key
   /events/{sort_key}/{sort_value}:
     get:
       parameters:
@@ -269,6 +289,13 @@ components:
             type: string
       description: Recon message to send
       required: true
+    Interest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Interest'
+      description: Interest to register on the node
+      required: true
   schemas:
     Version:
       description: "Version of the Ceramic node in semver format, e.g. 2.1.0"
@@ -367,5 +394,30 @@ components:
       required:
       - message
       title: Error response
+      type: object
+    Interest:
+      description: Describes a recon interest range to store and synchronize
+      example:
+        controller: controller
+        streamId: streamId
+        model: model
+        sep: sep
+      properties:
+        sep:
+          description: "Separator value, typically 'model' (sometimes called sort_key)"
+          type: string
+        model:
+          description: Multibase encoded stream ID (sometimes called sort_value)
+          type: string
+        controller:
+          description: Decentralized identifier (DID) string
+          type: string
+        streamId:
+          description: Multibase encoded stream ID.
+          type: string
+      required:
+      - model
+      - sep
+      title: A recon interest
       type: object
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -400,14 +400,15 @@ components:
       example:
         controller: controller
         streamId: streamId
-        model: model
+        sepValue: sepValue
         sep: sep
       properties:
         sep:
-          description: "Separator value, typically 'model' (sometimes called sort_key)"
+          description: "Separator key, typically 'model' (sometimes called sort_key)"
           type: string
-        model:
-          description: Multibase encoded stream ID (sometimes called sort_value)
+        sepValue:
+          description: "Multibase encoded separator value (sometimes called sort_value,\
+            \ typically a stream ID)"
           type: string
         controller:
           description: Decentralized identifier (DID) string
@@ -416,8 +417,8 @@ components:
           description: Multibase encoded stream ID.
           type: string
       required:
-      - model
       - sep
+      - sepValue
       title: A recon interest
       type: object
 

--- a/api-server/docs/BadRequestResponse.md
+++ b/api-server/docs/BadRequestResponse.md
@@ -1,0 +1,10 @@
+# BadRequestResponse
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**message** | **String** | Message describing the error | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/Interest.md
+++ b/api-server/docs/Interest.md
@@ -1,0 +1,13 @@
+# Interest
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**sep** | **String** | Separator value, typically 'model' (sometimes called sort_key) | 
+**model** | **String** | Multibase encoded stream ID (sometimes called sort_value) | 
+**controller** | **String** | Decentralized identifier (DID) string | [optional] [default to None]
+**stream_id** | **String** | Multibase encoded stream ID. | [optional] [default to None]
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/Interest.md
+++ b/api-server/docs/Interest.md
@@ -3,8 +3,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**sep** | **String** | Separator value, typically 'model' (sometimes called sort_key) | 
-**model** | **String** | Multibase encoded stream ID (sometimes called sort_value) | 
+**sep** | **String** | Separator key, typically 'model' (sometimes called sort_key) | 
+**sep_value** | **String** | Multibase encoded separator value (sometimes called sort_value, typically a stream ID) | 
 **controller** | **String** | Decentralized identifier (DID) string | [optional] [default to None]
 **stream_id** | **String** | Multibase encoded stream ID. | [optional] [default to None]
 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **POST** /events | Creates a new event
 ****](default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
 ****](default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
+****](default_api.md#) | **POST** /interests | Register interest for a sort key
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 ****](default_api.md#) | **POST** /version | Get the version of the Ceramic node
@@ -131,6 +132,31 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (interest)
+Register interest for a sort key
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **interest** | [**Interest**](Interest.md)| Interest to register on the node | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -4,7 +4,8 @@
 use ceramic_api_server::{
     models, Api, ApiNoContext, Client, ContextWrapperExt, EventsEventIdGetResponse,
     EventsPostResponse, EventsSortKeySortValueGetResponse, FeedEventsGetResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
+    InterestsPostResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
+    VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -135,6 +136,14 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        /* Disabled because there's no example.
+        Some("InterestsPost") => {
+            let result = rt.block_on(client.interests_post(
+                  ???
+            ));
+            info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
+        },
+        */
         Some("InterestsSortKeySortValuePost") => {
             let result = rt.block_on(client.interests_sort_key_sort_value_post(
                 "sort_key_example".to_string(),

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -102,8 +102,8 @@ impl<C> Server<C> {
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionPostResponse,
+    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
+    LivenessGetResponse, VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -167,6 +167,20 @@ where
             "feed_events_get({:?}, {:?}) - X-Span-ID: {:?}",
             resume_at,
             limit,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Register interest for a sort key
+    async fn interests_post(
+        &self,
+        interest: models::Interest,
+        context: &C,
+    ) -> Result<InterestsPostResponse, ApiError> {
+        info!(
+            "interests_post({:?}) - X-Span-ID: {:?}",
+            interest,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -580,9 +580,10 @@ where
                     .await?;
                 let body = str::from_utf8(&body)
                     .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                let body = serde_json::from_str::<String>(body).map_err(|e| {
-                    ApiError(format!("Response body did not match the schema: {}", e))
-                })?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
                 Ok(EventsPostResponse::BadRequest(body))
             }
             500 => {
@@ -704,6 +705,20 @@ where
                 })?;
                 Ok(EventsSortKeySortValueGetResponse::Success(body))
             }
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(EventsSortKeySortValueGetResponse::BadRequest(body))
+            }
             500 => {
                 let body = response.into_body();
                 let body = body
@@ -816,9 +831,10 @@ where
                     .await?;
                 let body = str::from_utf8(&body)
                     .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                let body = serde_json::from_str::<String>(body).map_err(|e| {
-                    ApiError(format!("Response body did not match the schema: {}", e))
-                })?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
                 Ok(FeedEventsGetResponse::BadRequest(body))
             }
             500 => {
@@ -920,6 +936,20 @@ where
 
         match response.status().as_u16() {
             204 => Ok(InterestsSortKeySortValuePostResponse::Success),
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(InterestsSortKeySortValuePostResponse::BadRequest(body))
+            }
             500 => {
                 let body = response.into_body();
                 let body = body

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -43,8 +43,8 @@ const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionPostResponse,
+    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
+    LivenessGetResponse, VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -849,6 +849,121 @@ where
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
                 Ok(FeedEventsGetResponse::InternalServerError(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn interests_post(
+        &self,
+        param_interest: models::Interest,
+        context: &C,
+    ) -> Result<InterestsPostResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/interests", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let body = serde_json::to_string(&param_interest).expect("impossible to fail to serialize");
+        *request.body_mut() = Body::from(body);
+
+        let header = "application/json";
+        request.headers_mut().insert(
+            CONTENT_TYPE,
+            match HeaderValue::from_str(header) {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create header: {} - {}",
+                        header, e
+                    )))
+                }
+            },
+        );
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            204 => Ok(InterestsPostResponse::Success),
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(InterestsPostResponse::BadRequest(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(InterestsPostResponse::InternalServerError(body))
             }
             code => {
                 let headers = response.headers().clone();

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -39,7 +39,7 @@ pub enum EventsPostResponse {
     /// success
     Success,
     /// bad request
-    BadRequest(String),
+    BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
 }
@@ -49,6 +49,8 @@ pub enum EventsPostResponse {
 pub enum EventsSortKeySortValueGetResponse {
     /// success
     Success(models::EventsGet),
+    /// bad request
+    BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
 }
@@ -59,7 +61,7 @@ pub enum FeedEventsGetResponse {
     /// success
     Success(models::EventFeed),
     /// bad request
-    BadRequest(String),
+    BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
 }
@@ -69,6 +71,8 @@ pub enum FeedEventsGetResponse {
 pub enum InterestsSortKeySortValuePostResponse {
     /// success
     Success,
+    /// bad request
+    BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
 }

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -68,6 +68,17 @@ pub enum FeedEventsGetResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum InterestsPostResponse {
+    /// success
+    Success,
+    /// bad request
+    BadRequest(models::BadRequestResponse),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum InterestsSortKeySortValuePostResponse {
     /// success
     Success,
@@ -141,6 +152,13 @@ pub trait Api<C: Send + Sync> {
     ) -> Result<FeedEventsGetResponse, ApiError>;
 
     /// Register interest for a sort key
+    async fn interests_post(
+        &self,
+        interest: models::Interest,
+        context: &C,
+    ) -> Result<InterestsPostResponse, ApiError>;
+
+    /// Register interest for a sort key
     async fn interests_sort_key_sort_value_post(
         &self,
         sort_key: String,
@@ -194,6 +212,12 @@ pub trait ApiNoContext<C: Send + Sync> {
         resume_at: Option<String>,
         limit: Option<i32>,
     ) -> Result<FeedEventsGetResponse, ApiError>;
+
+    /// Register interest for a sort key
+    async fn interests_post(
+        &self,
+        interest: models::Interest,
+    ) -> Result<InterestsPostResponse, ApiError>;
 
     /// Register interest for a sort key
     async fn interests_sort_key_sort_value_post(
@@ -277,6 +301,15 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     ) -> Result<FeedEventsGetResponse, ApiError> {
         let context = self.context().clone();
         self.api().feed_events_get(resume_at, limit, &context).await
+    }
+
+    /// Register interest for a sort key
+    async fn interests_post(
+        &self,
+        interest: models::Interest,
+    ) -> Result<InterestsPostResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().interests_post(interest, &context).await
     }
 
     /// Register interest for a sort key

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -753,6 +753,190 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
     }
 }
 
+/// Describes a recon interest range to store and synchronize
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct Interest {
+    /// Separator value, typically 'model' (sometimes called sort_key)
+    #[serde(rename = "sep")]
+    pub sep: String,
+
+    /// Multibase encoded stream ID (sometimes called sort_value)
+    #[serde(rename = "model")]
+    pub model: String,
+
+    /// Decentralized identifier (DID) string
+    #[serde(rename = "controller")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub controller: Option<String>,
+
+    /// Multibase encoded stream ID.
+    #[serde(rename = "streamId")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_id: Option<String>,
+}
+
+impl Interest {
+    #[allow(clippy::new_without_default)]
+    pub fn new(sep: String, model: String) -> Interest {
+        Interest {
+            sep,
+            model,
+            controller: None,
+            stream_id: None,
+        }
+    }
+}
+
+/// Converts the Interest value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for Interest {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> = vec![
+            Some("sep".to_string()),
+            Some(self.sep.to_string()),
+            Some("model".to_string()),
+            Some(self.model.to_string()),
+            self.controller
+                .as_ref()
+                .map(|controller| ["controller".to_string(), controller.to_string()].join(",")),
+            self.stream_id
+                .as_ref()
+                .map(|stream_id| ["streamId".to_string(), stream_id.to_string()].join(",")),
+        ];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a Interest value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for Interest {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub sep: Vec<String>,
+            pub model: Vec<String>,
+            pub controller: Vec<String>,
+            pub stream_id: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing Interest".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "sep" => intermediate_rep.sep.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "model" => intermediate_rep.model.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "controller" => intermediate_rep.controller.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "streamId" => intermediate_rep.stream_id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing Interest".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(Interest {
+            sep: intermediate_rep
+                .sep
+                .into_iter()
+                .next()
+                .ok_or_else(|| "sep missing in Interest".to_string())?,
+            model: intermediate_rep
+                .model
+                .into_iter()
+                .next()
+                .ok_or_else(|| "model missing in Interest".to_string())?,
+            controller: intermediate_rep.controller.into_iter().next(),
+            stream_id: intermediate_rep.stream_id.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<Interest> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<Interest>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<Interest>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for Interest - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<Interest> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <Interest as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into Interest - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// Version of the Ceramic node in semver format, e.g. 2.1.0
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -757,13 +757,13 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Interest {
-    /// Separator value, typically 'model' (sometimes called sort_key)
+    /// Separator key, typically 'model' (sometimes called sort_key)
     #[serde(rename = "sep")]
     pub sep: String,
 
-    /// Multibase encoded stream ID (sometimes called sort_value)
-    #[serde(rename = "model")]
-    pub model: String,
+    /// Multibase encoded separator value (sometimes called sort_value, typically a stream ID)
+    #[serde(rename = "sepValue")]
+    pub sep_value: String,
 
     /// Decentralized identifier (DID) string
     #[serde(rename = "controller")]
@@ -778,10 +778,10 @@ pub struct Interest {
 
 impl Interest {
     #[allow(clippy::new_without_default)]
-    pub fn new(sep: String, model: String) -> Interest {
+    pub fn new(sep: String, sep_value: String) -> Interest {
         Interest {
             sep,
-            model,
+            sep_value,
             controller: None,
             stream_id: None,
         }
@@ -796,8 +796,8 @@ impl std::string::ToString for Interest {
         let params: Vec<Option<String>> = vec![
             Some("sep".to_string()),
             Some(self.sep.to_string()),
-            Some("model".to_string()),
-            Some(self.model.to_string()),
+            Some("sepValue".to_string()),
+            Some(self.sep_value.to_string()),
             self.controller
                 .as_ref()
                 .map(|controller| ["controller".to_string(), controller.to_string()].join(",")),
@@ -822,7 +822,7 @@ impl std::str::FromStr for Interest {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub sep: Vec<String>,
-            pub model: Vec<String>,
+            pub sep_value: Vec<String>,
             pub controller: Vec<String>,
             pub stream_id: Vec<String>,
         }
@@ -851,7 +851,7 @@ impl std::str::FromStr for Interest {
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
-                    "model" => intermediate_rep.model.push(
+                    "sepValue" => intermediate_rep.sep_value.push(
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
@@ -881,11 +881,11 @@ impl std::str::FromStr for Interest {
                 .into_iter()
                 .next()
                 .ok_or_else(|| "sep missing in Interest".to_string())?,
-            model: intermediate_rep
-                .model
+            sep_value: intermediate_rep
+                .sep_value
                 .into_iter()
                 .next()
-                .ok_or_else(|| "model missing in Interest".to_string())?,
+                .ok_or_else(|| "sepValue missing in Interest".to_string())?,
             controller: intermediate_rep.controller.into_iter().next(),
             stream_id: intermediate_rep.stream_id.into_iter().next(),
         })

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -7,6 +7,143 @@ use validator::Validate;
 use crate::header;
 use crate::models;
 
+/// Bad request (input error)
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct BadRequestResponse {
+    /// Message describing the error
+    #[serde(rename = "message")]
+    pub message: String,
+}
+
+impl BadRequestResponse {
+    #[allow(clippy::new_without_default)]
+    pub fn new(message: String) -> BadRequestResponse {
+        BadRequestResponse { message }
+    }
+}
+
+/// Converts the BadRequestResponse value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for BadRequestResponse {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> =
+            vec![Some("message".to_string()), Some(self.message.to_string())];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a BadRequestResponse value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for BadRequestResponse {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub message: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing BadRequestResponse".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "message" => intermediate_rep.message.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing BadRequestResponse".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(BadRequestResponse {
+            message: intermediate_rep
+                .message
+                .into_iter()
+                .next()
+                .ok_or_else(|| "message missing in BadRequestResponse".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<BadRequestResponse> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<BadRequestResponse>>
+    for hyper::header::HeaderValue
+{
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<BadRequestResponse>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for BadRequestResponse - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue>
+    for header::IntoHeaderValue<BadRequestResponse>
+{
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <BadRequestResponse as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into BadRequestResponse - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// Error response
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -23,8 +23,8 @@ type ServiceFuture = BoxFuture<'static, Result<Response<Body>, crate::ServiceErr
 
 use crate::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionPostResponse,
+    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
+    LivenessGetResponse, VersionPostResponse,
 };
 
 mod paths {
@@ -36,6 +36,7 @@ mod paths {
             r"^/ceramic/events/(?P<event_id>[^/?#]*)$",
             r"^/ceramic/events/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
             r"^/ceramic/feed/events$",
+            r"^/ceramic/interests$",
             r"^/ceramic/interests/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
             r"^/ceramic/liveness$",
             r"^/ceramic/version$"
@@ -58,7 +59,8 @@ mod paths {
                 .expect("Unable to create regex for EVENTS_SORT_KEY_SORT_VALUE");
     }
     pub(crate) static ID_FEED_EVENTS: usize = 3;
-    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 4;
+    pub(crate) static ID_INTERESTS: usize = 4;
+    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 5;
     lazy_static! {
         pub static ref REGEX_INTERESTS_SORT_KEY_SORT_VALUE: regex::Regex =
             #[allow(clippy::invalid_regex)]
@@ -67,8 +69,8 @@ mod paths {
             )
             .expect("Unable to create regex for INTERESTS_SORT_KEY_SORT_VALUE");
     }
-    pub(crate) static ID_LIVENESS: usize = 5;
-    pub(crate) static ID_VERSION: usize = 6;
+    pub(crate) static ID_LIVENESS: usize = 6;
+    pub(crate) static ID_VERSION: usize = 7;
 }
 
 pub struct MakeService<T, C>
@@ -657,6 +659,101 @@ where
                     Ok(response)
                 }
 
+                // InterestsPost - POST /interests
+                hyper::Method::POST if path.matched(paths::ID_INTERESTS) => {
+                    // Body parameters (note that non-required body parameters will ignore garbage
+                    // values, rather than causing a 400 response). Produce warning header and logs for
+                    // any unused fields.
+                    let result = body.into_raw().await;
+                    match result {
+                            Ok(body) => {
+                                let mut unused_elements = Vec::new();
+                                let param_interest: Option<models::Interest> = if !body.is_empty() {
+                                    let deserializer = &mut serde_json::Deserializer::from_slice(&body);
+                                    match serde_ignored::deserialize(deserializer, |path| {
+                                            warn!("Ignoring unknown field in body: {}", path);
+                                            unused_elements.push(path.to_string());
+                                    }) {
+                                        Ok(param_interest) => param_interest,
+                                        Err(e) => return Ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from(format!("Couldn't parse body parameter Interest - doesn't match schema: {}", e)))
+                                                        .expect("Unable to create Bad Request response for invalid body parameter Interest due to schema")),
+                                    }
+                                } else {
+                                    None
+                                };
+                                let param_interest = match param_interest {
+                                    Some(param_interest) => param_interest,
+                                    None => return Ok(Response::builder()
+                                                        .status(StatusCode::BAD_REQUEST)
+                                                        .body(Body::from("Missing required body parameter Interest"))
+                                                        .expect("Unable to create Bad Request response for missing body parameter Interest")),
+                                };
+
+                                let result = api_impl.interests_post(
+                                            param_interest,
+                                        &context
+                                    ).await;
+                                let mut response = Response::new(Body::empty());
+                                response.headers_mut().insert(
+                                            HeaderName::from_static("x-span-id"),
+                                            HeaderValue::from_str((&context as &dyn Has<XSpanIdString>).get().0.clone().as_str())
+                                                .expect("Unable to create X-Span-ID header value"));
+
+                                        if !unused_elements.is_empty() {
+                                            response.headers_mut().insert(
+                                                HeaderName::from_static("warning"),
+                                                HeaderValue::from_str(format!("Ignoring unknown fields in body: {:?}", unused_elements).as_str())
+                                                    .expect("Unable to create Warning header value"));
+                                        }
+
+                                        match result {
+                                            Ok(rsp) => match rsp {
+                                                InterestsPostResponse::Success
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(204).expect("Unable to turn 204 into a StatusCode");
+                                                },
+                                                InterestsPostResponse::BadRequest
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(400).expect("Unable to turn 400 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for INTERESTS_POST_BAD_REQUEST"));
+                                                    let body_content = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body_content);
+                                                },
+                                                InterestsPostResponse::InternalServerError
+                                                    (body)
+                                                => {
+                                                    *response.status_mut() = StatusCode::from_u16(500).expect("Unable to turn 500 into a StatusCode");
+                                                    response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for INTERESTS_POST_INTERNAL_SERVER_ERROR"));
+                                                    let body_content = serde_json::to_string(&body).expect("impossible to fail to serialize");
+                                                    *response.body_mut() = Body::from(body_content);
+                                                },
+                                            },
+                                            Err(_) => {
+                                                // Application code returned an error. This should not happen, as the implementation should
+                                                // return a valid response.
+                                                *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                                                *response.body_mut() = Body::from("An internal error occurred");
+                                            },
+                                        }
+
+                                        Ok(response)
+                            },
+                            Err(e) => Ok(Response::builder()
+                                                .status(StatusCode::BAD_REQUEST)
+                                                .body(Body::from(format!("Couldn't read body parameter Interest: {}", e)))
+                                                .expect("Unable to create Bad Request response due to unable to read body parameter Interest")),
+                        }
+                }
+
                 // InterestsSortKeySortValuePost - POST /interests/{sort_key}/{sort_value}
                 hyper::Method::POST if path.matched(paths::ID_INTERESTS_SORT_KEY_SORT_VALUE) => {
                     // Path parameters
@@ -902,6 +999,7 @@ where
                 _ if path.matched(paths::ID_EVENTS_EVENT_ID) => method_not_allowed(),
                 _ if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
                 _ if path.matched(paths::ID_FEED_EVENTS) => method_not_allowed(),
+                _ if path.matched(paths::ID_INTERESTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_INTERESTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
                 _ if path.matched(paths::ID_LIVENESS) => method_not_allowed(),
                 _ if path.matched(paths::ID_VERSION) => method_not_allowed(),
@@ -933,6 +1031,8 @@ impl<T> RequestParser<T> for ApiRequestParser {
             }
             // FeedEventsGet - GET /feed/events
             hyper::Method::GET if path.matched(paths::ID_FEED_EVENTS) => Some("FeedEventsGet"),
+            // InterestsPost - POST /interests
+            hyper::Method::POST if path.matched(paths::ID_INTERESTS) => Some("InterestsPost"),
             // InterestsSortKeySortValuePost - POST /interests/{sort_key}/{sort_value}
             hyper::Method::POST if path.matched(paths::ID_INTERESTS_SORT_KEY_SORT_VALUE) => {
                 Some("InterestsSortKeySortValuePost")

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -516,6 +516,17 @@ where
                                     .expect("impossible to fail to serialize");
                                 *response.body_mut() = Body::from(body_content);
                             }
+                            EventsSortKeySortValueGetResponse::BadRequest(body) => {
+                                *response.status_mut() = StatusCode::from_u16(400)
+                                    .expect("Unable to turn 400 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EVENTS_SORT_KEY_SORT_VALUE_GET_BAD_REQUEST"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
                             EventsSortKeySortValueGetResponse::InternalServerError(body) => {
                                 *response.status_mut() = StatusCode::from_u16(500)
                                     .expect("Unable to turn 500 into a StatusCode");
@@ -755,6 +766,17 @@ where
                             InterestsSortKeySortValuePostResponse::Success => {
                                 *response.status_mut() = StatusCode::from_u16(204)
                                     .expect("Unable to turn 204 into a StatusCode");
+                            }
+                            InterestsSortKeySortValuePostResponse::BadRequest(body) => {
+                                *response.status_mut() = StatusCode::from_u16(400)
+                                    .expect("Unable to turn 400 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for INTERESTS_SORT_KEY_SORT_VALUE_POST_BAD_REQUEST"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
                             }
                             InterestsSortKeySortValuePostResponse::InternalServerError(body) => {
                                 *response.status_mut() = StatusCode::from_u16(500)

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -56,7 +56,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: "#/components/schemas/BadRequestResponse"
         "500":
           description: Internal server error
           content:
@@ -123,6 +123,12 @@ paths:
       responses:
         "204":
           description: success
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
         "500":
           description: Internal server error
           content:
@@ -177,6 +183,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EventsGet"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
         "500":
           description: Internal server error
           content:
@@ -212,7 +224,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: "#/components/schemas/BadRequestResponse"
         "500":
           description: Internal server error
           content:
@@ -243,6 +255,16 @@ components:
         version:
           type: string
           description: Version of the Ceramic node
+    BadRequestResponse:
+      title: Response to a bad request (400)
+      description: Bad request (input error)
+      type: object
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          description: Message describing the error
     Event:
       title: A Ceramic Event
       description: A Ceramic event as part of a Ceramic Stream

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -135,7 +135,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-
+  "/interests":
+    post:
+      summary: Register interest for a sort key
+      requestBody:
+        $ref: "#/components/requestBodies/Interest"
+      responses:
+        "204":
+          description: success
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   "/events/{sort_key}/{sort_value}":
     get:
       summary: Get events matching the interest stored on the node
@@ -248,6 +267,13 @@ components:
             type: string
       description: Recon message to send
       required: true
+    Interest:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Interest"
+      description: Interest to register on the node
+      required: true
   schemas:
     Version:
       description: Version of the Ceramic node in semver format, e.g. 2.1.0
@@ -327,3 +353,23 @@ components:
         message:
           type: string
           description: Error message
+    Interest:
+      title: A recon interest
+      description: Describes a recon interest range to store and synchronize
+      type: object
+      required:
+        - sep
+        - model
+      properties:
+        sep:
+          type: string
+          description: Separator value, typically 'model' (sometimes called sort_key)
+        model:
+          type: string
+          description: Multibase encoded stream ID (sometimes called sort_value)
+        controller:
+          type: string
+          description: Decentralized identifier (DID) string
+        streamId:
+          type: string
+          description: Multibase encoded stream ID.

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -359,14 +359,14 @@ components:
       type: object
       required:
         - sep
-        - model
+        - sepValue
       properties:
         sep:
           type: string
-          description: Separator value, typically 'model' (sometimes called sort_key)
-        model:
+          description: Separator key, typically 'model' (sometimes called sort_key)
+        sepValue:
           type: string
-          description: Multibase encoded stream ID (sometimes called sort_value)
+          description: Multibase encoded separator value (sometimes called sort_value, typically a stream ID)
         controller:
           type: string
           description: Decentralized identifier (DID) string

--- a/api/src/metrics/api.rs
+++ b/api/src/metrics/api.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use ceramic_api_server::{
     models, Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionPostResponse,
+    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
+    LivenessGetResponse, VersionPostResponse,
 };
 use ceramic_metrics::Recorder;
 use futures::Future;
@@ -96,6 +96,16 @@ where
     /// Get the version of the Ceramic node
     async fn version_post(&self, context: &C) -> Result<VersionPostResponse, ApiError> {
         self.record("/version", self.api.version_post(context))
+            .await
+    }
+
+    /// Register interest for a sort key
+    async fn interests_post(
+        &self,
+        interest: models::Interest,
+        context: &C,
+    ) -> Result<InterestsPostResponse, ApiError> {
+        self.record("/interests", self.api.interests_post(interest, context))
             .await
     }
 

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -129,10 +129,12 @@ where
         let hw = match (&hw).try_into() {
             Ok(hw) => hw,
             Err(err) => {
-                return Ok(FeedEventsGetResponse::BadRequest(format!(
-                    "Invalid resume token '{}'. {}",
-                    hw, err
-                )))
+                return Ok(FeedEventsGetResponse::BadRequest(
+                    models::BadRequestResponse::new(format!(
+                        "Invalid resume token '{}'. {}",
+                        hw, err
+                    )),
+                ))
             }
         };
         let (new_hw, event_ids) = self

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -74,7 +74,7 @@ struct ValidatedInterest {
     /// 'model' typically
     sep: String,
     /// Base36 encoded stream ID
-    model: String,
+    sep_value: String,
     /// DID
     controller: Option<String>,
     /// Base36 encoded stream ID
@@ -89,7 +89,7 @@ impl TryFrom<models::Interest> for ValidatedInterest {
         } else {
             interest.sep
         };
-        let model = convert_base(&interest.model, multibase::Base::Base36Lower)?;
+        let sep_value = convert_base(&interest.sep_value, multibase::Base::Base36Lower)?;
         let controller = interest
             .controller
             .map(|c| {
@@ -106,7 +106,7 @@ impl TryFrom<models::Interest> for ValidatedInterest {
             .transpose()?;
         Ok(ValidatedInterest {
             sep,
-            model,
+            sep_value,
             controller,
             stream_id,
         })
@@ -346,7 +346,7 @@ where
         // Construct start and stop event id based on provided data.
         let (start, stop) = self.build_start_stop_range(
             &interest.sep,
-            &interest.model,
+            &interest.sep_value,
             interest.controller,
             interest.stream_id,
         )?;
@@ -464,7 +464,7 @@ where
     ) -> Result<InterestsSortKeySortValuePostResponse, ApiError> {
         let interest = models::Interest {
             sep: sort_key,
-            model: sort_value,
+            sep_value: sort_value,
             controller,
             stream_id,
         };
@@ -677,7 +677,7 @@ mod tests {
         let server = Server::new(peer_id, network, mock_interest, mock_model);
         let interest = models::Interest {
             sep: "model".to_string(),
-            model: model.to_owned(),
+            sep_value: model.to_owned(),
             controller: None,
             stream_id: None,
         };
@@ -699,7 +699,7 @@ mod tests {
         let server = Server::new(peer_id, network, mock_interest, mock_model);
         let interest = models::Interest {
             sep: "model".to_string(),
-            model: model.to_owned(),
+            sep_value: model.to_owned(),
             controller: None,
             stream_id: None,
         };
@@ -713,7 +713,7 @@ mod tests {
         let peer_id = PeerId::random();
         let network = Network::InMemory;
         let model = "z3KWHw5Efh2qLou2FEdz3wB8ZvLgURJP94HeijLVurxtF1Ntv6fkg2G"; // base58 encoded should work cspell:disable-line
-        // we convert to base36 before storing
+                                                                               // we convert to base36 before storing
         let model_base36 = "k2t6wz4ylx0qr6v7dvbczbxqy7pqjb0879qx930c1e27gacg3r8sllonqt4xx9"; // cspell:disable-line
         let controller = "did:key:zGs1Det7LHNeu7DXT4nvoYrPfj3n6g7d6bj2K4AMXEvg1";
         let start = EventId::builder()


### PR DESCRIPTION
Linear WS1-1519

Creates a new `POST /interests` route that takes a post body. Shares the implementation with the existing `/interests/{separator}/{model}` route. I didn't modify the existing route as there is no way to remove the required path parameters. If we want that, I don't think we should include them in the payload body as required in the ticket. 

Two other things of note:
1. stream values are now required to be multibase encoded and we convert them to base36 before storing the interest.
2. I modified the all the existing routes to use a shared BadRequest object that matches the format of the error object i.e. `{"message": "string"}` body. 

Based on #284 