### PR TITLE
chore: remove mut from store traits

### DIFF
--- a/beetle/iroh-bitswap/src/peer_task_queue/peer_tracker.rs
+++ b/beetle/iroh-bitswap/src/peer_task_queue/peer_tracker.rs
@@ -555,7 +555,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -566,7 +567,8 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            }];
+            },
+        ];
 
         // push task "a"
         tracker.push_tasks(vec![tasks[0].clone()]); // Topic 1
@@ -633,7 +635,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -644,7 +647,8 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            }];
+            },
+        ];
 
         // push task "a"
         tracker.push_tasks(vec![tasks[0].clone()]); // Topic 1
@@ -667,7 +671,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -684,7 +689,8 @@ mod tests {
                 priority: 5,
                 work: 5,
                 data: "c",
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         // same topic, should replace "a" and update work from 10 to 20
@@ -711,7 +717,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -722,7 +729,8 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         // make "a" active
@@ -756,7 +764,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -767,7 +776,8 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -788,7 +798,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -805,7 +816,8 @@ mod tests {
                 priority: 10,
                 work: 10,
                 data: "c",
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -831,7 +843,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -848,7 +861,8 @@ mod tests {
                 priority: 15,
                 work: 10,
                 data: "c",
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -874,7 +888,8 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = [Task {
+        let tasks = [
+            Task {
                 topic: 1,
                 priority: 10,
                 work: 1,
@@ -891,7 +906,8 @@ mod tests {
                 priority: 10,
                 work: 1,
                 data: (),
-            }];
+            },
+        ];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         std::thread::sleep(Duration::from_millis(10));

--- a/beetle/iroh-bitswap/src/peer_task_queue/peer_tracker.rs
+++ b/beetle/iroh-bitswap/src/peer_task_queue/peer_tracker.rs
@@ -555,8 +555,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -567,8 +566,7 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            },
-        ];
+            }];
 
         // push task "a"
         tracker.push_tasks(vec![tasks[0].clone()]); // Topic 1
@@ -635,8 +633,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -647,8 +644,7 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            },
-        ];
+            }];
 
         // push task "a"
         tracker.push_tasks(vec![tasks[0].clone()]); // Topic 1
@@ -671,8 +667,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -689,8 +684,7 @@ mod tests {
                 priority: 5,
                 work: 5,
                 data: "c",
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         // same topic, should replace "a" and update work from 10 to 20
@@ -717,8 +711,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -729,8 +722,7 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         // make "a" active
@@ -764,8 +756,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -776,8 +767,7 @@ mod tests {
                 priority: 20,
                 work: 10,
                 data: "b",
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -798,8 +788,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -816,8 +805,7 @@ mod tests {
                 priority: 10,
                 work: 10,
                 data: "c",
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -843,8 +831,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 10,
@@ -861,8 +848,7 @@ mod tests {
                 priority: 15,
                 work: 10,
                 data: "c",
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         let popped = tracker.pop_tasks(10);
@@ -888,8 +874,7 @@ mod tests {
             MAX_ACTIVE_WORK_PER_PEER,
         );
 
-        let tasks = vec![
-            Task {
+        let tasks = [Task {
                 topic: 1,
                 priority: 10,
                 work: 1,
@@ -906,8 +891,7 @@ mod tests {
                 priority: 10,
                 work: 1,
                 data: (),
-            },
-        ];
+            }];
 
         tracker.push_tasks(vec![tasks[0].clone()]);
         std::thread::sleep(Duration::from_millis(10));

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1437,7 +1437,7 @@ mod tests {
     async fn get_addr_loop(client: P2pClient) -> Result<Multiaddr> {
         loop {
             let l = client.listeners().await?;
-            if let Some(a) = l.get(0) {
+            if let Some(a) = l.first() {
                 return Ok(a.clone());
             }
         }
@@ -1729,7 +1729,7 @@ mod tests {
         .context("timed out before finding providers for the given cid")??;
 
         assert!(providers.len() == 1);
-        assert!(providers.get(0).unwrap().contains(&test_runner_c.peer_id));
+        assert!(providers.first().unwrap().contains(&test_runner_c.peer_id));
 
         // c stop providing
         test_runner_c.client.stop_providing(&cid).await?;

--- a/recon/src/client.rs
+++ b/recon/src/client.rs
@@ -219,7 +219,7 @@ impl<K, H, S, I> Server<K, H, S, I>
 where
     K: Key,
     H: AssociativeHash,
-    S: Store<Key = K, Hash = H> + Send + 'static,
+    S: Store<Key = K, Hash = H> + Send + Sync + 'static,
     I: InterestProvider<Key = K> + 'static,
 {
     /// Construct a [`Server`] from a [`Recon`] instance.

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -265,7 +265,7 @@ where
         Ok(inner
             .keys
             .range(range)
-            .filter_map(|(key, _hash)| (!inner.values.contains_key(key)).then(|| key.clone()))
+            .filter(|&(key, _hash)| (!inner.values.contains_key(key))).map(|(key, _hash)| key.clone())
             .collect())
     }
 }

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -265,7 +265,8 @@ where
         Ok(inner
             .keys
             .range(range)
-            .filter(|&(key, _hash)| (!inner.values.contains_key(key))).map(|(key, _hash)| key.clone())
+            .filter(|&(key, _hash)| (!inner.values.contains_key(key)))
+            .map(|(key, _hash)| key.clone())
             .collect())
     }
 }

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -1,33 +1,32 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use ceramic_core::RangeOpen;
-use std::{collections::BTreeMap, ops::Bound};
+use std::{collections::BTreeMap, ops::Bound, sync::Arc};
+use tokio::sync::Mutex;
 
 use crate::recon::{AssociativeHash, Key, MaybeHashedKey, ReconItem, Store};
 
 use super::{HashCount, InsertResult};
 
-/// An implementation of a Store that stores keys in an in-memory BTree
 #[derive(Clone, Debug)]
-pub struct BTreeStore<K, H>
-where
-    K: Key,
-    H: AssociativeHash,
-{
-    /// The set of keys and their Sha256a hashes
-    keys: BTreeMap<K, H>, // this will be a b#tree at some point in the future
-    values: BTreeMap<K, Vec<u8>>, // Map from keys to values.
+struct BTreeStoreInner<K, H> {
+    keys: BTreeMap<K, H>,
+    values: BTreeMap<K, Vec<u8>>,
 }
 
-impl<K, H> Default for BTreeStore<K, H>
-where
-    K: Key,
-    H: AssociativeHash,
-{
+/// An implementation of a Store that stores keys in an in-memory BTree
+#[derive(Clone, Debug)]
+pub struct BTreeStore<K, H> {
+    inner: Arc<Mutex<BTreeStoreInner<K, H>>>,
+}
+
+impl<K, H> Default for BTreeStore<K, H> {
     fn default() -> Self {
         Self {
-            keys: Default::default(),
-            values: Default::default(),
+            inner: Arc::new(Mutex::new(BTreeStoreInner {
+                keys: BTreeMap::new(),
+                values: BTreeMap::new(),
+            })),
         }
     }
 }
@@ -38,16 +37,16 @@ where
     H: AssociativeHash,
 {
     /// make a new recon from a set of keys and values
-    pub fn from_set(s: BTreeMap<K, Option<Vec<u8>>>) -> Self {
-        let mut r = Self {
-            keys: Default::default(),
-            values: Default::default(),
-        };
-        for (key, value) in s {
-            let hash = H::digest(&key);
-            r.keys.insert(key.clone(), hash);
-            if let Some(value) = value {
-                r.values.insert(key, value);
+    pub async fn from_set(s: BTreeMap<K, Option<Vec<u8>>>) -> Self {
+        let r: Self = Default::default();
+        {
+            let mut inner = r.inner.lock().await;
+            for (key, value) in s {
+                let hash = H::digest(&key);
+                inner.keys.insert(key.clone(), hash);
+                if let Some(value) = value {
+                    inner.values.insert(key, value);
+                }
             }
         }
         r
@@ -55,7 +54,7 @@ where
 
     /// Return the hash of all keys in the range between left_fencepost and right_fencepost.
     /// Both range bounds are exclusive.
-    pub fn hash_range(
+    pub async fn hash_range(
         &self,
         left_fencepost: &K,
         right_fencepost: &K,
@@ -70,12 +69,14 @@ where
             Bound::Excluded(left_fencepost),
             Bound::Excluded(right_fencepost),
         );
+        let inner = self.inner.lock().await;
         let hash: H = H::identity().digest_many(
-            self.keys
+            inner
+                .keys
                 .range(range)
                 .map(|(key, hash)| MaybeHashedKey::new(key, Some(hash))),
         );
-        let count: usize = self.keys.range(range).count();
+        let count: usize = inner.keys.range(range).count();
         Ok(HashCount {
             hash,
             count: count as u64,
@@ -86,7 +87,7 @@ where
     /// Both range bounds are exclusive.
     ///
     /// Offset and limit values are applied within the range of keys.
-    pub fn range(
+    pub async fn range(
         &self,
         left_fencepost: &K,
         right_fencepost: &K,
@@ -98,6 +99,9 @@ where
             Bound::Excluded(right_fencepost),
         );
         let keys: Vec<K> = self
+            .inner
+            .lock()
+            .await
             .keys
             .range(range)
             .skip(offset)
@@ -111,7 +115,7 @@ where
     /// Both range bounds are exclusive.
     ///
     /// Offset and limit values are applied within the range of keys.
-    pub fn range_with_values(
+    pub async fn range_with_values(
         &self,
         left_fencepost: &K,
         right_fencepost: &K,
@@ -122,13 +126,15 @@ where
             Bound::Excluded(left_fencepost),
             Bound::Excluded(right_fencepost),
         );
-        let keys: Vec<(K, Vec<u8>)> = self
+        let inner = self.inner.lock().await;
+        let keys: Vec<(K, Vec<u8>)> = inner
             .keys
             .range(range)
             .skip(offset)
             .take(limit)
             .filter_map(|(key, _hash)| {
-                self.values
+                inner
+                    .values
                     .get(key)
                     .map(|value| (key.clone(), value.clone()))
             })
@@ -146,19 +152,20 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
-        let new = self
+    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+        let mut inner = self.inner.lock().await;
+        let new = inner
             .keys
             .insert(item.key.clone(), H::digest(item.key))
             .is_none();
 
         if let Some(val) = item.value {
-            self.values.insert(item.key.clone(), val.to_vec());
+            inner.values.insert(item.key.clone(), val.to_vec());
         }
         Ok(new)
     }
 
-    async fn insert_many<'a, I>(&mut self, items: I) -> Result<InsertResult>
+    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
     where
         I: ExactSizeIterator<Item = ReconItem<'a, K>> + Send + Sync,
     {
@@ -174,17 +181,17 @@ where
     }
 
     async fn hash_range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> anyhow::Result<HashCount<Self::Hash>> {
         // Self does not need async to implement hash_range, so it exposes a pub non async hash_range function
         // and we delegate to its implementation here.
-        BTreeStore::hash_range(self, left_fencepost, right_fencepost)
+        BTreeStore::hash_range(self, left_fencepost, right_fencepost).await
     }
 
     async fn range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -192,20 +199,20 @@ where
     ) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         // Self does not need async to implement range, so it exposes a pub non async range function
         // and we delegate to its implementation here.
-        BTreeStore::range(self, left_fencepost, right_fencepost, offset, limit)
+        BTreeStore::range(self, left_fencepost, right_fencepost, offset, limit).await
     }
     async fn range_with_values(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
     ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        BTreeStore::range_with_values(self, left_fencepost, right_fencepost, offset, limit)
+        BTreeStore::range_with_values(self, left_fencepost, right_fencepost, offset, limit).await
     }
 
     async fn last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -214,6 +221,9 @@ where
             Bound::Excluded(right_fencepost),
         );
         Ok(self
+            .inner
+            .lock()
+            .await
             .keys
             .range(range)
             .next_back()
@@ -221,7 +231,7 @@ where
     }
 
     async fn first_and_last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<(Self::Key, Self::Key)>> {
@@ -229,7 +239,8 @@ where
             Bound::Excluded(left_fencepost),
             Bound::Excluded(right_fencepost),
         );
-        let mut range = self.keys.range(range);
+        let inner = self.inner.lock().await;
+        let mut range = inner.keys.range(range);
         let first = range.next().map(|(k, _)| k);
         if let Some(first) = first {
             if let Some(last) = range.next_back().map(|(k, _)| k) {
@@ -243,17 +254,18 @@ where
     }
 
     /// value_for_key returns an Error is retrieving failed and None if the key is not stored.
-    async fn value_for_key(&mut self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
-        Ok(self.values.get(key).cloned())
+    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
+        Ok(self.inner.lock().await.values.get(key).cloned())
     }
     async fn keys_with_missing_values(
-        &mut self,
+        &self,
         range: RangeOpen<Self::Key>,
     ) -> Result<Vec<Self::Key>> {
-        Ok(self
+        let inner = self.inner.lock().await;
+        Ok(inner
             .keys
             .range(range)
-            .filter_map(|(key, _hash)| (!self.values.contains_key(key)).then(|| key.clone()))
+            .filter_map(|(key, _hash)| (!inner.values.contains_key(key)).then(|| key.clone()))
             .collect())
     }
 }

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -226,7 +226,8 @@ async fn from_setup_state(setup: SetupState<AlphaNumBytes>) -> ReconMemoryBytes 
                 .into_iter()
                 .map(|(k, v)| (k, v.map(|v| v.into_inner())))
                 .collect(),
-        ).await,
+        )
+        .await,
         metrics: Metrics::register(&mut Registry::default()),
     }
 }

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -217,19 +217,17 @@ pub struct SetupState<K: Key> {
     state: BTreeMap<K, Option<K>>,
 }
 
-impl From<SetupState<AlphaNumBytes>> for ReconMemoryBytes {
-    fn from(value: SetupState<AlphaNumBytes>) -> Self {
-        Recon {
-            interests: value.interests.into(),
-            store: BTreeStore::from_set(
-                value
-                    .state
-                    .into_iter()
-                    .map(|(k, v)| (k, v.map(|v| v.into_inner())))
-                    .collect(),
-            ),
-            metrics: Metrics::register(&mut Registry::default()),
-        }
+async fn from_setup_state(setup: SetupState<AlphaNumBytes>) -> ReconMemoryBytes {
+    Recon {
+        interests: setup.interests.into(),
+        store: BTreeStore::from_set(
+            setup
+                .state
+                .into_iter()
+                .map(|(k, v)| (k, v.map(|v| v.into_inner())))
+                .collect(),
+        ).await,
+        metrics: Metrics::register(&mut Registry::default()),
     }
 }
 
@@ -535,7 +533,7 @@ where
 #[test(tokio::test)]
 async fn word_lists() {
     async fn recon_from_string(s: &str) -> Client<AlphaNumBytes, Sha256a> {
-        let mut r = ReconBytes::new(
+        let r = ReconBytes::new(
             BTreeStore::default(),
             FullInterests::default(),
             Metrics::register(&mut Registry::default()),
@@ -1184,8 +1182,8 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
 
     let setup = parse_sequence(recon);
 
-    let cat = start_recon(setup.cat.clone().into());
-    let dog = start_recon(setup.dog.clone().into());
+    let cat = start_recon(from_setup_state(setup.cat.clone()).await);
+    let dog = start_recon(from_setup_state(setup.dog.clone()).await);
 
     let steps = Arc::new(std::sync::Mutex::new(Vec::<
         SequenceStep<AlphaNumBytes, MemoryAHash>,

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -219,7 +219,7 @@ pub struct SetupState<K: Key> {
 
 async fn from_setup_state(setup: SetupState<AlphaNumBytes>) -> ReconMemoryBytes {
     Recon {
-        interests: setup.interests.into(),
+        interests: setup.interests,
         store: BTreeStore::from_set(
             setup
                 .state
@@ -407,9 +407,9 @@ where
     fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D, A> {
         // Use Alpha and Omega as the min and max values respectively
         if self.0 == &K::min_value() {
-            allocator.text(format!("𝚨"))
+            allocator.text("𝚨".to_string())
         } else if self.0 == &K::max_value() {
-            allocator.text(format!("𝛀 "))
+            allocator.text("𝛀 ".to_string())
         } else {
             allocator.text(format!("{:?}", self.0))
         }
@@ -635,7 +635,7 @@ async fn word_lists() {
 fn parse_sequence(sequence: &str) -> SequenceSetup<AlphaNumBytes> {
     // We only parse the setup which is the first two lines.
     let setup = sequence
-        .split("\n")
+        .split('\n')
         .filter(|line| !line.trim().is_empty())
         .take(2)
         .collect::<Vec<&str>>()

--- a/recon/src/tests.rs
+++ b/recon/src/tests.rs
@@ -70,7 +70,7 @@ impl std::fmt::Display for AlphaNumBytes {
             f,
             "{}",
             String::from_utf8(self.0.as_slice().to_vec())
-                .unwrap_or_else(|_| format!("0x{}", hex::encode_upper(&self.0.as_slice())))
+                .unwrap_or_else(|_| format!("0x{}", hex::encode_upper(self.0.as_slice())))
         )
     }
 }

--- a/recon/src/tests.rs
+++ b/recon/src/tests.rs
@@ -11,22 +11,8 @@ use crate::Key;
 pub struct AlphaNumBytes(Vec<u8>);
 
 impl AlphaNumBytes {
-    /// Returns the inner slice held by this `Bytes`.
-    pub fn as_slice(&self) -> &[u8] {
-        &self.0
-    }
     pub fn into_inner(self) -> Vec<u8> {
         self.0
-    }
-
-    pub fn to_upper(self) -> Self {
-        Self(
-            String::from_utf8(self.0)
-                .unwrap()
-                .to_uppercase()
-                .as_bytes()
-                .to_vec(),
-        )
     }
 }
 

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -250,14 +250,14 @@ where
 #[async_trait]
 impl<S, K, H> recon::Store for StoreMetricsMiddleware<S>
 where
-    S: recon::Store<Key = K, Hash = H> + Send,
+    S: recon::Store<Key = K, Hash = H> + Send + Sync,
     K: recon::Key,
-    H: recon::AssociativeHash,
+    H: AssociativeHash,
 {
     type Key = K;
     type Hash = H;
 
-    async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
         let new_val = item.value.is_some();
         let new =
             StoreMetricsMiddleware::<S>::record(&self.metrics, "insert", self.store.insert(item))
@@ -266,7 +266,7 @@ where
         Ok(new)
     }
 
-    async fn insert_many<'a, I>(&mut self, items: I) -> Result<InsertResult>
+    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
     where
         I: ExactSizeIterator<Item = ReconItem<'a, K>> + Send + Sync,
     {
@@ -292,7 +292,7 @@ where
     }
 
     async fn hash_range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<HashCount<Self::Hash>> {
@@ -305,7 +305,7 @@ where
     }
 
     async fn range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -320,7 +320,7 @@ where
         .await
     }
     async fn range_with_values(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -335,13 +335,13 @@ where
         .await
     }
 
-    async fn full_range(&mut self) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+    async fn full_range(&self) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "full_range", self.store.full_range())
             .await
     }
 
     async fn middle(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -353,7 +353,7 @@ where
         .await
     }
     async fn count(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<usize> {
@@ -365,7 +365,7 @@ where
         .await
     }
     async fn first(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -377,7 +377,7 @@ where
         .await
     }
     async fn last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -390,7 +390,7 @@ where
     }
 
     async fn first_and_last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<(Self::Key, Self::Key)>> {
@@ -402,15 +402,15 @@ where
         .await
     }
 
-    async fn len(&mut self) -> Result<usize> {
+    async fn len(&self) -> Result<usize> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "len", self.store.len()).await
     }
 
-    async fn is_empty(&mut self) -> Result<bool> {
+    async fn is_empty(&self) -> Result<bool> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "is_empty", self.store.is_empty()).await
     }
 
-    async fn value_for_key(&mut self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "value_for_key",
@@ -419,7 +419,7 @@ where
         .await
     }
     async fn keys_with_missing_values(
-        &mut self,
+        &self,
         range: RangeOpen<Self::Key>,
     ) -> Result<Vec<Self::Key>> {
         StoreMetricsMiddleware::<S>::record(

--- a/store/src/sql/event.rs
+++ b/store/src/sql/event.rs
@@ -508,14 +508,14 @@ where
     type Hash = H;
 
     /// Returns true if the key was new. The value is always updated if included
-    async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
         let (new, _new_val) = self.insert_item(&item).await?;
         Ok(new)
     }
 
     /// Insert new keys into the key space.
     /// Returns true if a key did not previously exist.
-    async fn insert_many<'a, I>(&mut self, items: I) -> Result<InsertResult>
+    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
     where
         I: ExactSizeIterator<Item = ReconItem<'a, EventId>> + Send + Sync,
     {
@@ -542,7 +542,7 @@ where
     /// return the hash and count for a range
     #[instrument(skip(self))]
     async fn hash_range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<HashCount<Self::Hash>> {
@@ -583,7 +583,7 @@ where
 
     #[instrument(skip(self))]
     async fn range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -623,7 +623,7 @@ where
     }
     #[instrument(skip(self))]
     async fn range_with_values(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -636,7 +636,7 @@ where
     /// Return the number of keys within the range.
     #[instrument(skip(self))]
     async fn count(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<usize> {
@@ -662,7 +662,7 @@ where
     /// Return the first key within the range.
     #[instrument(skip(self))]
     async fn first(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -690,7 +690,7 @@ where
 
     #[instrument(skip(self))]
     async fn last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -720,7 +720,7 @@ where
 
     #[instrument(skip(self))]
     async fn first_and_last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<(Self::Key, Self::Key)>> {
@@ -761,13 +761,13 @@ where
     }
 
     #[instrument(skip(self))]
-    async fn value_for_key(&mut self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
         self.value_for_key_int(key).await
     }
 
     #[instrument(skip(self))]
     async fn keys_with_missing_values(
-        &mut self,
+        &self,
         range: RangeOpen<Self::Key>,
     ) -> Result<Vec<Self::Key>> {
         if range.start >= range.end {

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -559,7 +559,7 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_range_with_values_query() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let interest_0 = random_interest(None, None);
         let interest_1 = random_interest(None, None);
         AccessInterestStore::insert(&store, interest_0.clone())

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -562,8 +562,12 @@ mod interest_tests {
         let mut store = new_store().await;
         let interest_0 = random_interest(None, None);
         let interest_1 = random_interest(None, None);
-        AccessInterestStore::insert(&store, interest_0.clone()).await.unwrap();
-        AccessInterestStore::insert(&store, interest_1.clone()).await.unwrap();
+        AccessInterestStore::insert(&store, interest_0.clone())
+            .await
+            .unwrap();
+        AccessInterestStore::insert(&store, interest_1.clone())
+            .await
+            .unwrap();
         let ids = store
             .range_with_values(
                 &random_interest_min(),

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -171,7 +171,7 @@ where
     type Hash = H;
 
     /// Returns true if the key was new. The value is always updated if included
-    async fn insert(&mut self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
         // interests don't have values, if someone gives us something we throw an error but allow None/vec![]
         if let Some(val) = item.value {
             if !val.is_empty() {
@@ -185,7 +185,7 @@ where
 
     /// Insert new keys into the key space.
     /// Returns true if a key did not previously exist.
-    async fn insert_many<'a, I>(&mut self, items: I) -> Result<InsertResult>
+    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
     where
         I: ExactSizeIterator<Item = ReconItem<'a, Interest>> + Send + Sync,
     {
@@ -212,7 +212,7 @@ where
     /// return the hash and count for a range
     #[instrument(skip(self))]
     async fn hash_range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<HashCount<Self::Hash>> {
@@ -253,7 +253,7 @@ where
 
     #[instrument(skip(self))]
     async fn range(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -266,7 +266,7 @@ where
     #[instrument(skip(self))]
     /// Interests don't have values, so the value will always be an empty vec. Use `range` instead.
     async fn range_with_values(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
         offset: usize,
@@ -280,7 +280,7 @@ where
     /// Return the number of keys within the range.
     #[instrument(skip(self))]
     async fn count(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<usize> {
@@ -305,7 +305,7 @@ where
     /// Return the first key within the range.
     #[instrument(skip(self))]
     async fn first(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -339,7 +339,7 @@ where
 
     #[instrument(skip(self))]
     async fn last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<Self::Key>> {
@@ -373,7 +373,7 @@ where
 
     #[instrument(skip(self))]
     async fn first_and_last(
-        &mut self,
+        &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> Result<Option<(Self::Key, Self::Key)>> {
@@ -417,13 +417,13 @@ where
     }
 
     #[instrument(skip(self))]
-    async fn value_for_key(&mut self, _key: &Self::Key) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, _key: &Self::Key) -> Result<Option<Vec<u8>>> {
         Ok(Some(vec![]))
     }
 
     #[instrument(skip(self))]
     async fn keys_with_missing_values(
-        &mut self,
+        &self,
         _range: RangeOpen<Self::Key>,
     ) -> Result<Vec<Self::Key>> {
         Ok(vec![])
@@ -562,8 +562,8 @@ mod interest_tests {
         let mut store = new_store().await;
         let interest_0 = random_interest(None, None);
         let interest_1 = random_interest(None, None);
-        store.insert(interest_0.clone()).await.unwrap();
-        store.insert(interest_1.clone()).await.unwrap();
+        AccessInterestStore::insert(&store, interest_0.clone()).await.unwrap();
+        AccessInterestStore::insert(&store, interest_1.clone()).await.unwrap();
         let ids = store
             .range_with_values(
                 &random_interest_min(),


### PR DESCRIPTION
We don't need the store to be mutable and this was also implemented in the RedTree branch, but it hasn't been pulled out separately yet (https://github.com/ceramicnetwork/rust-ceramic/pull/280). Helps with the `Box<dyn>` changes to determine the database at runtime.