### PR TITLE
chore: add debug image builds

### DIFF
--- a/.github/workflows/cd-to-infra.yml
+++ b/.github/workflows/cd-to-infra.yml
@@ -52,10 +52,11 @@ jobs:
         else
           TAG_LATEST=false
         fi
-        make SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
+        make BUILD_MODE=release SHA="${{ github.SHA }}" SHA_TAG="$SHA_TAG" RELEASE_TAG="$RELEASE_TAG" TAG_LATEST="$TAG_LATEST" publish-docker
+        make BUILD_MODE=debug SHA="${{ github.SHA }}-debug" SHA_TAG="$SHA_TAG-debug" RELEASE_TAG="$RELEASE_TAG-debug" TAG_LATEST="$TAG_LATEST-debug" publish-docker
         echo "Deploy tag:"
-        echo ${DEPLOY_TAG}
-        echo "deploy_tag=${DEPLOY_TAG}" >> $GITHUB_OUTPUT
+        echo "${DEPLOY_TAG}-debug"
+        echo "deploy_tag=${DEPLOY_TAG}-debug" >> $GITHUB_OUTPUT
 
   deploy:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -66,14 +66,14 @@ check-queries-ci:
 release:
 	$(CARGO) build -p ceramic-one --locked --release
 
+.PHONY: debug
+debug:
+	$(CARGO) build -p ceramic-one --locked --features tokio-console
+
 # Prepare a release PR.
 .PHONY: release-pr
 release-pr:
 	./ci-scripts/release_pr.sh ${RELEASE_LEVEL}
-
-.PHONY: debug
-debug:
-	$(CARGO) build -p ceramic-one --locked
 
 .PHONY: test
 test:

--- a/ci-scripts/publish.sh
+++ b/ci-scripts/publish.sh
@@ -10,7 +10,9 @@
 #
 # to login to docker. That password will be valid for 12h.
 
-docker buildx build --load -t 3box/ceramic-one .
+BUILD_MODE=${BUILD_MODE-release}
+
+docker buildx build --load --build-arg="BUILD_MODE=$BUILD_MODE" -t 3box/ceramic-one .
 
 if [[ -n "$SHA" ]]; then
   docker tag 3box/ceramic-one:latest public.ecr.aws/r5b3e0r5/3box/ceramic-one:"$SHA"


### PR DESCRIPTION
This change builds two images a release and debug build. The same tags for the debug build are used as the release build with the addition of a `-debug` suffix. This also changes the deploy code to deploy the debug builds to infra. We can revert that change or parameterize it later. 