### PR TITLE
chore: version v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2024-03-26
+
+### 🚀 Features
+
+- Standard 500 error response body (ws1-1518) (#284)
+- Add POST interests route that accepts body instead of path/query parameters (#285)
+- Move GET events by interest route under experimental (#286)
+
+### 🐛 Bug Fixes
+
+- Moved api tests to a separate file (#268)
+
+### 📚 Documentation
+
+- Added explicit deps to build steps (#291)
+
 ## [0.13.0] - 2024-03-19
 
 ### 🚀 Features
@@ -18,6 +34,7 @@ All notable changes to this project will be documented in this file.
 - Delete subscribe endpoint (#277)
 - Only lint single commit or PR title (#279)
 - Remove support for old event payload during creation (#272)
+- Version v0.13.0 (#290)
 
 ## [0.12.0] - 2024-02-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "ceramic-core",
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1216,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "built",
  "project-root",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1287,7 +1287,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.7",
  "anyhow",
@@ -1330,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "ahash 0.8.7",
  "anyhow",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cid 0.10.1",
  "futures",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "bytes 1.5.0",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "cid 0.10.1",
  "nix 0.26.4",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ xtaskops = "0.3"
 zeroize = "1.4"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.10.0
-- Build date: 2024-02-08T18:22:18.284762+05:30[Asia/Kolkata]
+- API version: 0.14.0
+- Build date: 2024-03-26T12:19:16.201436-06:00[America/Denver]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.13.0
+  version: 0.14.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.13.0";
+pub const API_VERSION: &str = "0.14.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.13.0
+  version: 0.14.0
   title: Ceramic API
     #license:
     #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.13.0
-- Build date: 2024-03-19T14:39:15.565667669Z[Etc/UTC]
+- API version: 0.14.0
+- Build date: 2024-03-26T12:19:17.274907-06:00[America/Denver]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.13.0
+  version: 0.14.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.13.0";
+pub const API_VERSION: &str = "0.14.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.13.0
+  version: 0.14.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.14.0] - 2024-03-26

### 🚀 Features

- Standard 500 error response body (ws1-1518) (#284)
- Add POST interests route that accepts body instead of path/query parameters (#285)
- Move GET events by interest route under experimental (#286)

### 🐛 Bug Fixes

- Moved api tests to a separate file (#268)

### 📚 Documentation

- Added explicit deps to build steps (#291)