### PR TITLE
chore: don't hang the executor

### DIFF
--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -38,7 +38,7 @@ pub const AGENT_VERSION: &str = concat!("ceramic-one/", env!("CARGO_PKG_VERSION"
 #[behaviour(to_swarm = "Event")]
 pub(crate) struct NodeBehaviour<I, M, S>
 where
-    S: iroh_bitswap::Store,
+    S: iroh_bitswap::Store + Send + Sync,
 {
     // Place limits first in the behaviour tree.
     // Behaviours are called in order and the limits behaviour can deny connections etc.
@@ -61,9 +61,9 @@ where
 
 impl<I, M, S> NodeBehaviour<I, M, S>
 where
-    I: Recon<Key = Interest, Hash = Sha256a>,
-    M: Recon<Key = EventId, Hash = Sha256a>,
-    S: iroh_bitswap::Store,
+    I: Recon<Key = Interest, Hash = Sha256a> + Send + Sync,
+    M: Recon<Key = EventId, Hash = Sha256a> + Send + Sync,
+    S: iroh_bitswap::Store + Send + Sync,
 {
     pub async fn new(
         local_key: &Keypair,
@@ -206,8 +206,9 @@ where
     pub fn notify_new_blocks(&self, blocks: Vec<Block>) {
         if let Some(bs) = self.bitswap.as_ref() {
             let client = bs.client().clone();
-            tokio::task::spawn(async move {
-                if let Err(err) = client.notify_new_blocks(&blocks).await {
+            let handle = tokio::runtime::Handle::current();
+            tokio::task::block_in_place(move || {
+                if let Err(err) = handle.block_on(client.notify_new_blocks(&blocks)) {
                     warn!("failed to notify bitswap about blocks: {:?}", err);
                 }
             });

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use ceramic_core::{EventId, Interest};
-use libp2p::{noise, relay, swarm::Executor, tcp, tls, yamux, Swarm, SwarmBuilder};
+use libp2p::{noise, relay, tcp, tls, yamux, Swarm, SwarmBuilder};
 use libp2p_identity::Keypair;
 use recon::{libp2p::Recon, Sha256a};
 use std::sync::Arc;
@@ -83,27 +83,14 @@ where
     M: Recon<Key = EventId, Hash = Sha256a> + Send,
     S: iroh_bitswap::Store,
 {
-    // TODO(WS1-1363): Remove bitswap async initialization
     let keypair = keypair.clone();
     let config = config.clone();
-    let handle = tokio::runtime::Handle::current();
-    std::thread::spawn(move || {
-        handle.block_on(NodeBehaviour::new(
-            &keypair,
-            &config,
-            relay_client,
-            recons,
-            block_store,
-            metrics,
-        ))
-    })
-    .join()
-    .unwrap()
-}
-
-struct Tokio;
-impl Executor for Tokio {
-    fn exec(&self, fut: std::pin::Pin<Box<dyn futures::Future<Output = ()> + Send>>) {
-        tokio::task::spawn(fut);
-    }
+    tokio::runtime::Handle::current().block_on(NodeBehaviour::new(
+        &keypair,
+        &config,
+        relay_client,
+        recons,
+        block_store,
+        metrics,
+    ))
 }

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -85,12 +85,17 @@ where
 {
     let keypair = keypair.clone();
     let config = config.clone();
-    tokio::runtime::Handle::current().block_on(NodeBehaviour::new(
-        &keypair,
-        &config,
-        relay_client,
-        recons,
-        block_store,
-        metrics,
-    ))
+    let handle = tokio::runtime::Handle::current();
+    std::thread::spawn(move || {
+        handle.block_on(NodeBehaviour::new(
+            &keypair,
+            &config,
+            relay_client,
+            recons,
+            block_store,
+            metrics,
+        ))
+    })
+    .join()
+    .unwrap()
 }


### PR DESCRIPTION
Remove uses of std::thread and ensure the p2p poller is appropriately tied to a waker.