### PR TITLE
docs: added explicit deps to build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ Use the provided `Makefile` for basic actions to ensure your changes are ready f
     $ make check-fmt
     $ make test
 
-Using the makefile is not necessary during your development cycle, feel free to use the relevant cargo commands directly.
+Using the makefile is not necessary during your development cycle, feel free to use the relevant cargo commands directly, in which case you'll likely need openssl's dev files, the protocol buffer compiler and a c dev environment; on a clean slate Ubuntu:
+
+    $ apt install make protobuf-compiler clang libssl-dev
+
 However running `make` before publishing a PR will provide a good signal if you PR will pass CI.
 
 ### Generating Servers


### PR DESCRIPTION
Minor doc update for shiny new computer setups wanting to compile using `cargo run`.