### PR TITLE
fix: use TAG_LATEST

### DIFF
--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -47,12 +47,12 @@ jobs:
           DEPLOY_TAG=$RELEASE_TAG
         fi
         # Tag with latest if this is a release (not pre-release)
-        if [[ "${{ github.event.action }}" == "published" && "${{ github.event.release.prerelease }}" == "true" ]]; then
-          TAG_LATEST=false
-        elif [[ "${{ github.event.action }}" == "released" ]]; then
+        if [[ "${{ github.event_name }}" == "push" ]]; then
           TAG_LATEST=true
+        elif
+          TAG_LATEST=false
         fi
-        make SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" publish-docker
+        make SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
         echo "Deploy tag:"
         echo ${DEPLOY_TAG}
         echo "deploy_tag=${DEPLOY_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -46,7 +46,7 @@ jobs:
           # Use the release tag to deploy, if one is available.
           DEPLOY_TAG=$RELEASE_TAG
         fi
-        # Tag with latest if this is a release (not pre-release)
+        # Tag with latest if this is a push to master
         if [[ "${{ github.event_name }}" == "push" ]]; then
           TAG_LATEST=true
         elif

--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -46,6 +46,12 @@ jobs:
           # Use the release tag to deploy, if one is available.
           DEPLOY_TAG=$RELEASE_TAG
         fi
+        # Tag with latest if this is a release (not pre-release)
+        if [[ "${{ github.event.action }}" == "published" && "${{ github.event.release.prerelease }}" == "true" ]]; then
+          TAG_LATEST=false
+        elif [[ "${{ github.event.action }}" == "released" ]]; then
+          TAG_LATEST=true
+        fi
         make SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" publish-docker
         echo "Deploy tag:"
         echo ${DEPLOY_TAG}
@@ -73,7 +79,7 @@ jobs:
             # "prerelease" flag.
             #
             # Strangely enough, the "edited" and "released" events are triggered when promoting the pre-release to a
-            # release through the GitHub console (╯°□°)╯︵ ┻━┻ 
+            # release through the GitHub console (╯°□°)╯︵ ┻━┻
             if [[ "${{ github.event.action }}" == "published" && "${{ github.event.release.prerelease }}" == "true" ]]; then
               DEPLOY_ENV="tnet"
             elif [[ "${{ github.event.action }}" == "released" ]]; then

--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -97,13 +97,7 @@ jobs:
         else
           BUILD_TAG=$(echo ${{ github.sha }} | head -c 12)
         fi
-        # Tag with latest if merge to main
-        if [ "${{ github.event_name }}" == "merge_group" ]; then
-          TAG_LATEST=true
-        else
-          TAG_LATEST=false
-        fi
-        make SHA_TAG="$BUILD_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
+        make SHA_TAG="$BUILD_TAG" TAG_LATEST="false" publish-docker
         echo "Build tag:"
         echo ${BUILD_TAG}
         echo "build_tag=${BUILD_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -97,7 +97,13 @@ jobs:
         else
           BUILD_TAG=$(echo ${{ github.sha }} | head -c 12)
         fi
-        make SHA_TAG="$BUILD_TAG" publish-docker
+        # Tag with latest if merge to main
+        if [ "${{ github.event_name }}" == "merge_group" ]; then
+          TAG_LATEST=true
+        else
+          TAG_LATEST=false
+        fi
+        make SHA_TAG="$BUILD_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
         echo "Build tag:"
         echo ${BUILD_TAG}
         echo "build_tag=${BUILD_TAG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/rust-build-and-test.yml
+++ b/.github/workflows/rust-build-and-test.yml
@@ -97,13 +97,7 @@ jobs:
         else
           BUILD_TAG=$(echo ${{ github.sha }} | head -c 12)
         fi
-        # Tag with latest if merge to main
-        if [ "${{ github.event_name }}" == "merge_group" ]; then
-          TAG_LATEST=true
-        else
-          TAG_LATEST=false
-        fi
-        make SHA_TAG="$BUILD_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
+        make SHA_TAG="$BUILD_TAG" publish-docker
         echo "Build tag:"
         echo ${BUILD_TAG}
         echo "build_tag=${BUILD_TAG}" >> $GITHUB_OUTPUT

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -20,8 +20,6 @@ if [[ -n "$SHA_TAG" ]]; then
 fi
 if [[ -n "$RELEASE_TAG" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:"$RELEASE_TAG"
-fi
-if [[ "$TAG_LATEST" == "true" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
 fi
 

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -11,7 +11,6 @@
 # to login to docker. That password will be valid for 12h.
 
 docker buildx build --load -t 3box/ceramic-one .
-docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
 
 if [[ -n "$SHA" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:"$SHA"
@@ -21,6 +20,9 @@ if [[ -n "$SHA_TAG" ]]; then
 fi
 if [[ -n "$RELEASE_TAG" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:"$RELEASE_TAG"
+fi
+if [[ "$TAG_LATEST" == "true" ]]; then
+  docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
 fi
 
 docker push -a public.ecr.aws/r5b3e0r5/3box/ceramic-one

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -20,6 +20,8 @@ if [[ -n "$SHA_TAG" ]]; then
 fi
 if [[ -n "$RELEASE_TAG" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:"$RELEASE_TAG"
+fi
+if [[ "$TAG_LATEST" == "true" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:latest
 fi
 


### PR DESCRIPTION
Only tag the workflow docker image with "latest" when it's a merge to main.

Currently we're getting branches tagged with latest.