### PR TITLE
chore: adjust types to allow dynamic usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,7 +1344,6 @@ dependencies = [
  "prometheus-client",
  "rand 0.8.5",
  "recon",
- "serde",
  "sqlx",
  "test-log",
  "tokio",

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -115,37 +115,48 @@ impl TryFrom<models::Interest> for ValidatedInterest {
 }
 
 #[async_trait]
-pub trait AccessInterestStore: Clone + Send + Sync {
-    type Key: Key;
-    type Hash: AssociativeHash + std::fmt::Debug + Serialize + for<'de> Deserialize<'de>;
-
+pub trait AccessInterestStore: Send + Sync {
     /// Returns true if the key was newly inserted, false if it already existed.
-    async fn insert(&self, key: Self::Key) -> Result<bool>;
+    async fn insert(&self, key: Interest) -> Result<bool>;
     async fn range(
         &self,
-        start: Self::Key,
-        end: Self::Key,
+        start: &Interest,
+        end: &Interest,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<Self::Key>>;
+    ) -> Result<Vec<Interest>>;
 }
 
 #[async_trait]
-pub trait AccessModelStore: Clone + Send + Sync {
-    type Key: Key;
-    type Hash: AssociativeHash + std::fmt::Debug + Serialize + for<'de> Deserialize<'de>;
+impl<S: AccessInterestStore> AccessInterestStore for Arc<S> {
+    async fn insert(&self, key: Interest) -> Result<bool> {
+        self.as_ref().insert(key).await
+    }
 
-    /// Returns (new_key, new_value) where true if was newly inserted, false if it already existed.
-    async fn insert(&self, key: Self::Key, value: Option<Vec<u8>>) -> Result<(bool, bool)>;
-    async fn range_with_values(
+    async fn range(
         &self,
-        start: Self::Key,
-        end: Self::Key,
+        start: &Interest,
+        end: &Interest,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<(Self::Key, Vec<u8>)>>;
+    ) -> Result<Vec<Interest>> {
+        self.as_ref().range(start, end, offset, limit).await
+    }
+}
 
-    async fn value_for_key(&self, key: Self::Key) -> Result<Option<Vec<u8>>>;
+#[async_trait]
+pub trait AccessModelStore: Send + Sync {
+    /// Returns (new_key, new_value) where true if was newly inserted, false if it already existed.
+    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> Result<(bool, bool)>;
+    async fn range_with_values(
+        &self,
+        start: &EventId,
+        end: &EventId,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(EventId, Vec<u8>)>>;
+
+    async fn value_for_key(&self, key: &EventId) -> Result<Option<Vec<u8>>>;
 
     // it's likely `highwater` will be a string or struct when we have alternative storage for now we
     // keep it simple to allow easier error propagation. This isn't currently public outside of this repo.
@@ -153,7 +164,40 @@ pub trait AccessModelStore: Clone + Send + Sync {
         &self,
         highwater: i64,
         limit: i64,
-    ) -> anyhow::Result<(i64, Vec<Self::Key>)>;
+    ) -> Result<(i64, Vec<EventId>)>;
+}
+
+#[async_trait::async_trait]
+impl<S: AccessModelStore> AccessModelStore for Arc<S> {
+    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> Result<(bool, bool)> {
+        self.as_ref().insert(key, value).await
+    }
+
+    async fn range_with_values(
+        &self,
+        start: &EventId,
+        end: &EventId,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Vec<(EventId, Vec<u8>)>> {
+        self.as_ref()
+            .range_with_values(start, end, offset, limit)
+            .await
+    }
+
+    async fn value_for_key(&self, key: &EventId) -> Result<Option<Vec<u8>>> {
+        self.as_ref().value_for_key(key).await
+    }
+
+    async fn keys_since_highwater_mark(
+        &self,
+        highwater: i64,
+        limit: i64,
+    ) -> Result<(i64, Vec<EventId>)> {
+        self.as_ref()
+            .keys_since_highwater_mark(highwater, limit)
+            .await
+    }
 }
 
 #[derive(Clone)]
@@ -167,8 +211,8 @@ pub struct Server<C, I, M> {
 
 impl<C, I, M> Server<C, I, M>
 where
-    I: AccessInterestStore<Key = Interest>,
-    M: AccessModelStore<Key = EventId>,
+    I: AccessInterestStore,
+    M: AccessModelStore,
 {
     pub fn new(peer_id: PeerId, network: Network, interest: I, model: M) -> Self {
         Server {
@@ -232,7 +276,7 @@ where
 
         let events = self
             .model
-            .range_with_values(start, stop, offset, limit)
+            .range_with_values(&start, &stop, offset, limit)
             .await
             .map_err(|err| ErrorResponse::new(format!("failed to get keys: {err}")))?
             .into_iter()
@@ -281,7 +325,7 @@ where
         event_id: String,
     ) -> Result<EventsEventIdGetResponse, ErrorResponse> {
         let decoded_event_id = decode_event_id(&event_id)?;
-        match self.model.value_for_key(decoded_event_id.clone()).await {
+        match self.model.value_for_key(&decoded_event_id).await {
             Ok(Some(data)) => {
                 let event = BuildResponse::event(decoded_event_id, data);
                 Ok(EventsEventIdGetResponse::Success(event))
@@ -385,8 +429,8 @@ pub(crate) fn decode_event_data(value: &str) -> Result<Vec<u8>, ErrorResponse> {
 impl<C, I, M> Api<C> for Server<C, I, M>
 where
     C: Send + Sync,
-    I: AccessInterestStore<Key = Interest> + Sync,
-    M: AccessModelStore<Key = EventId> + Sync,
+    I: AccessInterestStore + Sync,
+    M: AccessModelStore + Sync,
 {
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn liveness_get(

--- a/beetle/iroh-bitswap/src/lib.rs
+++ b/beetle/iroh-bitswap/src/lib.rs
@@ -754,7 +754,7 @@ mod tests {
     async fn get_block<const N: usize>() {
         info!("get_block");
         let (peer1_id, trans) = mk_transport();
-        let store1 = TestStore::default();
+        let store1 = Arc::new(TestStore::default());
         let bs1 = Bitswap::new(peer1_id, store1.clone(), Config::default()).await;
 
         let config = swarm::Config::with_tokio_executor()
@@ -789,7 +789,7 @@ mod tests {
 
         info!("peer2: startup");
         let (peer2_id, trans) = mk_transport();
-        let store2 = TestStore::default();
+        let store2 = Arc::new(TestStore::default());
         let bs2 = Bitswap::new(peer2_id, store2.clone(), Config::default()).await;
 
         let config = swarm::Config::with_tokio_executor()

--- a/beetle/iroh-bitswap/src/lib.rs
+++ b/beetle/iroh-bitswap/src/lib.rs
@@ -156,7 +156,7 @@ impl<S: Store> Bitswap<S> {
 
         let mut workers = Vec::new();
         workers.push(tokio::task::spawn({
-            let server = server.as_ref().map(|s| s.clone());
+            let server = server.clone();
             let client = client.clone();
 
             async move {
@@ -176,7 +176,7 @@ impl<S: Store> Bitswap<S> {
         }));
 
         workers.push(tokio::task::spawn({
-            let server = server.as_ref().map(|s| s.clone());
+            let server = server.clone();
             let client = client.clone();
 
             async move {

--- a/beetle/iroh-bitswap/src/server.rs
+++ b/beetle/iroh-bitswap/src/server.rs
@@ -56,13 +56,22 @@ pub struct Stat {
     pub data_sent: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Server<S: Store> {
     // sent_histogram -> iroh-metrics
     // send_time_histogram -> iroh-metric
     /// Decision engine for which who to send which blocks to.
     engine: Arc<DecisionEngine<S>>,
     inner: Arc<Inner>,
+}
+
+impl<S: Store> Clone for Server<S> {
+    fn clone(&self) -> Self {
+        Server {
+            engine: self.engine.clone(),
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -81,7 +90,7 @@ struct Inner {
 }
 
 impl<S: Store> Server<S> {
-    pub async fn new(network: Network, store: S, config: Config) -> Self {
+    pub async fn new(network: Network, store: Arc<S>, config: Config) -> Self {
         let engine = DecisionEngine::new(store, *network.self_id(), config.decision_config).await;
         let provide_keys = mpsc::channel(PROVIDE_KEYS_BUFFER_SIZE);
         let new_blocks = mpsc::channel(config.has_block_buffer_size);

--- a/beetle/iroh-bitswap/src/server/decision.rs
+++ b/beetle/iroh-bitswap/src/server/decision.rs
@@ -122,7 +122,7 @@ pub struct Engine<S: Store> {
 }
 
 impl<S: Store> Engine<S> {
-    pub async fn new(store: S, _self_id: PeerId, config: Config) -> Self {
+    pub async fn new(store: Arc<S>, _self_id: PeerId, config: Config) -> Self {
         // TODO: insert options for peertaskqueue
 
         // TODO: limit?

--- a/kubo-rpc/src/lib.rs
+++ b/kubo-rpc/src/lib.rs
@@ -160,16 +160,16 @@ pub trait IpfsDep: Clone {
 /// Implementation of IPFS APIs
 pub struct IpfsService<S> {
     p2p: P2pClient,
-    store: S,
+    store: Arc<S>,
     resolver: Resolver<S>,
 }
 
 impl<S> IpfsService<S>
 where
-    S: iroh_bitswap::Store + Clone,
+    S: iroh_bitswap::Store,
 {
     /// Create new IpfsService
-    pub fn new(p2p: P2pClient, store: S) -> Self {
+    pub fn new(p2p: P2pClient, store: Arc<S>) -> Self {
         let resolver = Resolver::new(store.clone());
         Self {
             p2p,
@@ -264,7 +264,7 @@ where
 // * dag-json
 // * dag-jose
 struct Resolver<S> {
-    store: S,
+    store: Arc<S>,
 }
 
 // Represents an IPFS DAG node
@@ -281,7 +281,7 @@ impl<S> Resolver<S>
 where
     S: iroh_bitswap::Store,
 {
-    fn new(store: S) -> Self {
+    fn new(store: Arc<S>) -> Self {
         Resolver { store }
     }
     #[instrument(skip(self))]

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -38,7 +38,7 @@ impl Builder<Init> {
         libp2p_config: Libp2pConfig,
         keypair: Keypair,
         recons: Option<(I, M)>,
-        block_store: S,
+        block_store: Arc<S>,
         metrics: ceramic_p2p::Metrics,
     ) -> anyhow::Result<Builder<WithP2p>>
     where
@@ -72,7 +72,7 @@ impl Builder<Init> {
 
 /// Finish the build
 impl Builder<WithP2p> {
-    pub async fn build<S>(self, block_store: S, ipfs_metrics: IpfsMetrics) -> Result<Ipfs<S>>
+    pub async fn build<S>(self, block_store: Arc<S>, ipfs_metrics: IpfsMetrics) -> Result<Ipfs<S>>
     where
         S: iroh_bitswap::Store,
     {

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -19,6 +19,7 @@ use libp2p::{
 };
 use libp2p_identity::Keypair;
 use recon::{libp2p::Recon, Sha256a};
+use std::sync::Arc;
 use tracing::{info, warn};
 
 use self::ceramic_peer_manager::CeramicPeerManager;
@@ -69,7 +70,7 @@ where
         config: &Libp2pConfig,
         relay_client: Option<relay::client::Behaviour>,
         recons: Option<(I, M)>,
-        block_store: S,
+        block_store: Arc<S>,
         metrics: Metrics,
     ) -> Result<Self> {
         let pub_key = local_key.public();

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -146,7 +146,7 @@ where
         rpc_addr: P2pAddr,
         keypair: Keypair,
         recons: Option<(I, M)>,
-        block_store: S,
+        block_store: Arc<S>,
         metrics: Metrics,
     ) -> Result<Self> {
         let (network_sender_in, network_receiver_in) = channel(1024); // TODO: configurable

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1164,7 +1164,7 @@ mod tests {
 
     use async_trait::async_trait;
     use ceramic_core::RangeOpen;
-    use ceramic_store::SqlitePool;
+    use ceramic_store::{SqliteEventStore, SqlitePool};
     use futures::TryStreamExt;
     use rand::prelude::*;
     use rand_chacha::ChaCha8Rng;
@@ -1390,7 +1390,7 @@ mod tests {
                 rpc_server_addr,
                 keypair.into(),
                 None::<(DummyRecon<Interest>, DummyRecon<EventId>)>,
-                ceramic_store::EventStore::new(sql_pool).await?,
+                Arc::new(SqliteEventStore::new(sql_pool).await?),
                 metrics,
             )
             .await?;

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -3,6 +3,7 @@ use ceramic_core::{EventId, Interest};
 use libp2p::{noise, relay, swarm::Executor, tcp, tls, yamux, Swarm, SwarmBuilder};
 use libp2p_identity::Keypair;
 use recon::{libp2p::Recon, Sha256a};
+use std::sync::Arc;
 
 use crate::{behaviour::NodeBehaviour, Libp2pConfig, Metrics};
 
@@ -10,7 +11,7 @@ pub(crate) async fn build_swarm<I, M, S>(
     config: &Libp2pConfig,
     keypair: Keypair,
     recons: Option<(I, M)>,
-    block_store: S,
+    block_store: Arc<S>,
     metrics: Metrics,
 ) -> Result<Swarm<NodeBehaviour<I, M, S>>>
 where
@@ -74,7 +75,7 @@ fn new_behavior<I, M, S>(
     keypair: &Keypair,
     relay_client: Option<relay::client::Behaviour>,
     recons: Option<(I, M)>,
-    block_store: S,
+    block_store: Arc<S>,
     metrics: Metrics,
 ) -> Result<NodeBehaviour<I, M, S>>
 where

--- a/recon/src/client.rs
+++ b/recon/src/client.rs
@@ -207,7 +207,7 @@ pub struct Server<K, H, S, I>
 where
     K: Key,
     H: AssociativeHash,
-    S: Store<Key = K, Hash = H> + Send,
+    S: Store<Key = K, Hash = H> + Send + Sync,
     I: InterestProvider<Key = K>,
 {
     requests_sender: Sender<Request<K, H>>,
@@ -255,7 +255,7 @@ where
                     Request::Insert { key, value, ret } => {
                         let val = self
                             .recon
-                            .insert(ReconItem::new(&key, value.as_deref()))
+                            .insert(&ReconItem::new(&key, value.as_deref()))
                             .await;
                         send(ret, val);
                     }

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -5,8 +5,9 @@ pub use crate::{
     client::{Client, Server},
     metrics::Metrics,
     recon::{
-        btreestore::BTreeStore, AssociativeHash, FullInterests, HashCount, InsertResult,
-        InterestProvider, Key, Range, Recon, ReconInterestProvider, ReconItem, Store, SyncState,
+        btreestore::BTreeStore, AssociativeHash, EventIdStore, FullInterests, HashCount,
+        InsertResult, InterestProvider, InterestStore, Key, Range, Recon, ReconInterestProvider,
+        ReconItem, Store, SyncState,
     },
     sha256a::Sha256a,
 };

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -248,7 +248,7 @@ where
     /// Insert many keys into the key space. Includes an optional value for each key.
     /// Returns an array with a boolean for each key indicating if the key was new.
     /// The order is the same as the order of the keys. True means new, false means not new.
-    pub async fn insert_many(&self, items: &Vec<ReconItem<'_, K>>) -> Result<Vec<bool>> {
+    pub async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> Result<Vec<bool>> {
         let result = self.store.insert_many(items).await?;
 
         Ok(result.keys)
@@ -440,7 +440,7 @@ pub trait Store {
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, Self::Key>>) -> Result<InsertResult>;
+    async fn insert_many(&self, items: &[ReconItem<'_, Self::Key>]) -> Result<InsertResult>;
 
     /// Return the hash of all keys in the range between left_fencepost and right_fencepost.
     /// Both range bounds are exclusive.
@@ -596,7 +596,7 @@ where
         self.as_ref().insert(item).await
     }
 
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, Self::Key>>) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, Self::Key>]) -> Result<InsertResult> {
         self.as_ref().insert_many(items).await
     }
 

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -28,7 +28,7 @@ pub struct Recon<K, H, S, I>
 where
     K: Key,
     H: AssociativeHash,
-    S: Store<Key = K, Hash = H> + Send,
+    S: Store<Key = K, Hash = H> + Send + Sync,
     I: InterestProvider<Key = K>,
 {
     interests: I,
@@ -96,17 +96,15 @@ where
         let mut new_keys = Vec::with_capacity(2);
 
         if !range.first.is_fencepost() {
-            should_add.push(range.first.clone());
+            should_add.push(ReconItem::new_key(&range.first));
         }
 
         if !range.last.is_fencepost() {
-            should_add.push(range.last.clone());
+            should_add.push(ReconItem::new_key(&range.last));
         }
 
         if !should_add.is_empty() {
-            let new = self
-                .insert_many(should_add.iter().map(|key| ReconItem::new_key(key)))
-                .await?;
+            let new = self.insert_many(&should_add).await?;
             debug_assert_eq!(
                 new.len(),
                 should_add.len(),
@@ -114,7 +112,7 @@ where
             );
             for (idx, key) in should_add.into_iter().enumerate() {
                 if new[idx] {
-                    new_keys.push(key);
+                    new_keys.push(key.key.clone());
                 }
             }
         }
@@ -239,7 +237,7 @@ where
 
     /// Insert key into the key space. Includes an optional value.
     /// Returns a boolean (true) indicating if the key was new.
-    pub async fn insert(&self, item: ReconItem<'_, K>) -> Result<bool> {
+    pub async fn insert(&self, item: &ReconItem<'_, K>) -> Result<bool> {
         self.store.insert(item).await
     }
     /// Report all keys in the range that are missing a value
@@ -250,10 +248,7 @@ where
     /// Insert many keys into the key space. Includes an optional value for each key.
     /// Returns an array with a boolean for each key indicating if the key was new.
     /// The order is the same as the order of the keys. True means new, false means not new.
-    pub async fn insert_many<'a, IT>(&self, items: IT) -> Result<Vec<bool>>
-    where
-        IT: ExactSizeIterator<Item = ReconItem<'a, K>> + Send + Sync,
-    {
+    pub async fn insert_many(&self, items: &Vec<ReconItem<'_, K>>) -> Result<Vec<bool>> {
         let result = self.store.insert_many(items).await?;
 
         Ok(result.keys)
@@ -290,7 +285,7 @@ where
     ///
     /// Offset and limit values are applied within the range of keys.
     pub async fn range_with_values(
-        &mut self,
+        &self,
         left_fencepost: &K,
         right_fencepost: &K,
         offset: usize,
@@ -352,9 +347,9 @@ where
     }
 }
 
-impl<H> std::fmt::Display for HashCount<H>
+impl<H> Display for HashCount<H>
 where
-    H: std::fmt::Display,
+    H: Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}#{}", self.hash, self.count)
@@ -432,7 +427,7 @@ impl InsertResult {
 
 /// Store defines the API needed to store the Recon set.
 #[async_trait]
-pub trait Store: std::fmt::Debug {
+pub trait Store {
     /// Type of the Key being stored.
     type Key: Key;
     /// Type of the AssociativeHash to compute over keys.
@@ -440,14 +435,12 @@ pub trait Store: std::fmt::Debug {
 
     /// Insert a new key into the key space. Returns true if the key did not exist.
     /// The value will be updated if included
-    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool>;
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool>;
 
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.
-    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
-    where
-        I: ExactSizeIterator<Item = ReconItem<'a, Self::Key>> + Send + Sync;
+    async fn insert_many(&self, items: &Vec<ReconItem<'_, Self::Key>>) -> Result<InsertResult>;
 
     /// Return the hash of all keys in the range between left_fencepost and right_fencepost.
     /// Both range bounds are exclusive.
@@ -588,6 +581,78 @@ pub trait Store: std::fmt::Debug {
     async fn keys_with_missing_values(&self, range: RangeOpen<Self::Key>)
         -> Result<Vec<Self::Key>>;
 }
+
+#[async_trait::async_trait]
+impl<K, H, S> Store for std::sync::Arc<S>
+where
+    K: Key,
+    H: AssociativeHash,
+    S: Store<Key = K, Hash = H> + Send + Sync,
+{
+    type Key = K;
+    type Hash = H;
+
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
+        self.as_ref().insert(item).await
+    }
+
+    async fn insert_many(&self, items: &Vec<ReconItem<'_, Self::Key>>) -> Result<InsertResult> {
+        self.as_ref().insert_many(items).await
+    }
+
+    async fn hash_range(
+        &self,
+        left_fencepost: &Self::Key,
+        right_fencepost: &Self::Key,
+    ) -> Result<HashCount<Self::Hash>> {
+        self.as_ref()
+            .hash_range(left_fencepost, right_fencepost)
+            .await
+    }
+
+    async fn range(
+        &self,
+        left_fencepost: &Self::Key,
+        right_fencepost: &Self::Key,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+        self.as_ref()
+            .range(left_fencepost, right_fencepost, offset, limit)
+            .await
+    }
+
+    async fn range_with_values(
+        &self,
+        left_fencepost: &Self::Key,
+        right_fencepost: &Self::Key,
+        offset: usize,
+        limit: usize,
+    ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
+        self.as_ref()
+            .range_with_values(left_fencepost, right_fencepost, offset, limit)
+            .await
+    }
+
+    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
+        self.as_ref().value_for_key(key).await
+    }
+
+    async fn keys_with_missing_values(
+        &self,
+        range: RangeOpen<Self::Key>,
+    ) -> Result<Vec<Self::Key>> {
+        self.as_ref().keys_with_missing_values(range).await
+    }
+}
+
+/// Store for Interests
+#[async_trait::async_trait]
+pub trait InterestStore: Store<Key = Interest, Hash = Sha256a> {}
+
+/// Store for EventId
+#[async_trait::async_trait]
+pub trait EventIdStore: Store<Key = EventId, Hash = Sha256a> {}
 
 /// Represents a key that can be reconciled via Recon.
 pub trait Key:

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -152,7 +152,7 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&self, item: ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
         let mut inner = self.inner.lock().await;
         let new = inner
             .keys
@@ -165,17 +165,14 @@ where
         Ok(new)
     }
 
-    async fn insert_many<'a, I>(&self, items: I) -> Result<InsertResult>
-    where
-        I: ExactSizeIterator<Item = ReconItem<'a, K>> + Send + Sync,
-    {
+    async fn insert_many(&self, items: &Vec<ReconItem<'_, K>>) -> Result<InsertResult> {
         let mut new = vec![false; items.len()];
         let mut new_val_cnt = 0;
-        for (idx, item) in items.enumerate() {
+        for (idx, item) in items.iter().enumerate() {
             if item.value.is_some() {
                 new_val_cnt += 1;
             }
-            new[idx] = self.insert(item).await?;
+            new[idx] = self.insert(&item).await?;
         }
         Ok(InsertResult::new(new, new_val_cnt))
     }

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -165,14 +165,14 @@ where
         Ok(new)
     }
 
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, K>>) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> Result<InsertResult> {
         let mut new = vec![false; items.len()];
         let mut new_val_cnt = 0;
         for (idx, item) in items.iter().enumerate() {
             if item.value.is_some() {
                 new_val_cnt += 1;
             }
-            new[idx] = self.insert(&item).await?;
+            new[idx] = self.insert(item).await?;
         }
         Ok(InsertResult::new(new, new_val_cnt))
     }

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -541,7 +541,7 @@ async fn word_lists() {
         );
         for key in s.split([' ', '\n']).map(|s| s.to_string()) {
             if !s.is_empty() {
-                r.insert(ReconItem::new(
+                r.insert(&ReconItem::new(
                     &key.as_bytes().into(),
                     key.to_uppercase().as_bytes().into(),
                 ))

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -26,7 +26,6 @@ itertools = "0.12.0"
 multihash.workspace = true
 prometheus-client.workspace = true
 recon.workspace = true
-serde.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -8,4 +8,4 @@ mod sql;
 mod tests;
 
 pub use metrics::{Metrics, StoreMetricsMiddleware};
-pub use sql::{DbTx, EventStore, InterestStore, Migrations, RootStore, SqlitePool};
+pub use sql::{DbTx, Migrations, RootStore, SqliteEventStore, SqliteInterestStore, SqlitePool};

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -258,7 +258,7 @@ where
         Ok(new)
     }
 
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, K>>) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> Result<InsertResult> {
         let res = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "insert_many",

--- a/store/src/sql/event.rs
+++ b/store/src/sql/event.rs
@@ -502,7 +502,7 @@ impl recon::Store for SqliteEventStore {
 
     /// Insert new keys into the key space.
     /// Returns true if a key did not previously exist.
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, EventId>>) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, EventId>]) -> Result<InsertResult> {
         match items.len() {
             0 => Ok(InsertResult::new(vec![], 0)),
             _ => {

--- a/store/src/sql/event.rs
+++ b/store/src/sql/event.rs
@@ -872,10 +872,10 @@ mod test {
 
     #[test(tokio::test)]
     async fn hash_range_query() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(1),
                 Some("baeabeiazgwnti363jifhxaeaegbluw4ogcd2t5hsjaglo46wuwcgajqa5u"),
             )),
@@ -883,28 +883,27 @@ mod test {
         .await
         .unwrap();
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(2),
                 Some("baeabeihyl35xdlfju3zrkvy2exmnl6wics3rc5ppz7hwg7l7g4brbtnpny"),
             )),
         )
         .await
         .unwrap();
-        let hash =
-            recon::Store::hash_range(&mut store, &random_event_id_min(), &random_event_id_max())
-                .await
-                .unwrap();
+        let hash = recon::Store::hash_range(&store, &random_event_id_min(), &random_event_id_max())
+            .await
+            .unwrap();
         expect!["65C7A25327CC05C19AB5812103EEB8D1156595832B453C7BAC6A186F4811FA0A#2"]
             .assert_eq(&format!("{hash}"));
     }
 
     #[test(tokio::test)]
     async fn range_query() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(1),
                 Some("baeabeichhhmbhsic4maraneqf5gkhekgzcawhtpj3fh6opjtglznapz524"),
             )),
@@ -912,8 +911,8 @@ mod test {
         .await
         .unwrap();
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(2),
                 Some("baeabeibmek7v4ljsu575ohgjhovdxhcw6p6oivgb55hzkeap5po7ghzqty"),
             )),
@@ -921,7 +920,7 @@ mod test {
         .await
         .unwrap();
         let ids = recon::Store::range(
-            &mut store,
+            &store,
             &random_event_id_min(),
             &random_event_id_max(),
             0,
@@ -980,7 +979,7 @@ mod test {
 
     #[test(tokio::test)]
     async fn range_query_with_values() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         // Write three keys, two with values and one without
         let one_id = random_event_id(
             Some(1),
@@ -992,16 +991,16 @@ mod test {
         );
         let (_one_blocks, one_car) = build_car_file(2).await;
         let (_two_blocks, two_car) = build_car_file(3).await;
-        recon::Store::insert(&mut store, ReconItem::new(&one_id, Some(&one_car)))
+        recon::Store::insert(&store, &ReconItem::new(&one_id, Some(&one_car)))
             .await
             .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new(&two_id, Some(&two_car)))
+        recon::Store::insert(&store, &ReconItem::new(&two_id, Some(&two_car)))
             .await
             .unwrap();
         // Insert new event without a value to ensure we skip it in the query
         recon::Store::insert(
-            &mut store,
-            ReconItem::new(
+            &store,
+            &ReconItem::new(
                 &random_event_id(
                     Some(2),
                     Some("baeabeicyxeqioadjgy6v6cpy62a3gngylax54sds7rols2b67yetzaw5r4"),
@@ -1012,7 +1011,7 @@ mod test {
         .await
         .unwrap();
         let values: Vec<(EventId, Vec<u8>)> = recon::Store::range_with_values(
-            &mut store,
+            &store,
             &random_event_id_min(),
             &random_event_id_max(),
             0,
@@ -1027,7 +1026,7 @@ mod test {
 
     #[test(tokio::test)]
     async fn double_insert() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let id = random_event_id(Some(10), None);
 
         // first insert reports its a new key
@@ -1038,7 +1037,7 @@ mod test {
             )
             "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&id)).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new_key(&id)).await);
 
         // second insert of same key reports it already existed
         expect![
@@ -1048,12 +1047,12 @@ mod test {
             )
             "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&id)).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new_key(&id)).await);
     }
 
     #[test(tokio::test)]
     async fn double_insert_with_value() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let id = random_event_id(Some(10), None);
         let (_, car) = build_car_file(2).await;
 
@@ -1067,7 +1066,7 @@ mod test {
             )
             "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, item.clone()).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &item).await);
 
         // the second insert of same key with value reports it already exists.
         // Do not override values
@@ -1076,12 +1075,12 @@ mod test {
                 false,
             )
         "#]]
-        .assert_debug_eq(&recon::Store::insert(&mut store, item).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &item).await);
     }
 
     #[test(tokio::test)]
     async fn update_missing_value() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let id = random_event_id(Some(10), None);
         let (_, car) = build_car_file(2).await;
 
@@ -1096,7 +1095,7 @@ mod test {
             )
             "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, item_without_value).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &item_without_value).await);
 
         // accept the second insert of same key with the value
         expect![[r#"
@@ -1104,15 +1103,15 @@ mod test {
                 false,
             )
         "#]]
-        .assert_debug_eq(&recon::Store::insert(&mut store, item_with_value).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &item_with_value).await);
     }
 
     #[test(tokio::test)]
     async fn first_and_last() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(10),
                 Some("baeabeie2bcird7765t7646jcoatd72tfn2tscdaap7g6kvvy7k43s34aau"),
             )),
@@ -1120,8 +1119,8 @@ mod test {
         .await
         .unwrap();
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_event_id(
+            &store,
+            &ReconItem::new_key(&random_event_id(
                 Some(11),
                 Some("baeabeianftvrst5bja422dod6uf42pmwkwix6rprguanwsxylfut56e3ue"),
             )),
@@ -1131,7 +1130,7 @@ mod test {
 
         // Only one key in range
         let ret = recon::Store::first_and_last(
-            &mut store,
+            &store,
             &event_id_builder().with_event_height(9).build_fencepost(),
             &event_id_builder().with_event_height(11).build_fencepost(),
         )
@@ -1189,7 +1188,7 @@ mod test {
 
         // No keys in range
         let ret = recon::Store::first_and_last(
-            &mut store,
+            &store,
             &event_id_builder().with_event_height(12).build_fencepost(),
             &event_id_builder().with_max_event_height().build_fencepost(),
         )
@@ -1201,13 +1200,10 @@ mod test {
         .assert_debug_eq(&ret);
 
         // Two keys in range
-        let ret = recon::Store::first_and_last(
-            &mut store,
-            &random_event_id_min(),
-            &random_event_id_max(),
-        )
-        .await
-        .unwrap();
+        let ret =
+            recon::Store::first_and_last(&store, &random_event_id_min(), &random_event_id_max())
+                .await
+                .unwrap();
         expect![[r#"
             Some(
                 (
@@ -1261,16 +1257,16 @@ mod test {
 
     #[test(tokio::test)]
     async fn store_value_for_key() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_event_id(None, None);
         let (_, store_value) = build_car_file(3).await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_with_value(&key, store_value.as_slice()),
+            &store,
+            &ReconItem::new_with_value(&key, store_value.as_slice()),
         )
         .await
         .unwrap();
-        let value = recon::Store::value_for_key(&mut store, &key)
+        let value = recon::Store::value_for_key(&store, &key)
             .await
             .unwrap()
             .unwrap();
@@ -1278,16 +1274,16 @@ mod test {
     }
     #[test(tokio::test)]
     async fn keys_with_missing_value() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_event_id(
             Some(4),
             Some("baeabeigc5edwvc47ul6belpxk3lgddipri5hw6f347s6ur4pdzwceprqbu"),
         );
-        recon::Store::insert(&mut store, ReconItem::new(&key, None))
+        recon::Store::insert(&store, &ReconItem::new(&key, None))
             .await
             .unwrap();
         let missing_keys = recon::Store::keys_with_missing_values(
-            &mut store,
+            &store,
             (EventId::min_value(), EventId::max_value()).into(),
         )
         .await
@@ -1320,11 +1316,11 @@ mod test {
         .assert_debug_eq(&missing_keys);
 
         let (_, value) = build_car_file(2).await;
-        recon::Store::insert(&mut store, ReconItem::new(&key, Some(&value)))
+        recon::Store::insert(&store, &ReconItem::new(&key, Some(&value)))
             .await
             .unwrap();
         let missing_keys = recon::Store::keys_with_missing_values(
-            &mut store,
+            &store,
             (EventId::min_value(), EventId::max_value()).into(),
         )
         .await
@@ -1337,16 +1333,16 @@ mod test {
 
     #[test(tokio::test)]
     async fn read_value_as_block() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_event_id(None, None);
         let (blocks, store_value) = build_car_file(3).await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_with_value(&key, store_value.as_slice()),
+            &store,
+            &ReconItem::new_with_value(&key, store_value.as_slice()),
         )
         .await
         .unwrap();
-        let value = recon::Store::value_for_key(&mut store, &key)
+        let value = recon::Store::value_for_key(&store, &key)
             .await
             .unwrap()
             .unwrap();
@@ -1362,7 +1358,7 @@ mod test {
     // stores 3 keys with 3,5,10 block long CAR files
     // each one takes n+1 blocks as it needs to store the root and all blocks so we expect 3+5+10+3=21 blocks
     // but we use a delivered integer per event, so we expect it to increment by 1 for each event
-    async fn prep_highwater_tests(store: &mut EventStore<Sha256a>) -> (EventId, EventId, EventId) {
+    async fn prep_highwater_tests(store: &SqliteEventStore) -> (EventId, EventId, EventId) {
         let key_a = random_event_id(None, None);
         let key_b = random_event_id(None, None);
         let key_c = random_event_id(None, None);
@@ -1371,7 +1367,7 @@ mod test {
             assert_eq!(_blocks.len(), x);
             recon::Store::insert(
                 store,
-                ReconItem::new_with_value(key, store_value.as_slice()),
+                &ReconItem::new_with_value(key, store_value.as_slice()),
             )
             .await
             .unwrap();
@@ -1382,8 +1378,8 @@ mod test {
 
     #[test(tokio::test)]
     async fn keys_since_highwater_mark_all_global_counter() {
-        let mut store1 = new_store().await;
-        let (key_a, key_b, key_c) = prep_highwater_tests(&mut store1).await;
+        let store1 = new_store().await;
+        let (key_a, key_b, key_c) = prep_highwater_tests(&store1).await;
 
         let (hw, res) = store1.new_keys_since_value(0, 10).await.unwrap();
         assert_eq!(3, res.len());
@@ -1391,9 +1387,9 @@ mod test {
         let exp = [key_a.clone(), key_b.clone(), key_c.clone()];
         assert_eq!(exp, res.as_slice());
         drop(store1);
-        let mut store2 = new_store().await;
+        let store2 = new_store().await;
 
-        let (key1_a, key1_b, key1_c) = prep_highwater_tests(&mut store2).await;
+        let (key1_a, key1_b, key1_c) = prep_highwater_tests(&store2).await;
         let (hw, res) = store2.new_keys_since_value(0, 10).await.unwrap();
         assert_eq!(3, res.len());
         assert!(hw > 6); // THIS IS GLOBAL COUNTER. 3 rows in db, counter 7 or more depending on how many other tests are running
@@ -1403,8 +1399,8 @@ mod test {
 
     #[test(tokio::test)]
     async fn keys_since_highwater_mark_limit_1() {
-        let mut store: EventStore<Sha256a> = new_local_store().await;
-        let (key_a, _key_b, _key_c) = prep_highwater_tests(&mut store).await;
+        let store = new_local_store().await;
+        let (key_a, _key_b, _key_c) = prep_highwater_tests(&store).await;
 
         let (hw, res) = store.new_keys_since_value(0, 1).await.unwrap();
         assert_eq!(1, res.len());
@@ -1414,8 +1410,8 @@ mod test {
 
     #[test(tokio::test)]
     async fn keys_since_highwater_mark_middle_start() {
-        let mut store: EventStore<Sha256a> = new_local_store().await;
-        let (key_a, key_b, key_c) = prep_highwater_tests(&mut store).await;
+        let store = new_local_store().await;
+        let (key_a, key_b, key_c) = prep_highwater_tests(&store).await;
 
         // starting at rowid 1 which is in the middle of key A should still return key A
         let (hw, res) = store.new_keys_since_value(1, 2).await.unwrap();

--- a/store/src/sql/event.rs
+++ b/store/src/sql/event.rs
@@ -496,7 +496,7 @@ impl recon::Store for SqliteEventStore {
 
     /// Returns true if the key was new. The value is always updated if included
     async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
-        let (new, _new_val) = self.insert_item(&item).await?;
+        let (new, _new_val) = self.insert_item(item).await?;
         Ok(new)
     }
 
@@ -511,7 +511,7 @@ impl recon::Store for SqliteEventStore {
                 let mut tx = self.pool.writer().begin().await?;
 
                 for (idx, item) in items.iter().enumerate() {
-                    let (new_key, new_val) = self.insert_item_int(&item, &mut tx).await?;
+                    let (new_key, new_val) = self.insert_item_int(item, &mut tx).await?;
                     results[idx] = new_key;
                     if new_val {
                         new_val_cnt += 1;
@@ -837,12 +837,12 @@ impl ceramic_api::AccessModelStore for SqliteEventStore {
         limit: usize,
     ) -> Result<Vec<(EventId, Vec<u8>)>> {
         let res = self
-            .range_with_values_int(&start, &end, offset, limit)
+            .range_with_values_int(start, end, offset, limit)
             .await?;
         Ok(res.collect())
     }
     async fn value_for_key(&self, key: &EventId) -> Result<Option<Vec<u8>>> {
-        self.value_for_key_int(&key).await
+        self.value_for_key_int(key).await
     }
 
     async fn keys_since_highwater_mark(

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -137,7 +137,7 @@ impl ceramic_api::AccessInterestStore for SqliteInterestStore {
         offset: usize,
         limit: usize,
     ) -> Result<Vec<Interest>> {
-        Ok(self.range_int(&start, &end, offset, limit).await?.collect())
+        Ok(self.range_int(start, end, offset, limit).await?.collect())
     }
 }
 

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -161,7 +161,7 @@ impl recon::Store for SqliteInterestStore {
 
     /// Insert new keys into the key space.
     /// Returns true if a key did not previously exist.
-    async fn insert_many(&self, items: &Vec<ReconItem<'_, Interest>>) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, Interest>]) -> Result<InsertResult> {
         match items.len() {
             0 => Ok(InsertResult::new(vec![], 0)),
             _ => {

--- a/store/src/sql/interest.rs
+++ b/store/src/sql/interest.rs
@@ -415,7 +415,7 @@ mod interest_tests {
         PeerId,
     };
     use rand::{thread_rng, Rng};
-    use recon::{AssociativeHash, Key, ReconItem, Sha256a, Store};
+    use recon::{AssociativeHash, Key, ReconItem, Store};
 
     use expect_test::expect;
     use test_log::test;
@@ -485,16 +485,16 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_hash_range_query() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(42))),
+            &store,
+            &ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(42))),
         )
         .await
         .unwrap();
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(24))),
+            &store,
+            &ReconItem::new_key(&random_interest(Some((&[0], &[1])), Some(24))),
         )
         .await
         .unwrap();
@@ -508,17 +508,17 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_range_query() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let interest_0 = random_interest(None, None);
         let interest_1 = random_interest(None, None);
-        recon::Store::insert(&mut store, ReconItem::new_key(&interest_0))
+        recon::Store::insert(&store, &ReconItem::new_key(&interest_0))
             .await
             .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new_key(&interest_1))
+        recon::Store::insert(&store, &ReconItem::new_key(&interest_1))
             .await
             .unwrap();
         let ids = recon::Store::range(
-            &mut store,
+            &store,
             &random_interest_min(),
             &random_interest_max(),
             0,
@@ -559,7 +559,7 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_double_insert() {
-        let mut store = new_store().await;
+        let store = new_store().await;
 
         let interest = random_interest(None, None);
         // do take the first one
@@ -570,7 +570,7 @@ mod interest_tests {
         )
         "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&interest)).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new_key(&interest)).await);
 
         // reject the second insert of same key
         expect![
@@ -580,18 +580,18 @@ mod interest_tests {
         )
         "#
         ]
-        .assert_debug_eq(&recon::Store::insert(&mut store, ReconItem::new_key(&interest)).await);
+        .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new_key(&interest)).await);
     }
 
     #[test(tokio::test)]
     async fn test_first_and_last() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let interest_0 = random_interest(Some((&[], &[])), Some(42));
         let interest_1 = random_interest(Some((&[], &[])), Some(43));
-        recon::Store::insert(&mut store, ReconItem::new_key(&interest_0))
+        recon::Store::insert(&store, &ReconItem::new_key(&interest_0))
             .await
             .unwrap();
-        recon::Store::insert(&mut store, ReconItem::new_key(&interest_1))
+        recon::Store::insert(&store, &ReconItem::new_key(&interest_1))
             .await
             .unwrap();
 
@@ -724,12 +724,12 @@ mod interest_tests {
     #[test(tokio::test)]
     #[should_panic(expected = "Interests do not support values! Invalid request.")]
     async fn test_store_value_for_key_error() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_interest(None, None);
         let store_value = random_interest(None, None);
         recon::Store::insert(
-            &mut store,
-            ReconItem::new_with_value(&key, store_value.as_slice()),
+            &store,
+            &ReconItem::new_with_value(&key, store_value.as_slice()),
         )
         .await
         .unwrap();
@@ -737,9 +737,9 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_keys_with_missing_value() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_interest(None, None);
-        recon::Store::insert(&mut store, ReconItem::new(&key, None))
+        recon::Store::insert(&store, &ReconItem::new(&key, None))
             .await
             .unwrap();
         let missing_keys = store
@@ -751,7 +751,7 @@ mod interest_tests {
         "#]]
         .assert_debug_eq(&missing_keys);
 
-        recon::Store::insert(&mut store, ReconItem::new(&key, Some(&[])))
+        recon::Store::insert(&store, &ReconItem::new(&key, Some(&[])))
             .await
             .unwrap();
         let missing_keys = store
@@ -766,9 +766,9 @@ mod interest_tests {
 
     #[test(tokio::test)]
     async fn test_value_for_key() {
-        let mut store = new_store().await;
+        let store = new_store().await;
         let key = random_interest(None, None);
-        recon::Store::insert(&mut store, ReconItem::new(&key, None))
+        recon::Store::insert(&store, &ReconItem::new(&key, None))
             .await
             .unwrap();
         let value = store.value_for_key(&key).await.unwrap();

--- a/store/src/sql/mod.rs
+++ b/store/src/sql/mod.rs
@@ -2,8 +2,8 @@ mod event;
 mod interest;
 mod root;
 
-pub use event::EventStore;
-pub use interest::InterestStore;
+pub use event::SqliteEventStore;
+pub use interest::SqliteInterestStore;
 pub use root::RootStore;
 
 use chrono::{SecondsFormat, Utc};

--- a/store/src/tests.rs
+++ b/store/src/tests.rs
@@ -1,4 +1,4 @@
-use self::EventStore;
+use self::SqliteEventStore;
 
 use super::*;
 
@@ -16,17 +16,16 @@ use libipld::{ipld, prelude::Encode, Ipld};
 use libipld_cbor::DagCborCodec;
 use multihash::{Code, MultihashDigest};
 use rand::Rng;
-use recon::Sha256a;
 
-pub(crate) async fn new_store() -> EventStore<Sha256a> {
+pub(crate) async fn new_store() -> SqliteEventStore {
     let conn = SqlitePool::connect_in_memory().await.unwrap();
-    EventStore::new(conn).await.unwrap()
+    SqliteEventStore::new(conn).await.unwrap()
 }
 
 // for the highwater tests that care about event ordering
-pub(crate) async fn new_local_store() -> EventStore<Sha256a> {
+pub(crate) async fn new_local_store() -> SqliteEventStore {
     let conn = SqlitePool::connect_in_memory().await.unwrap();
-    EventStore::new_local(conn).await.unwrap()
+    SqliteEventStore::new_local(conn).await.unwrap()
 }
 
 #[tokio::test]


### PR DESCRIPTION
Adjusts types so that they may be used from a dynamic context, which allows other database implementations to be provided. Additionally types no longer require clone, but instead use arc as needed for clone.