### PR TITLE
feat: don't mark peers failed when we error during sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6647,6 +6647,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "uuid 1.8.0",
  "void",
 ]
 
@@ -8260,7 +8261,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -9111,6 +9112,15 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.12",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+dependencies = [
+ "getrandom 0.2.12",
 ]
 
 [[package]]

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -24,6 +24,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+uuid = { version = "1.8.0", features = ["v4"] }
 void.workspace = true
 
 [dev-dependencies]

--- a/recon/src/libp2p.rs
+++ b/recon/src/libp2p.rs
@@ -198,6 +198,10 @@ where
                         status: info.status,
                     })));
             }),
+            //We had an internal error during synchronization, for now we will just log the error
+            FromHandler::TransientError(error) => self.peers.entry(peer_id).and_modify(|info| {
+                warn!(%peer_id, %error, status=?info.status, "transient internal failure to synchronization with peer");
+            }),
 
             // The peer has failed to synchronized with us, mark the time and record that the peer connection
             // is now failed.

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -201,7 +201,8 @@ where
                         }
                         Err(e) => {
                             // TODO: differentiate between transient and permanent errors
-                            // for now, we don't want to try to keep talking so we treat all errors as transient
+                            // for now, we want to keep talking so we treat all errors as transient
+                            // but in the future, we will want to shut down the connection if the error is permanent
                             return Poll::Ready(ConnectionHandlerEvent::NotifyBehaviour(
                                 FromHandler::TransientError(e),
                             ));

--- a/recon/src/metrics.rs
+++ b/recon/src/metrics.rs
@@ -12,7 +12,7 @@ use prometheus_client::{
 };
 
 use crate::{
-    protocol::{InitiatorMessage, ResponderMessage},
+    protocol::{InitiatorMessage, ReconMessage, ResponderMessage},
     AssociativeHash, Key,
 };
 
@@ -36,12 +36,12 @@ pub struct Metrics {
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
 pub(crate) struct MessageLabels {
-    message_type: &'static str,
+    pub(crate) message_type: &'static str,
 }
 
-impl<K: Key, H: AssociativeHash> From<&InitiatorMessage<K, H>> for MessageLabels {
-    fn from(value: &InitiatorMessage<K, H>) -> Self {
-        match value {
+impl<K: Key, H: AssociativeHash> From<&ReconMessage<InitiatorMessage<K, H>>> for MessageLabels {
+    fn from(value: &ReconMessage<InitiatorMessage<K, H>>) -> Self {
+        match value.body {
             InitiatorMessage::ValueRequest(_) => Self {
                 message_type: "ValueRequest",
             },
@@ -64,9 +64,9 @@ impl<K: Key, H: AssociativeHash> From<&InitiatorMessage<K, H>> for MessageLabels
     }
 }
 
-impl<K: Key, H: AssociativeHash> From<&ResponderMessage<K, H>> for MessageLabels {
-    fn from(value: &ResponderMessage<K, H>) -> Self {
-        match value {
+impl<K: Key, H: AssociativeHash> From<&ReconMessage<ResponderMessage<K, H>>> for MessageLabels {
+    fn from(value: &ReconMessage<ResponderMessage<K, H>>) -> Self {
+        match value.body {
             ResponderMessage::ValueRequest(_) => Self {
                 message_type: "ValueRequest",
             },

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -38,6 +38,7 @@ use expect_test::{expect, Expect};
 use lalrpop_util::ParseError;
 use pretty::{Arena, DocAllocator, DocBuilder, Pretty};
 
+use crate::protocol::ReconMessage;
 use crate::{
     protocol::{self, InitiatorMessage, ResponderMessage, ValueResponse},
     recon::{FullInterests, HashCount, InterestProvider, Range, ReconItem},
@@ -576,8 +577,8 @@ async fn word_lists() {
         local: Client<AlphaNumBytes, Sha256a>,
         remote: Client<AlphaNumBytes, Sha256a>,
     ) {
-        type InitiatorEnv = InitiatorMessage<AlphaNumBytes, Sha256a>;
-        type ResponderEnv = ResponderMessage<AlphaNumBytes, Sha256a>;
+        type InitiatorEnv = ReconMessage<InitiatorMessage<AlphaNumBytes, Sha256a>>;
+        type ResponderEnv = ReconMessage<ResponderMessage<AlphaNumBytes, Sha256a>>;
 
         let (local_channel, remote_channel): (
             DuplexChannel<InitiatorEnv, ResponderEnv>,
@@ -1190,8 +1191,8 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
         SequenceStep<AlphaNumBytes, MemoryAHash>,
     >::new()));
 
-    type InitiatorEnv = InitiatorMessage<AlphaNumBytes, MemoryAHash>;
-    type ResponderEnv = ResponderMessage<AlphaNumBytes, MemoryAHash>;
+    type InitiatorEnv = ReconMessage<InitiatorMessage<AlphaNumBytes, MemoryAHash>>;
+    type ResponderEnv = ReconMessage<ResponderMessage<AlphaNumBytes, MemoryAHash>>;
 
     let (cat_channel, dog_channel): (
         DuplexChannel<InitiatorEnv, ResponderEnv>,
@@ -1208,7 +1209,7 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
             async move {
                 let state = snapshot_state(dog).await.unwrap();
                 steps.lock().unwrap().push(SequenceStep {
-                    message: Message::DogToCat(message.as_ref().unwrap().clone()),
+                    message: Message::DogToCat(message.as_ref().unwrap().body.clone()),
                     state,
                 });
                 message
@@ -1224,7 +1225,7 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
             async move {
                 let state = snapshot_state(cat).await.unwrap();
                 steps.lock().unwrap().push(SequenceStep {
-                    message: Message::CatToDog(message.as_ref().unwrap().clone()),
+                    message: Message::CatToDog(message.as_ref().unwrap().body.clone()),
                     state,
                 });
                 message


### PR DESCRIPTION
We have a "transient" error type (for now) to indicate that we had an internal failure during sync and should retry, rather than mark the peer as failed, which terminates the conversation.

This also incorporates the sync_id changes in #304.