### PR TITLE
feat: move GET events by interest route under experimental

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:20:12.691788-06:00[America/Denver]
+- Build date: 2024-03-19T15:55:16.016487-06:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:17:26.010196-06:00[America/Denver]
+- Build date: 2024-03-19T10:20:12.691788-06:00[America/Denver]
 
 
 
@@ -64,7 +64,7 @@ To run a client, follow one of the following simple steps:
 ```
 cargo run --example client EventsEventIdGet
 cargo run --example client EventsSortKeySortValueGet
-cargo run --example client ExperimentalEventsSepModelGet
+cargo run --example client ExperimentalEventsSepSepValueGet
 cargo run --example client FeedEventsGet
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
@@ -105,7 +105,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /events/{event_id} | Get event data
 [****](docs/default_api.md#) | **POST** /events | Creates a new event
 [****](docs/default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
-[****](docs/default_api.md#) | **GET** /experimental/events/{sep}/{model} | Get events matching the interest stored on the node
+[****](docs/default_api.md#) | **GET** /experimental/events/{sep}/{sepValue} | Get events matching the interest stored on the node
 [****](docs/default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 [****](docs/default_api.md#) | **POST** /interests | Register interest for a sort key
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.13.0
-- Build date: 2024-03-19T10:14:35.778106-06:00[America/Denver]
+- Build date: 2024-03-19T10:17:26.010196-06:00[America/Denver]
 
 
 
@@ -64,6 +64,7 @@ To run a client, follow one of the following simple steps:
 ```
 cargo run --example client EventsEventIdGet
 cargo run --example client EventsSortKeySortValueGet
+cargo run --example client ExperimentalEventsSepModelGet
 cargo run --example client FeedEventsGet
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
@@ -104,6 +105,7 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **GET** /events/{event_id} | Get event data
 [****](docs/default_api.md#) | **POST** /events | Creates a new event
 [****](docs/default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
+[****](docs/default_api.md#) | **GET** /experimental/events/{sep}/{model} | Get events matching the interest stored on the node
 [****](docs/default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 [****](docs/default_api.md#) | **POST** /interests | Register interest for a sort key
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -173,7 +173,7 @@ paths:
           type: string
         style: simple
       - description: The value of the field in the Events header indicated by the
-          separator key e.g. multibase encoded model ID
+          separator key me.g. multibase encoded model ID
         explode: false
         in: path
         name: sepValue

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -160,8 +160,82 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Register interest for a sort key
+  /experimental/events/{sep}/{model}:
+    get:
+      parameters:
+      - description: name of the separator/sort_key e.g. 'model'
+        explode: false
+        in: path
+        name: sep
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: value associated with the sort key e.g. multibase encoded model
+          ID
+        explode: false
+        in: path
+        name: model
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: the controller to filter (DID string)
+        explode: true
+        in: query
+        name: controller
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: the stream to filter (multibase encoded stream ID)
+        explode: true
+        in: query
+        name: streamId
+        required: false
+        schema:
+          type: string
+        style: form
+      - description: "token that designates the point to resume from, that is find\
+          \ keys added after this point"
+        explode: true
+        in: query
+        name: offset
+        required: false
+        schema:
+          type: integer
+        style: form
+      - description: "the maximum number of events to return, default is 10000."
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          type: integer
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EventsGet'
+          description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get events matching the interest stored on the node
   /events/{sort_key}/{sort_value}:
     get:
+      deprecated: true
       parameters:
       - description: name of the sort_key e.g. 'model'
         explode: false

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -160,10 +160,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Register interest for a sort key
-  /experimental/events/{sep}/{model}:
+  /experimental/events/{sep}/{sepValue}:
     get:
       parameters:
-      - description: name of the separator/sort_key e.g. 'model'
+      - description: Name of the field in the Events header that holds the separator
+          value e.g. 'model'
         explode: false
         in: path
         name: sep
@@ -171,11 +172,11 @@ paths:
         schema:
           type: string
         style: simple
-      - description: value associated with the sort key e.g. multibase encoded model
-          ID
+      - description: The value of the field in the Events header indicated by the
+          separator key e.g. multibase encoded model ID
         explode: false
         in: path
-        name: model
+        name: sepValue
         required: true
         schema:
           type: string

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -7,7 +7,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /events/{event_id} | Get event data
 ****](default_api.md#) | **POST** /events | Creates a new event
 ****](default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
-****](default_api.md#) | **GET** /experimental/events/{sep}/{model} | Get events matching the interest stored on the node
+****](default_api.md#) | **GET** /experimental/events/{sep}/{sepValue} | Get events matching the interest stored on the node
 ****](default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 ****](default_api.md#) | **POST** /interests | Register interest for a sort key
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
@@ -105,15 +105,15 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> models::EventsGet (sep, model, optional)
+> models::EventsGet (sep, sep_value, optional)
 Get events matching the interest stored on the node
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-  **sep** | **String**| name of the separator/sort_key e.g. 'model' | 
-  **model** | **String**| value associated with the sort key e.g. multibase encoded model ID | 
+  **sep** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
+  **sep_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -121,8 +121,8 @@ Optional parameters are passed through a map[string]interface{}.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **sep** | **String**| name of the separator/sort_key e.g. 'model' | 
- **model** | **String**| value associated with the sort key e.g. multibase encoded model ID | 
+ **sep** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
+ **sep_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
  **controller** | **String**| the controller to filter (DID string) | 
  **stream_id** | **String**| the stream to filter (multibase encoded stream ID) | 
  **offset** | **i32**| token that designates the point to resume from, that is find keys added after this point | 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -7,6 +7,7 @@ Method | HTTP request | Description
 ****](default_api.md#) | **GET** /events/{event_id} | Get event data
 ****](default_api.md#) | **POST** /events | Creates a new event
 ****](default_api.md#) | **GET** /events/{sort_key}/{sort_value} | Get events matching the interest stored on the node
+****](default_api.md#) | **GET** /experimental/events/{sep}/{model} | Get events matching the interest stored on the node
 ****](default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
 ****](default_api.md#) | **POST** /interests | Register interest for a sort key
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
@@ -85,6 +86,45 @@ Name | Type | Description  | Notes
  **sort_value** | **String**| value associated with the sort key e.g. model ID | 
  **controller** | **String**| the controller to filter | 
  **stream_id** | **String**| the stream to filter | 
+ **offset** | **i32**| token that designates the point to resume from, that is find keys added after this point | 
+ **limit** | **i32**| the maximum number of events to return, default is 10000. | 
+
+### Return type
+
+[**models::EventsGet**](EventsGet.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::EventsGet (sep, model, optional)
+Get events matching the interest stored on the node
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **sep** | **String**| name of the separator/sort_key e.g. 'model' | 
+  **model** | **String**| value associated with the sort key e.g. multibase encoded model ID | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **sep** | **String**| name of the separator/sort_key e.g. 'model' | 
+ **model** | **String**| value associated with the sort key e.g. multibase encoded model ID | 
+ **controller** | **String**| the controller to filter (DID string) | 
+ **stream_id** | **String**| the stream to filter (multibase encoded stream ID) | 
  **offset** | **i32**| token that designates the point to resume from, that is find keys added after this point | 
  **limit** | **i32**| the maximum number of events to return, default is 10000. | 
 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -113,7 +113,7 @@ Get events matching the interest stored on the node
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **sep** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
-  **sep_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
+  **sep_value** | **String**| The value of the field in the Events header indicated by the separator key me.g. multibase encoded model ID | 
  **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
 
 ### Optional Parameters
@@ -122,7 +122,7 @@ Optional parameters are passed through a map[string]interface{}.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **sep** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
- **sep_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
+ **sep_value** | **String**| The value of the field in the Events header indicated by the separator key me.g. multibase encoded model ID | 
  **controller** | **String**| the controller to filter (DID string) | 
  **stream_id** | **String**| the stream to filter (multibase encoded stream ID) | 
  **offset** | **i32**| token that designates the point to resume from, that is find keys added after this point | 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -3,9 +3,9 @@
 #[allow(unused_imports)]
 use ceramic_api_server::{
     models, Api, ApiNoContext, Client, ContextWrapperExt, EventsEventIdGetResponse,
-    EventsPostResponse, EventsSortKeySortValueGetResponse, ExperimentalEventsSepModelGetResponse,
-    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, VersionPostResponse,
+    EventsPostResponse, EventsSortKeySortValueGetResponse,
+    ExperimentalEventsSepSepValueGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -37,7 +37,7 @@ fn main() {
                 .possible_values(&[
                     "EventsEventIdGet",
                     "EventsSortKeySortValueGet",
-                    "ExperimentalEventsSepModelGet",
+                    "ExperimentalEventsSepSepValueGet",
                     "FeedEventsGet",
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
@@ -128,10 +128,10 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
-        Some("ExperimentalEventsSepModelGet") => {
-            let result = rt.block_on(client.experimental_events_sep_model_get(
+        Some("ExperimentalEventsSepSepValueGet") => {
+            let result = rt.block_on(client.experimental_events_sep_sep_value_get(
                 "sep_example".to_string(),
-                "model_example".to_string(),
+                "sep_value_example".to_string(),
                 Some("controller_example".to_string()),
                 Some("stream_id_example".to_string()),
                 Some(56),

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -3,9 +3,9 @@
 #[allow(unused_imports)]
 use ceramic_api_server::{
     models, Api, ApiNoContext, Client, ContextWrapperExt, EventsEventIdGetResponse,
-    EventsPostResponse, EventsSortKeySortValueGetResponse, FeedEventsGetResponse,
-    InterestsPostResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionPostResponse,
+    EventsPostResponse, EventsSortKeySortValueGetResponse, ExperimentalEventsSepModelGetResponse,
+    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
+    LivenessGetResponse, VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -37,6 +37,7 @@ fn main() {
                 .possible_values(&[
                     "EventsEventIdGet",
                     "EventsSortKeySortValueGet",
+                    "ExperimentalEventsSepModelGet",
                     "FeedEventsGet",
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
@@ -116,6 +117,21 @@ fn main() {
             let result = rt.block_on(client.events_sort_key_sort_value_get(
                 "sort_key_example".to_string(),
                 "sort_value_example".to_string(),
+                Some("controller_example".to_string()),
+                Some("stream_id_example".to_string()),
+                Some(56),
+                Some(56),
+            ));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("ExperimentalEventsSepModelGet") => {
+            let result = rt.block_on(client.experimental_events_sep_model_get(
+                "sep_example".to_string(),
+                "model_example".to_string(),
                 Some("controller_example".to_string()),
                 Some("stream_id_example".to_string()),
                 Some(56),

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -102,8 +102,8 @@ impl<C> Server<C> {
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, VersionPostResponse,
+    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -153,6 +153,21 @@ where
         context: &C,
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
         info!("events_sort_key_sort_value_get(\"{}\", \"{}\", {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", sort_key, sort_value, controller, stream_id, offset, limit, context.get().0.clone());
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Get events matching the interest stored on the node
+    async fn experimental_events_sep_model_get(
+        &self,
+        sep: String,
+        model: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+        info!("experimental_events_sep_model_get(\"{}\", \"{}\", {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", sep, model, controller, stream_id, offset, limit, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
 

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -102,7 +102,7 @@ impl<C> Server<C> {
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, FeedEventsGetResponse, InterestsPostResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 use std::error::Error;
@@ -157,17 +157,17 @@ where
     }
 
     /// Get events matching the interest stored on the node
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
         sep: String,
-        model: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
         context: &C,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
-        info!("experimental_events_sep_model_get(\"{}\", \"{}\", {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", sep, model, controller, stream_id, offset, limit, context.get().0.clone());
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError> {
+        info!("experimental_events_sep_sep_value_get(\"{}\", \"{}\", {:?}, {:?}, {:?}, {:?}) - X-Span-ID: {:?}", sep, sep_value, controller, stream_id, offset, limit, context.get().0.clone());
         Err(ApiError("Generic failure".into()))
     }
 

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -43,8 +43,8 @@ const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, VersionPostResponse,
+    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -731,6 +731,141 @@ where
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
                 Ok(EventsSortKeySortValueGetResponse::InternalServerError(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn experimental_events_sep_model_get(
+        &self,
+        param_sep: String,
+        param_model: String,
+        param_controller: Option<String>,
+        param_stream_id: Option<String>,
+        param_offset: Option<i32>,
+        param_limit: Option<i32>,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/ceramic/experimental/events/{sep}/{model}",
+            self.base_path,
+            sep = utf8_percent_encode(&param_sep.to_string(), ID_ENCODE_SET),
+            model = utf8_percent_encode(&param_model.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            if let Some(param_controller) = param_controller {
+                query_string.append_pair("controller", &param_controller);
+            }
+            if let Some(param_stream_id) = param_stream_id {
+                query_string.append_pair("streamId", &param_stream_id);
+            }
+            if let Some(param_offset) = param_offset {
+                query_string.append_pair("offset", &param_offset.to_string());
+            }
+            if let Some(param_limit) = param_limit {
+                query_string.append_pair("limit", &param_limit.to_string());
+            }
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::EventsGet>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(ExperimentalEventsSepModelGetResponse::Success(body))
+            }
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(ExperimentalEventsSepModelGetResponse::BadRequest(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(ExperimentalEventsSepModelGetResponse::InternalServerError(
+                    body,
+                ))
             }
             code => {
                 let headers = response.headers().clone();

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -43,7 +43,7 @@ const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, FeedEventsGetResponse, InterestsPostResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 
@@ -751,22 +751,22 @@ where
         }
     }
 
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
         param_sep: String,
-        param_model: String,
+        param_sep_value: String,
         param_controller: Option<String>,
         param_stream_id: Option<String>,
         param_offset: Option<i32>,
         param_limit: Option<i32>,
         context: &C,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError> {
         let mut client_service = self.client_service.clone();
         let mut uri = format!(
-            "{}/ceramic/experimental/events/{sep}/{model}",
+            "{}/ceramic/experimental/events/{sep}/{sep_value}",
             self.base_path,
             sep = utf8_percent_encode(&param_sep.to_string(), ID_ENCODE_SET),
-            model = utf8_percent_encode(&param_model.to_string(), ID_ENCODE_SET)
+            sep_value = utf8_percent_encode(&param_sep_value.to_string(), ID_ENCODE_SET)
         );
 
         // Query parameters
@@ -836,7 +836,7 @@ where
                 let body = serde_json::from_str::<models::EventsGet>(body).map_err(|e| {
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
-                Ok(ExperimentalEventsSepModelGetResponse::Success(body))
+                Ok(ExperimentalEventsSepSepValueGetResponse::Success(body))
             }
             400 => {
                 let body = response.into_body();
@@ -850,7 +850,7 @@ where
                     serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
                         ApiError(format!("Response body did not match the schema: {}", e))
                     })?;
-                Ok(ExperimentalEventsSepModelGetResponse::BadRequest(body))
+                Ok(ExperimentalEventsSepSepValueGetResponse::BadRequest(body))
             }
             500 => {
                 let body = response.into_body();
@@ -863,9 +863,7 @@ where
                 let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
                     ApiError(format!("Response body did not match the schema: {}", e))
                 })?;
-                Ok(ExperimentalEventsSepModelGetResponse::InternalServerError(
-                    body,
-                ))
+                Ok(ExperimentalEventsSepSepValueGetResponse::InternalServerError(body))
             }
             code => {
                 let headers = response.headers().clone();

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -57,7 +57,7 @@ pub enum EventsSortKeySortValueGetResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
-pub enum ExperimentalEventsSepModelGetResponse {
+pub enum ExperimentalEventsSepSepValueGetResponse {
     /// success
     Success(models::EventsGet),
     /// bad request
@@ -155,16 +155,16 @@ pub trait Api<C: Send + Sync> {
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
 
     /// Get events matching the interest stored on the node
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
         sep: String,
-        model: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
         context: &C,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError>;
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -230,15 +230,15 @@ pub trait ApiNoContext<C: Send + Sync> {
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
 
     /// Get events matching the interest stored on the node
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
         sep: String,
-        model: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError>;
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -328,19 +328,19 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     }
 
     /// Get events matching the interest stored on the node
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
         sep: String,
-        model: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError> {
         let context = self.context().clone();
         self.api()
-            .experimental_events_sep_model_get(
-                sep, model, controller, stream_id, offset, limit, &context,
+            .experimental_events_sep_sep_value_get(
+                sep, sep_value, controller, stream_id, offset, limit, &context,
             )
             .await
     }

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -57,6 +57,17 @@ pub enum EventsSortKeySortValueGetResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum ExperimentalEventsSepModelGetResponse {
+    /// success
+    Success(models::EventsGet),
+    /// bad request
+    BadRequest(models::BadRequestResponse),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum FeedEventsGetResponse {
     /// success
     Success(models::EventFeed),
@@ -143,6 +154,18 @@ pub trait Api<C: Send + Sync> {
         context: &C,
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
 
+    /// Get events matching the interest stored on the node
+    async fn experimental_events_sep_model_get(
+        &self,
+        sep: String,
+        model: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError>;
+
     /// Get all new event keys since resume token
     async fn feed_events_get(
         &self,
@@ -205,6 +228,17 @@ pub trait ApiNoContext<C: Send + Sync> {
         offset: Option<i32>,
         limit: Option<i32>,
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError>;
+
+    /// Get events matching the interest stored on the node
+    async fn experimental_events_sep_model_get(
+        &self,
+        sep: String,
+        model: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -289,6 +323,24 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api()
             .events_sort_key_sort_value_get(
                 sort_key, sort_value, controller, stream_id, offset, limit, &context,
+            )
+            .await
+    }
+
+    /// Get events matching the interest stored on the node
+    async fn experimental_events_sep_model_get(
+        &self,
+        sep: String,
+        model: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api()
+            .experimental_events_sep_model_get(
+                sep, model, controller, stream_id, offset, limit, &context,
             )
             .await
     }

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -23,8 +23,8 @@ type ServiceFuture = BoxFuture<'static, Result<Response<Body>, crate::ServiceErr
 
 use crate::{
     Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, VersionPostResponse,
+    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 
 mod paths {
@@ -35,6 +35,7 @@ mod paths {
             r"^/ceramic/events$",
             r"^/ceramic/events/(?P<event_id>[^/?#]*)$",
             r"^/ceramic/events/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
+            r"^/ceramic/experimental/events/(?P<sep>[^/?#]*)/(?P<model>[^/?#]*)$",
             r"^/ceramic/feed/events$",
             r"^/ceramic/interests$",
             r"^/ceramic/interests/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$",
@@ -58,9 +59,18 @@ mod paths {
             regex::Regex::new(r"^/ceramic/events/(?P<sort_key>[^/?#]*)/(?P<sort_value>[^/?#]*)$")
                 .expect("Unable to create regex for EVENTS_SORT_KEY_SORT_VALUE");
     }
-    pub(crate) static ID_FEED_EVENTS: usize = 3;
-    pub(crate) static ID_INTERESTS: usize = 4;
-    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 5;
+    pub(crate) static ID_EXPERIMENTAL_EVENTS_SEP_MODEL: usize = 3;
+    lazy_static! {
+        pub static ref REGEX_EXPERIMENTAL_EVENTS_SEP_MODEL: regex::Regex =
+            #[allow(clippy::invalid_regex)]
+            regex::Regex::new(
+                r"^/ceramic/experimental/events/(?P<sep>[^/?#]*)/(?P<model>[^/?#]*)$"
+            )
+            .expect("Unable to create regex for EXPERIMENTAL_EVENTS_SEP_MODEL");
+    }
+    pub(crate) static ID_FEED_EVENTS: usize = 4;
+    pub(crate) static ID_INTERESTS: usize = 5;
+    pub(crate) static ID_INTERESTS_SORT_KEY_SORT_VALUE: usize = 6;
     lazy_static! {
         pub static ref REGEX_INTERESTS_SORT_KEY_SORT_VALUE: regex::Regex =
             #[allow(clippy::invalid_regex)]
@@ -69,8 +79,8 @@ mod paths {
             )
             .expect("Unable to create regex for INTERESTS_SORT_KEY_SORT_VALUE");
     }
-    pub(crate) static ID_LIVENESS: usize = 6;
-    pub(crate) static ID_VERSION: usize = 7;
+    pub(crate) static ID_LIVENESS: usize = 7;
+    pub(crate) static ID_VERSION: usize = 8;
 }
 
 pub struct MakeService<T, C>
@@ -552,6 +562,195 @@ where
                     Ok(response)
                 }
 
+                // ExperimentalEventsSepModelGet - GET /experimental/events/{sep}/{model}
+                hyper::Method::GET if path.matched(paths::ID_EXPERIMENTAL_EVENTS_SEP_MODEL) => {
+                    // Path parameters
+                    let path: &str = uri.path();
+                    let path_params =
+                    paths::REGEX_EXPERIMENTAL_EVENTS_SEP_MODEL
+                    .captures(path)
+                    .unwrap_or_else(||
+                        panic!("Path {} matched RE EXPERIMENTAL_EVENTS_SEP_MODEL in set but failed match against \"{}\"", path, paths::REGEX_EXPERIMENTAL_EVENTS_SEP_MODEL.as_str())
+                    );
+
+                    let param_sep = match percent_encoding::percent_decode(path_params["sep"].as_bytes()).decode_utf8() {
+                    Ok(param_sep) => match param_sep.parse::<String>() {
+                        Ok(param_sep) => param_sep,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter sep: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["sep"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                    let param_model = match percent_encoding::percent_decode(path_params["model"].as_bytes()).decode_utf8() {
+                    Ok(param_model) => match param_model.parse::<String>() {
+                        Ok(param_model) => param_model,
+                        Err(e) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't parse path parameter model: {}", e)))
+                                        .expect("Unable to create Bad Request response for invalid path parameter")),
+                    },
+                    Err(_) => return Ok(Response::builder()
+                                        .status(StatusCode::BAD_REQUEST)
+                                        .body(Body::from(format!("Couldn't percent-decode path parameter as UTF-8: {}", &path_params["model"])))
+                                        .expect("Unable to create Bad Request response for invalid percent decode"))
+                };
+
+                    // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
+                    let query_params =
+                        form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+                            .collect::<Vec<_>>();
+                    let param_controller = query_params
+                        .iter()
+                        .filter(|e| e.0 == "controller")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_controller = match param_controller {
+                        Some(param_controller) => {
+                            let param_controller =
+                                <String as std::str::FromStr>::from_str(&param_controller);
+                            match param_controller {
+                            Ok(param_controller) => Some(param_controller),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter controller - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter controller")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_stream_id = query_params
+                        .iter()
+                        .filter(|e| e.0 == "streamId")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_stream_id = match param_stream_id {
+                        Some(param_stream_id) => {
+                            let param_stream_id =
+                                <String as std::str::FromStr>::from_str(&param_stream_id);
+                            match param_stream_id {
+                            Ok(param_stream_id) => Some(param_stream_id),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter streamId - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter streamId")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_offset = query_params
+                        .iter()
+                        .filter(|e| e.0 == "offset")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_offset = match param_offset {
+                        Some(param_offset) => {
+                            let param_offset = <i32 as std::str::FromStr>::from_str(&param_offset);
+                            match param_offset {
+                            Ok(param_offset) => Some(param_offset),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter offset - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter offset")),
+                        }
+                        }
+                        None => None,
+                    };
+                    let param_limit = query_params
+                        .iter()
+                        .filter(|e| e.0 == "limit")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_limit = match param_limit {
+                        Some(param_limit) => {
+                            let param_limit = <i32 as std::str::FromStr>::from_str(&param_limit);
+                            match param_limit {
+                            Ok(param_limit) => Some(param_limit),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter limit - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter limit")),
+                        }
+                        }
+                        None => None,
+                    };
+
+                    let result = api_impl
+                        .experimental_events_sep_model_get(
+                            param_sep,
+                            param_model,
+                            param_controller,
+                            param_stream_id,
+                            param_offset,
+                            param_limit,
+                            &context,
+                        )
+                        .await;
+                    let mut response = Response::new(Body::empty());
+                    response.headers_mut().insert(
+                        HeaderName::from_static("x-span-id"),
+                        HeaderValue::from_str(
+                            (&context as &dyn Has<XSpanIdString>)
+                                .get()
+                                .0
+                                .clone()
+                                .as_str(),
+                        )
+                        .expect("Unable to create X-Span-ID header value"),
+                    );
+
+                    match result {
+                        Ok(rsp) => match rsp {
+                            ExperimentalEventsSepModelGetResponse::Success(body) => {
+                                *response.status_mut() = StatusCode::from_u16(200)
+                                    .expect("Unable to turn 200 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EXPERIMENTAL_EVENTS_SEP_MODEL_GET_SUCCESS"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                            ExperimentalEventsSepModelGetResponse::BadRequest(body) => {
+                                *response.status_mut() = StatusCode::from_u16(400)
+                                    .expect("Unable to turn 400 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EXPERIMENTAL_EVENTS_SEP_MODEL_GET_BAD_REQUEST"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                            ExperimentalEventsSepModelGetResponse::InternalServerError(body) => {
+                                *response.status_mut() = StatusCode::from_u16(500)
+                                    .expect("Unable to turn 500 into a StatusCode");
+                                response.headers_mut().insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_str("application/json")
+                                                            .expect("Unable to create Content-Type header for EXPERIMENTAL_EVENTS_SEP_MODEL_GET_INTERNAL_SERVER_ERROR"));
+                                let body_content = serde_json::to_string(&body)
+                                    .expect("impossible to fail to serialize");
+                                *response.body_mut() = Body::from(body_content);
+                            }
+                        },
+                        Err(_) => {
+                            // Application code returned an error. This should not happen, as the implementation should
+                            // return a valid response.
+                            *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+                            *response.body_mut() = Body::from("An internal error occurred");
+                        }
+                    }
+
+                    Ok(response)
+                }
+
                 // FeedEventsGet - GET /feed/events
                 hyper::Method::GET if path.matched(paths::ID_FEED_EVENTS) => {
                     // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
@@ -998,6 +1197,7 @@ where
                 _ if path.matched(paths::ID_EVENTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_EVENTS_EVENT_ID) => method_not_allowed(),
                 _ if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
+                _ if path.matched(paths::ID_EXPERIMENTAL_EVENTS_SEP_MODEL) => method_not_allowed(),
                 _ if path.matched(paths::ID_FEED_EVENTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_INTERESTS) => method_not_allowed(),
                 _ if path.matched(paths::ID_INTERESTS_SORT_KEY_SORT_VALUE) => method_not_allowed(),
@@ -1028,6 +1228,10 @@ impl<T> RequestParser<T> for ApiRequestParser {
             // EventsSortKeySortValueGet - GET /events/{sort_key}/{sort_value}
             hyper::Method::GET if path.matched(paths::ID_EVENTS_SORT_KEY_SORT_VALUE) => {
                 Some("EventsSortKeySortValueGet")
+            }
+            // ExperimentalEventsSepModelGet - GET /experimental/events/{sep}/{model}
+            hyper::Method::GET if path.matched(paths::ID_EXPERIMENTAL_EVENTS_SEP_MODEL) => {
+                Some("ExperimentalEventsSepModelGet")
             }
             // FeedEventsGet - GET /feed/events
             hyper::Method::GET if path.matched(paths::ID_FEED_EVENTS) => Some("FeedEventsGet"),

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -155,19 +155,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  "/experimental/events/{sep}/{model}":
+  "/experimental/events/{sep}/{sepValue}":
     get:
       summary: Get events matching the interest stored on the node
       parameters:
         - name: sep
           in: path
-          description: name of the separator/sort_key e.g. 'model'
+          description: Name of the field in the Events header that holds the separator value e.g. 'model'
           schema:
             type: string
           required: true
-        - name: model
+        - name: sepValue
           in: path
-          description: value associated with the sort key e.g. multibase encoded model ID
+          description: The value of the field in the Events header indicated by the separator key me.g. multibase encoded model ID
           schema:
             type: string
           required: true

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -155,9 +155,69 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  "/experimental/events/{sep}/{model}":
+    get:
+      summary: Get events matching the interest stored on the node
+      parameters:
+        - name: sep
+          in: path
+          description: name of the separator/sort_key e.g. 'model'
+          schema:
+            type: string
+          required: true
+        - name: model
+          in: path
+          description: value associated with the sort key e.g. multibase encoded model ID
+          schema:
+            type: string
+          required: true
+        - name: controller
+          in: query
+          description: the controller to filter (DID string)
+          required: false
+          schema:
+            type: string
+        - name: streamId
+          in: query
+          description: the stream to filter (multibase encoded stream ID)
+          required: false
+          schema:
+            type: string
+        - name: offset
+          in: query
+          description: token that designates the point to resume from, that is find keys added after this point
+          schema:
+            type: integer
+          required: false
+        - name: limit
+          in: query
+          description: the maximum number of events to return, default is 10000.
+          required: false
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventsGet"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   "/events/{sort_key}/{sort_value}":
     get:
       summary: Get events matching the interest stored on the node
+      deprecated: true
       parameters:
         - name: sort_key
           in: path

--- a/api/src/metrics/api.rs
+++ b/api/src/metrics/api.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use ceramic_api_server::{
     models, Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, FeedEventsGetResponse, InterestsPostResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 use ceramic_metrics::Recorder;
@@ -74,20 +74,20 @@ where
     }
 
     /// Get events for a stream
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
-        sort_key: String,
-        sort_value: String,
+        sep: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
         context: &C,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError> {
         self.record(
             "/experimental/events",
-            self.api.experimental_events_sep_model_get(
-                sort_key, sort_value, controller, stream_id, offset, limit, context,
+            self.api.experimental_events_sep_sep_value_get(
+                sep, sep_value, controller, stream_id, offset, limit, context,
             ),
         )
         .await

--- a/api/src/metrics/api.rs
+++ b/api/src/metrics/api.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use ceramic_api_server::{
     models, Api, EventsEventIdGetResponse, EventsPostResponse, EventsSortKeySortValueGetResponse,
-    FeedEventsGetResponse, InterestsPostResponse, InterestsSortKeySortValuePostResponse,
-    LivenessGetResponse, VersionPostResponse,
+    ExperimentalEventsSepModelGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionPostResponse,
 };
 use ceramic_metrics::Recorder;
 use futures::Future;
@@ -69,6 +69,26 @@ where
             "/feed/events",
             self.api
                 .feed_events_get(param_resume_at, param_limit, context),
+        )
+        .await
+    }
+
+    /// Get events for a stream
+    async fn experimental_events_sep_model_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+        self.record(
+            "/experimental/events",
+            self.api.experimental_events_sep_model_get(
+                sort_key, sort_value, controller, stream_id, offset, limit, context,
+            ),
         )
         .await
     }

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -33,7 +33,8 @@ use ceramic_api_server::{
     LivenessGetResponse, VersionPostResponse,
 };
 use ceramic_api_server::{
-    Api, EventsSortKeySortValueGetResponse, FeedEventsGetResponse, InterestsPostResponse,
+    Api, EventsSortKeySortValueGetResponse, ExperimentalEventsSepModelGetResponse,
+    FeedEventsGetResponse, InterestsPostResponse,
 };
 use ceramic_core::{interest, EventId, Interest, Network, PeerId, StreamId};
 use std::error::Error;
@@ -221,10 +222,11 @@ where
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
-    ) -> Result<EventsSortKeySortValueGetResponse, ErrorResponse> {
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ErrorResponse> {
         let limit: usize =
             limit.map_or(10000, |l| if l.is_negative() { 10000 } else { l }) as usize;
         let offset = offset.map_or(0, |o| if o.is_negative() { 0 } else { o }) as usize;
+        // Should we validate that sort_value and stream_id are base36 encoded or just rely on input directly?
         let (start, stop) =
             self.build_start_stop_range(&sort_key, &sort_value, controller, stream_id)?;
 
@@ -238,7 +240,7 @@ where
             .collect::<Vec<_>>();
 
         let event_cnt = events.len();
-        Ok(EventsSortKeySortValueGetResponse::Success(
+        Ok(ExperimentalEventsSepModelGetResponse::Success(
             models::EventsGet {
                 resume_offset: (offset + event_cnt) as i32,
                 events,
@@ -415,6 +417,28 @@ where
     }
 
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
+    async fn experimental_events_sep_model_get(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        controller: Option<String>,
+        stream_id: Option<String>,
+        offset: Option<i32>,
+        limit: Option<i32>,
+        _context: &C,
+    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
+        self.get_events_sort_key_sort_value(
+            sort_key, sort_value, controller, stream_id, offset, limit,
+        )
+        .await
+        .or_else(|err| {
+            Ok(ExperimentalEventsSepModelGetResponse::InternalServerError(
+                err,
+            ))
+        })
+    }
+
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn events_sort_key_sort_value_get(
         &self,
         sort_key: String,
@@ -425,11 +449,25 @@ where
         limit: Option<i32>,
         _context: &C,
     ) -> Result<EventsSortKeySortValueGetResponse, ApiError> {
-        self.get_events_sort_key_sort_value(
-            sort_key, sort_value, controller, stream_id, offset, limit,
-        )
-        .await
-        .or_else(|err| Ok(EventsSortKeySortValueGetResponse::InternalServerError(err)))
+        match self
+            .get_events_sort_key_sort_value(
+                sort_key, sort_value, controller, stream_id, offset, limit,
+            )
+            .await
+        {
+            Ok(v) => match v {
+                ExperimentalEventsSepModelGetResponse::Success(s) => {
+                    Ok(EventsSortKeySortValueGetResponse::Success(s))
+                }
+                ExperimentalEventsSepModelGetResponse::BadRequest(r) => {
+                    Ok(EventsSortKeySortValueGetResponse::BadRequest(r))
+                }
+                ExperimentalEventsSepModelGetResponse::InternalServerError(err) => {
+                    Ok(EventsSortKeySortValueGetResponse::InternalServerError(err))
+                }
+            },
+            Err(err) => Ok(EventsSortKeySortValueGetResponse::InternalServerError(err)),
+        }
     }
 
     #[instrument(skip(self, _context, event), fields(event.id = event.id, event.data.len = event.data.len()), ret(level = Level::DEBUG), err(level = Level::ERROR))]

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -33,7 +33,7 @@ use ceramic_api_server::{
     LivenessGetResponse, VersionPostResponse,
 };
 use ceramic_api_server::{
-    Api, EventsSortKeySortValueGetResponse, ExperimentalEventsSepModelGetResponse,
+    Api, EventsSortKeySortValueGetResponse, ExperimentalEventsSepSepValueGetResponse,
     FeedEventsGetResponse, InterestsPostResponse,
 };
 use ceramic_core::{interest, EventId, Interest, Network, PeerId, StreamId};
@@ -222,7 +222,7 @@ where
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ErrorResponse> {
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ErrorResponse> {
         let limit: usize =
             limit.map_or(10000, |l| if l.is_negative() { 10000 } else { l }) as usize;
         let offset = offset.map_or(0, |o| if o.is_negative() { 0 } else { o }) as usize;
@@ -240,7 +240,7 @@ where
             .collect::<Vec<_>>();
 
         let event_cnt = events.len();
-        Ok(ExperimentalEventsSepModelGetResponse::Success(
+        Ok(ExperimentalEventsSepSepValueGetResponse::Success(
             models::EventsGet {
                 resume_offset: (offset + event_cnt) as i32,
                 events,
@@ -417,25 +417,19 @@ where
     }
 
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
-    async fn experimental_events_sep_model_get(
+    async fn experimental_events_sep_sep_value_get(
         &self,
-        sort_key: String,
-        sort_value: String,
+        sep: String,
+        sep_value: String,
         controller: Option<String>,
         stream_id: Option<String>,
         offset: Option<i32>,
         limit: Option<i32>,
         _context: &C,
-    ) -> Result<ExperimentalEventsSepModelGetResponse, ApiError> {
-        self.get_events_sort_key_sort_value(
-            sort_key, sort_value, controller, stream_id, offset, limit,
-        )
-        .await
-        .or_else(|err| {
-            Ok(ExperimentalEventsSepModelGetResponse::InternalServerError(
-                err,
-            ))
-        })
+    ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError> {
+        self.get_events_sort_key_sort_value(sep, sep_value, controller, stream_id, offset, limit)
+            .await
+            .or_else(|err| Ok(ExperimentalEventsSepSepValueGetResponse::InternalServerError(err)))
     }
 
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
@@ -456,13 +450,13 @@ where
             .await
         {
             Ok(v) => match v {
-                ExperimentalEventsSepModelGetResponse::Success(s) => {
+                ExperimentalEventsSepSepValueGetResponse::Success(s) => {
                     Ok(EventsSortKeySortValueGetResponse::Success(s))
                 }
-                ExperimentalEventsSepModelGetResponse::BadRequest(r) => {
+                ExperimentalEventsSepSepValueGetResponse::BadRequest(r) => {
                     Ok(EventsSortKeySortValueGetResponse::BadRequest(r))
                 }
-                ExperimentalEventsSepModelGetResponse::InternalServerError(err) => {
+                ExperimentalEventsSepSepValueGetResponse::InternalServerError(err) => {
                     Ok(EventsSortKeySortValueGetResponse::InternalServerError(err))
                 }
             },


### PR DESCRIPTION
Linear ticket WS1-1522. 

Created a new GET /experimental/events/{sep}/{model} route to query events by an interest filter. The old route still exists (marked deprecated) until the tests are updated and then it can be deleted.

Targets #285 which targets #284 