### PR TITLE
chore: add variants for error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6696,6 +6696,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "test-log",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,7 @@ dependencies = [
  "recon",
  "sqlx",
  "test-log",
+ "thiserror",
  "tmpdir",
  "tokio",
  "tracing",

--- a/one/src/events.rs
+++ b/one/src/events.rs
@@ -405,7 +405,7 @@ async fn migrate_from_database(input_ceramic_db: PathBuf, store: SqliteEventStor
         Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
         input_ceramic_db_filename
     );
-    result
+    Ok(result?)
 }
 
 #[cfg(test)]

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1169,7 +1169,7 @@ mod tests {
     use futures::TryStreamExt;
     use rand::prelude::*;
     use rand_chacha::ChaCha8Rng;
-    use recon::{Range, Sha256a, SyncState};
+    use recon::{Range, Result as ReconResult, Sha256a, SyncState};
     use ssh_key::private::Ed25519Keypair;
 
     use libp2p::{identity::Keypair as Libp2pKeypair, kad::RecordKey};
@@ -1251,7 +1251,7 @@ mod tests {
         type Key = K;
         type Hash = Sha256a;
 
-        async fn insert(&self, _key: Self::Key, _value: Option<Vec<u8>>) -> Result<()> {
+        async fn insert(&self, _key: Self::Key, _value: Option<Vec<u8>>) -> ReconResult<()> {
             unreachable!()
         }
 
@@ -1261,45 +1261,45 @@ mod tests {
             _right_fencepost: Self::Key,
             _offset: usize,
             _limit: usize,
-        ) -> Result<Vec<Self::Key>> {
+        ) -> ReconResult<Vec<Self::Key>> {
             unreachable!()
         }
 
-        async fn len(&self) -> Result<usize> {
+        async fn len(&self) -> ReconResult<usize> {
             unreachable!()
         }
 
-        async fn value_for_key(&self, _key: Self::Key) -> Result<Option<Vec<u8>>> {
+        async fn value_for_key(&self, _key: Self::Key) -> ReconResult<Option<Vec<u8>>> {
             Ok(None)
         }
         async fn keys_with_missing_values(
             &self,
             _range: RangeOpen<Self::Key>,
-        ) -> Result<Vec<Self::Key>> {
+        ) -> ReconResult<Vec<Self::Key>> {
             unreachable!()
         }
-        async fn interests(&self) -> Result<Vec<RangeOpen<Self::Key>>> {
+        async fn interests(&self) -> ReconResult<Vec<RangeOpen<Self::Key>>> {
             unreachable!()
         }
 
         async fn process_interests(
             &self,
             _interests: Vec<RangeOpen<Self::Key>>,
-        ) -> Result<Vec<RangeOpen<Self::Key>>> {
+        ) -> ReconResult<Vec<RangeOpen<Self::Key>>> {
             unreachable!()
         }
 
         async fn initial_range(
             &self,
             _interest: RangeOpen<Self::Key>,
-        ) -> Result<Range<Self::Key, Self::Hash>> {
+        ) -> ReconResult<Range<Self::Key, Self::Hash>> {
             unreachable!()
         }
 
         async fn process_range(
             &self,
             _range: Range<Self::Key, Self::Hash>,
-        ) -> Result<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)> {
+        ) -> ReconResult<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)> {
             unreachable!()
         }
 

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -22,6 +22,7 @@ multihash.workspace = true
 prometheus-client.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 uuid = { version = "1.8.0", features = ["v4"] }

--- a/recon/src/error.rs
+++ b/recon/src/error.rs
@@ -1,0 +1,77 @@
+use anyhow::anyhow;
+
+#[derive(Debug, thiserror::Error)]
+/// The Errors that can be raised by store operations
+pub enum Error {
+    #[error("Application error encountered: {error}")]
+    /// An application specific error that may be resolved with different inputs or other changes
+    Application {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+    #[error("Fatal error encountered: {error}")]
+    /// A fatal error that is unlikely to be recoverable, and may require terminating the process completely
+    Fatal {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+    #[error("Transient error encountered: {error}")]
+    /// An error that can be retried, and may resolve itself. If an error is transient repeatedly, it should be
+    /// considered an "application" level error and propagated upward.
+    Transient {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+}
+
+impl Error {
+    /// Create a transient error
+    pub fn new_transient(error: impl Into<anyhow::Error>) -> Self {
+        Self::Transient {
+            error: error.into(),
+        }
+    }
+    /// Create a fatal error
+    pub fn new_fatal(error: impl Into<anyhow::Error>) -> Self {
+        Self::Fatal {
+            error: error.into(),
+        }
+    }
+
+    /// Create an application error
+    pub fn new_app(error: impl Into<anyhow::Error>) -> Self {
+        Self::Application {
+            error: error.into(),
+        }
+    }
+
+    /// Add context to the internal error. Works identically to `anyhow::context`
+    pub fn context<C>(self, context: C) -> Self
+    where
+        C: std::fmt::Display + Send + Sync + 'static,
+    {
+        match self {
+            Error::Application { error } => Self::Application {
+                error: error.context(context),
+            },
+            Error::Fatal { error } => Self::Fatal {
+                error: error.context(context),
+            },
+            Error::Transient { error } => Self::Transient {
+                error: error.context(context),
+            },
+        }
+    }
+}
+
+impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
+    fn from(value: tokio::sync::mpsc::error::SendError<T>) -> Self {
+        Self::new_fatal(anyhow!(value.to_string()).context("Unable to send to recon server"))
+    }
+}
+
+impl From<tokio::sync::oneshot::error::RecvError> for Error {
+    fn from(value: tokio::sync::oneshot::error::RecvError) -> Self {
+        Self::new_fatal(anyhow!(value.to_string()).context("No response from recon server"))
+    }
+}

--- a/recon/src/lib.rs
+++ b/recon/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub use crate::{
     client::{Client, Server},
+    error::Error,
     metrics::Metrics,
     recon::{
         btreestore::BTreeStore, AssociativeHash, EventIdStore, FullInterests, HashCount,
@@ -13,6 +14,7 @@ pub use crate::{
 };
 
 mod client;
+mod error;
 pub mod libp2p;
 mod metrics;
 pub mod protocol;
@@ -21,3 +23,6 @@ mod sha256a;
 
 #[cfg(test)]
 mod tests;
+
+/// A result type that wraps a recon Error
+pub type Result<T> = std::result::Result<T, Error>;

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -1,18 +1,15 @@
-use std::sync::{atomic::AtomicBool, Arc};
+use crate::{
+    libp2p::{stream_set::StreamSet, PeerEvent, PeerStatus},
+    AssociativeHash, BTreeStore, Error, FullInterests, HashCount, InsertResult, InterestProvider,
+    Key, Metrics, Recon, ReconItem, Result as ReconResult, Server, Store,
+};
 
-use anyhow::{bail, Result};
 use async_trait::async_trait;
 use ceramic_core::RangeOpen;
 use ceramic_metrics::init_local_tracing;
 use libp2p::{metrics::Registry, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
 use tracing::info;
-
-use crate::{
-    libp2p::{stream_set::StreamSet, PeerEvent, PeerStatus},
-    AssociativeHash, BTreeStore, FullInterests, HashCount, InsertResult, InterestProvider, Key,
-    Metrics, Recon, ReconItem, Server, Store,
-};
 
 fn start_recon<K, H, S, I>(recon: Recon<K, H, S, I>) -> crate::Client<K, H>
 where
@@ -28,16 +25,33 @@ where
 }
 
 /// An implementation of a Store that stores keys in an in-memory BTree and throws errors if desired.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct BTreeStoreErrors<K, H> {
-    should_error: Arc<AtomicBool>,
+    error: Option<Error>,
     inner: BTreeStore<K, H>,
 }
 
 impl<K, H> BTreeStoreErrors<K, H> {
-    fn set_error(&self, should_error: bool) {
-        self.should_error
-            .store(should_error, std::sync::atomic::Ordering::SeqCst);
+    fn set_error(&mut self, error: Error) {
+        self.error = Some(error);
+    }
+
+    fn return_error(&self) -> Result<(), Error> {
+        if let Some(err) = &self.error {
+            match err {
+                Error::Application { error } => Err(Error::Application {
+                    error: anyhow::anyhow!(error.to_string()),
+                }),
+                Error::Fatal { error } => Err(Error::Fatal {
+                    error: anyhow::anyhow!(error.to_string()),
+                }),
+                Error::Transient { error } => Err(Error::Transient {
+                    error: anyhow::anyhow!(error.to_string()),
+                }),
+            }
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -45,7 +59,7 @@ impl<K, H> Default for BTreeStoreErrors<K, H> {
     /// By default no errors are thrown. Use set_error to change this.
     fn default() -> Self {
         Self {
-            should_error: Arc::new(AtomicBool::new(false)),
+            error: None,
             inner: BTreeStore::default(),
         }
     }
@@ -60,32 +74,26 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: insert")
-        } else {
-            self.inner.insert(item).await
-        }
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> ReconResult<bool> {
+        self.return_error()?;
+
+        self.inner.insert(item).await
     }
 
-    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> Result<InsertResult> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: insert_many")
-        } else {
-            self.inner.insert_many(items).await
-        }
+    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> ReconResult<InsertResult> {
+        self.return_error()?;
+
+        self.inner.insert_many(items).await
     }
 
     async fn hash_range(
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> anyhow::Result<HashCount<Self::Hash>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: hash_range")
-        } else {
-            self.inner.hash_range(left_fencepost, right_fencepost).await
-        }
+    ) -> ReconResult<HashCount<Self::Hash>> {
+        self.return_error()?;
+
+        self.inner.hash_range(left_fencepost, right_fencepost).await
     }
 
     async fn range(
@@ -94,14 +102,12 @@ where
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: range")
-        } else {
-            self.inner
-                .range(left_fencepost, right_fencepost, offset, limit)
-                .await
-        }
+    ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+        self.return_error()?;
+
+        self.inner
+            .range(left_fencepost, right_fencepost, offset, limit)
+            .await
     }
     async fn range_with_values(
         &self,
@@ -109,58 +115,48 @@ where
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: range_with_values")
-        } else {
-            self.inner
-                .range_with_values(left_fencepost, right_fencepost, offset, limit)
-                .await
-        }
+    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
+        self.return_error()?;
+
+        self.inner
+            .range_with_values(left_fencepost, right_fencepost, offset, limit)
+            .await
     }
 
     async fn last(
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: last")
-        } else {
-            self.inner.last(left_fencepost, right_fencepost).await
-        }
+    ) -> ReconResult<Option<Self::Key>> {
+        self.return_error()?;
+
+        self.inner.last(left_fencepost, right_fencepost).await
     }
 
     async fn first_and_last(
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<(Self::Key, Self::Key)>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: first_and_last")
-        } else {
-            self.inner
-                .first_and_last(left_fencepost, right_fencepost)
-                .await
-        }
+    ) -> ReconResult<Option<(Self::Key, Self::Key)>> {
+        self.return_error()?;
+
+        self.inner
+            .first_and_last(left_fencepost, right_fencepost)
+            .await
     }
 
-    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: value_for_key")
-        } else {
-            self.inner.value_for_key(key).await
-        }
+    async fn value_for_key(&self, key: &Self::Key) -> ReconResult<Option<Vec<u8>>> {
+        self.return_error()?;
+
+        self.inner.value_for_key(key).await
     }
     async fn keys_with_missing_values(
         &self,
         range: RangeOpen<Self::Key>,
-    ) -> Result<Vec<Self::Key>> {
-        if self.should_error.load(std::sync::atomic::Ordering::SeqCst) {
-            bail!("Sorry, bad tree returns errors: keys_with_missing_values")
-        } else {
-            self.inner.keys_with_missing_values(range).await
-        }
+    ) -> ReconResult<Vec<Self::Key>> {
+        self.return_error()?;
+
+        self.inner.keys_with_missing_values(range).await
     }
 }
 
@@ -247,10 +243,12 @@ async fn in_sync_no_overlap() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn initiator_model_error() {
-    let alice_model_store = BTreeStoreErrors::default();
-    alice_model_store.set_error(true);
+    let mut alice_model_store = BTreeStoreErrors::default();
+    alice_model_store.set_error(Error::new_transient(anyhow::anyhow!(
+        "transient error should be handled"
+    )));
     let (mut swarm1, mut swarm2) = setup_test!(
-        alice_model_store.clone(),
+        alice_model_store,
         BTreeStoreErrors::default(),
         BTreeStoreErrors::default(),
         BTreeStoreErrors::default(),
@@ -284,12 +282,14 @@ async fn initiator_model_error() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn responder_model_error() {
-    let bob_model_store = BTreeStoreErrors::default();
-    bob_model_store.set_error(true);
+    let mut bob_model_store = BTreeStoreErrors::default();
+    bob_model_store.set_error(Error::new_transient(anyhow::anyhow!(
+        "transient error should be handled"
+    )));
     let (mut swarm1, mut swarm2) = setup_test!(
         BTreeStoreErrors::default(),
         BTreeStoreErrors::default(),
-        bob_model_store.clone(),
+        bob_model_store,
         BTreeStoreErrors::default(),
     );
 

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -36,7 +36,7 @@ impl<K, H> BTreeStoreErrors<K, H> {
         self.error = Some(error);
     }
 
-    fn return_error(&self) -> Result<(), Error> {
+    fn as_error(&self) -> Result<(), Error> {
         if let Some(err) = &self.error {
             match err {
                 Error::Application { error } => Err(Error::Application {
@@ -75,13 +75,13 @@ where
     type Hash = H;
 
     async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> ReconResult<bool> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.insert(item).await
     }
 
     async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> ReconResult<InsertResult> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.insert_many(items).await
     }
@@ -91,7 +91,7 @@ where
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> ReconResult<HashCount<Self::Hash>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.hash_range(left_fencepost, right_fencepost).await
     }
@@ -103,7 +103,7 @@ where
         offset: usize,
         limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner
             .range(left_fencepost, right_fencepost, offset, limit)
@@ -116,7 +116,7 @@ where
         offset: usize,
         limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner
             .range_with_values(left_fencepost, right_fencepost, offset, limit)
@@ -128,7 +128,7 @@ where
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> ReconResult<Option<Self::Key>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.last(left_fencepost, right_fencepost).await
     }
@@ -138,7 +138,7 @@ where
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
     ) -> ReconResult<Option<(Self::Key, Self::Key)>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner
             .first_and_last(left_fencepost, right_fencepost)
@@ -146,7 +146,7 @@ where
     }
 
     async fn value_for_key(&self, key: &Self::Key) -> ReconResult<Option<Vec<u8>>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.value_for_key(key).await
     }
@@ -154,7 +154,7 @@ where
         &self,
         range: RangeOpen<Self::Key>,
     ) -> ReconResult<Vec<Self::Key>> {
-        self.return_error()?;
+        self.as_error()?;
 
         self.inner.keys_with_missing_values(range).await
     }

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -32,7 +32,7 @@ use crate::{
         RangeEnqueueFailed, RangeEnqueued, WantDequeued, WantEnqueueFailed, WantEnqueued,
     },
     recon::{Range, SyncState},
-    AssociativeHash, Client, Key,
+    AssociativeHash, Client, Key, Result as ReconResult,
 };
 
 // Number of want value requests to buffer.
@@ -971,7 +971,7 @@ pub trait Recon: Clone + Send + Sync + 'static {
     type Hash: AssociativeHash + std::fmt::Debug + Serialize + for<'de> Deserialize<'de>;
 
     /// Insert a new key into the key space.
-    async fn insert(&self, key: Self::Key, value: Option<Vec<u8>>) -> Result<()>;
+    async fn insert(&self, key: Self::Key, value: Option<Vec<u8>>) -> ReconResult<()>;
 
     /// Get all keys in the specified range
     async fn range(
@@ -980,43 +980,45 @@ pub trait Recon: Clone + Send + Sync + 'static {
         right_fencepost: Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<Self::Key>>;
+    ) -> ReconResult<Vec<Self::Key>>;
 
     /// Reports total number of keys
-    async fn len(&self) -> Result<usize>;
+    async fn len(&self) -> ReconResult<usize>;
 
     /// Reports if the set is empty.
-    async fn is_empty(&self) -> Result<bool> {
+    async fn is_empty(&self) -> ReconResult<bool> {
         Ok(self.len().await? == 0)
     }
 
     /// Retrieve a value associated with a recon key
-    async fn value_for_key(&self, key: Self::Key) -> Result<Option<Vec<u8>>>;
+    async fn value_for_key(&self, key: Self::Key) -> ReconResult<Option<Vec<u8>>>;
 
     /// Report all keys in the range that are missing a value
-    async fn keys_with_missing_values(&self, range: RangeOpen<Self::Key>)
-        -> Result<Vec<Self::Key>>;
+    async fn keys_with_missing_values(
+        &self,
+        range: RangeOpen<Self::Key>,
+    ) -> ReconResult<Vec<Self::Key>>;
 
     /// Reports the interests of this recon instance
-    async fn interests(&self) -> Result<Vec<RangeOpen<Self::Key>>>;
+    async fn interests(&self) -> ReconResult<Vec<RangeOpen<Self::Key>>>;
 
     /// Computes the intersection of input interests with the local interests
     async fn process_interests(
         &self,
         interests: Vec<RangeOpen<Self::Key>>,
-    ) -> Result<Vec<RangeOpen<Self::Key>>>;
+    ) -> ReconResult<Vec<RangeOpen<Self::Key>>>;
 
     /// Compute an initial hash for the range
     async fn initial_range(
         &self,
         interest: RangeOpen<Self::Key>,
-    ) -> Result<Range<Self::Key, Self::Hash>>;
+    ) -> ReconResult<Range<Self::Key, Self::Hash>>;
 
     /// Computes a response to a remote range
     async fn process_range(
         &self,
         range: Range<Self::Key, Self::Hash>,
-    ) -> Result<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)>;
+    ) -> ReconResult<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)>;
 
     /// Create a handle to the metrics
     fn metrics(&self) -> Metrics;
@@ -1031,7 +1033,7 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&self, key: Self::Key, value: Option<Vec<u8>>) -> Result<()> {
+    async fn insert(&self, key: Self::Key, value: Option<Vec<u8>>) -> ReconResult<()> {
         let _ = Client::insert(self, key, value).await?;
         Ok(())
     }
@@ -1042,7 +1044,7 @@ where
         right_fencepost: Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<Self::Key>> {
+    ) -> ReconResult<Vec<Self::Key>> {
         Ok(
             Client::range(self, left_fencepost, right_fencepost, offset, limit)
                 .await?
@@ -1050,40 +1052,40 @@ where
         )
     }
 
-    async fn len(&self) -> Result<usize> {
+    async fn len(&self) -> ReconResult<usize> {
         Client::len(self).await
     }
 
-    async fn value_for_key(&self, key: Self::Key) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, key: Self::Key) -> ReconResult<Option<Vec<u8>>> {
         Client::value_for_key(self, key).await
     }
     async fn keys_with_missing_values(
         &self,
         range: RangeOpen<Self::Key>,
-    ) -> Result<Vec<Self::Key>> {
+    ) -> ReconResult<Vec<Self::Key>> {
         Client::keys_with_missing_values(self, range).await
     }
-    async fn interests(&self) -> Result<Vec<RangeOpen<Self::Key>>> {
+    async fn interests(&self) -> ReconResult<Vec<RangeOpen<Self::Key>>> {
         Client::interests(self).await
     }
     async fn process_interests(
         &self,
         interests: Vec<RangeOpen<Self::Key>>,
-    ) -> Result<Vec<RangeOpen<Self::Key>>> {
+    ) -> ReconResult<Vec<RangeOpen<Self::Key>>> {
         Client::process_interests(self, interests).await
     }
 
     async fn initial_range(
         &self,
         interest: RangeOpen<Self::Key>,
-    ) -> Result<Range<Self::Key, Self::Hash>> {
+    ) -> ReconResult<Range<Self::Key, Self::Hash>> {
         Client::initial_range(self, interest).await
     }
 
     async fn process_range(
         &self,
         range: Range<Self::Key, Self::Hash>,
-    ) -> Result<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)> {
+    ) -> ReconResult<(SyncState<Self::Key, Self::Hash>, Vec<Self::Key>)> {
         Client::process_range(self, range).await
     }
     fn metrics(&self) -> Metrics {

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -1,12 +1,12 @@
-use anyhow::Result;
 use async_trait::async_trait;
 use ceramic_core::RangeOpen;
 use std::{collections::BTreeMap, ops::Bound, sync::Arc};
 use tokio::sync::Mutex;
 
-use crate::recon::{AssociativeHash, Key, MaybeHashedKey, ReconItem, Store};
-
-use super::{HashCount, InsertResult};
+use crate::{
+    recon::{AssociativeHash, Key, MaybeHashedKey, ReconItem, Store},
+    HashCount, InsertResult, Result,
+};
 
 #[derive(Clone, Debug)]
 struct BTreeStoreInner<K, H> {
@@ -58,7 +58,7 @@ where
         &self,
         left_fencepost: &K,
         right_fencepost: &K,
-    ) -> anyhow::Result<HashCount<H>> {
+    ) -> Result<HashCount<H>> {
         if left_fencepost >= right_fencepost {
             return Ok(HashCount {
                 hash: H::identity(),
@@ -181,7 +181,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> anyhow::Result<HashCount<Self::Hash>> {
+    ) -> Result<HashCount<Self::Hash>> {
         // Self does not need async to implement hash_range, so it exposes a pub non async hash_range function
         // and we delegate to its implementation here.
         BTreeStore::hash_range(self, left_fencepost, right_fencepost).await

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -38,12 +38,12 @@ use expect_test::{expect, Expect};
 use lalrpop_util::ParseError;
 use pretty::{Arena, DocAllocator, DocBuilder, Pretty};
 
-use crate::protocol::ReconMessage;
 use crate::{
-    protocol::{self, InitiatorMessage, ResponderMessage, ValueResponse},
+    protocol::{self, InitiatorMessage, ReconMessage, ResponderMessage, ValueResponse},
     recon::{FullInterests, HashCount, InterestProvider, Range, ReconItem},
     tests::AlphaNumBytes,
-    AssociativeHash, BTreeStore, Client, Key, Metrics, Recon, Server, Sha256a, Store,
+    AssociativeHash, BTreeStore, Client, Key, Metrics, Recon, Result as ReconResult, Server,
+    Sha256a, Store,
 };
 
 #[derive(Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -146,7 +146,7 @@ impl<K: Key> FixedInterests<K> {
 impl<K: Key> InterestProvider for FixedInterests<K> {
     type Key = K;
 
-    async fn interests(&self) -> anyhow::Result<Vec<RangeOpen<Self::Key>>> {
+    async fn interests(&self) -> ReconResult<Vec<RangeOpen<Self::Key>>> {
         Ok(self.0.clone())
     }
 }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -23,6 +23,7 @@ iroh-car.workspace = true
 itertools = "0.12.0"
 multihash.workspace = true
 prometheus-client.workspace = true
+thiserror.workspace = true
 recon.workspace = true
 sqlx.workspace = true
 tokio.workspace = true

--- a/store/src/error.rs
+++ b/store/src/error.rs
@@ -108,3 +108,13 @@ impl From<sqlx::Error> for Error {
         }
     }
 }
+
+impl From<Error> for recon::Error {
+    fn from(value: Error) -> Self {
+        match value {
+            Error::Application { error } => recon::Error::Application { error },
+            Error::Fatal { error } => recon::Error::Fatal { error },
+            Error::Transient { error } => recon::Error::Transient { error },
+        }
+    }
+}

--- a/store/src/error.rs
+++ b/store/src/error.rs
@@ -1,0 +1,110 @@
+use anyhow::anyhow;
+
+#[derive(Debug, thiserror::Error)]
+/// The Errors that can be raised by store operations
+pub enum Error {
+    #[error("Application error encountered: {error}")]
+    /// An application specific error that may be resolved with different inputs or other changes
+    Application {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+    #[error("Fatal error encountered: {error}")]
+    /// A fatal error that is unlikely to be recoverable, and may require terminating the process completely
+    Fatal {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+    #[error("Transient error encountered: {error}")]
+    /// An error that can be retried, and may resolve itself. If an error is transient repeatedly, it should be
+    /// considered an "application" level error and propagated upward.
+    Transient {
+        /// The error details that may include context and other information
+        error: anyhow::Error,
+    },
+}
+
+impl Error {
+    /// Create a transient error
+    pub fn new_transient(error: impl Into<anyhow::Error>) -> Self {
+        Self::Transient {
+            error: error.into(),
+        }
+    }
+    /// Create a fatal error
+    pub fn new_fatal(error: impl Into<anyhow::Error>) -> Self {
+        Self::Fatal {
+            error: error.into(),
+        }
+    }
+
+    /// Create an application error
+    pub fn new_app(error: impl Into<anyhow::Error>) -> Self {
+        Self::Application {
+            error: error.into(),
+        }
+    }
+
+    /// Add context to the internal error. Works identically to `anyhow::context`
+    pub fn context<C>(self, context: C) -> Self
+    where
+        C: std::fmt::Display + Send + Sync + 'static,
+    {
+        match self {
+            Error::Application { error } => Self::Application {
+                error: error.context(context),
+            },
+            Error::Fatal { error } => Self::Fatal {
+                error: error.context(context),
+            },
+            Error::Transient { error } => Self::Transient {
+                error: error.context(context),
+            },
+        }
+    }
+}
+
+impl From<sqlx::Error> for Error {
+    fn from(e: sqlx::Error) -> Self {
+        match e {
+            // Transient errors can be retried after some time
+            sqlx::Error::PoolTimedOut => {
+                Self::new_transient(anyhow!("Timeout getting database connection"))
+            }
+            // typically transient, but could be fatal (e.g. OOM)
+            sqlx::Error::Io(e) => Self::new_transient(e),
+
+            // Unrecoverable (fatal) errors
+            sqlx::Error::PoolClosed => Self::new_fatal(anyhow!("Database pool closed")), // Currently fatal, potentially recoverable in the future
+            sqlx::Error::Configuration(e) => Self::new_fatal(anyhow!(e)),
+            sqlx::Error::Protocol(e) => Self::new_fatal(anyhow!(e)),
+            sqlx::Error::Tls(e) => Self::new_fatal(anyhow!(e)),
+            sqlx::Error::WorkerCrashed => Self::new_fatal(anyhow!("Worker thread crashed")),
+            // these column / decode errors mean our sql statements are invalid and the application can't resolve that
+            sqlx::Error::ColumnIndexOutOfBounds { index, len } => Self::new_fatal(anyhow!(
+                "Column index out of bounds: index {} out of {} columns",
+                index,
+                len
+            )),
+            sqlx::Error::ColumnNotFound(e) => Self::new_fatal(anyhow!(e)),
+            sqlx::Error::ColumnDecode { index, source } => Self::new_fatal(anyhow!(
+                "Column decode error: index '{}' - source: '{}'",
+                index,
+                source
+            )),
+            sqlx::Error::TypeNotFound { type_name } => {
+                Self::new_fatal(anyhow!("Database type not found: {}", type_name))
+            }
+            sqlx::Error::AnyDriverError(e) => Self::new_fatal(anyhow!(e)),
+            sqlx::Error::Migrate(e) => Self::new_fatal(e),
+
+            // Application Errors (possible to retry with different input/fix/etc)
+            sqlx::Error::Database(e) => Self::new_app(e),
+            sqlx::Error::Decode(e) => Self::new_app(anyhow!(e)),
+            sqlx::Error::RowNotFound => Self::new_app(anyhow!("Row not found")),
+            // non_exhaustive
+            // TODO: is there a way to skip a variant and throw a compilation error if one is ever added?
+            e => Self::new_app(e),
+        }
+    }
+}

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -2,12 +2,16 @@
 //! This unified implementation allows for exposing Recon values as IPFS blocks
 #![warn(missing_docs)]
 
+mod error;
 mod metrics;
 mod sql;
 #[cfg(test)]
 mod tests;
 
+pub use error::Error;
 pub use metrics::{Metrics, StoreMetricsMiddleware};
 pub use sql::{
     DbTxSqlite, Migrations, SqliteEventStore, SqliteInterestStore, SqlitePool, SqliteRootStore,
 };
+
+pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use anyhow::Result;
 use async_trait::async_trait;
 use ceramic_core::{EventId, Interest, RangeOpen};
 use ceramic_metrics::{register, Recorder};
@@ -14,7 +13,7 @@ use prometheus_client::{
     },
     registry::Registry,
 };
-use recon::{AssociativeHash, HashCount, InsertResult, ReconItem};
+use recon::{AssociativeHash, HashCount, InsertResult, ReconItem, Result as ReconResult};
 use tokio::time::Instant;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -159,7 +158,7 @@ impl<S> ceramic_api::AccessInterestStore for StoreMetricsMiddleware<S>
 where
     S: ceramic_api::AccessInterestStore,
 {
-    async fn insert(&self, key: Interest) -> Result<bool> {
+    async fn insert(&self, key: Interest) -> anyhow::Result<bool> {
         let new = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "interest_insert",
@@ -175,7 +174,7 @@ where
         end: &Interest,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<Interest>> {
+    ) -> anyhow::Result<Vec<Interest>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "interest_range",
@@ -190,7 +189,7 @@ impl<S> ceramic_api::AccessModelStore for StoreMetricsMiddleware<S>
 where
     S: ceramic_api::AccessModelStore,
 {
-    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> Result<(bool, bool)> {
+    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> anyhow::Result<(bool, bool)> {
         let (new_key, new_val) = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "model_insert",
@@ -207,7 +206,7 @@ where
         end: &EventId,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<(EventId, Vec<u8>)>> {
+    ) -> anyhow::Result<Vec<(EventId, Vec<u8>)>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "model_range_with_values",
@@ -216,7 +215,7 @@ where
         .await
     }
 
-    async fn value_for_key(&self, key: &EventId) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, key: &EventId) -> anyhow::Result<Option<Vec<u8>>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "model_value_for_key",
@@ -249,7 +248,7 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> ReconResult<bool> {
         let new_val = item.value.is_some();
         let new =
             StoreMetricsMiddleware::<S>::record(&self.metrics, "insert", self.store.insert(item))
@@ -258,7 +257,7 @@ where
         Ok(new)
     }
 
-    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> ReconResult<InsertResult> {
         let res = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "insert_many",
@@ -284,7 +283,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<HashCount<Self::Hash>> {
+    ) -> ReconResult<HashCount<Self::Hash>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "hash_range",
@@ -299,7 +298,7 @@ where
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+    ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "range",
@@ -314,7 +313,7 @@ where
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
+    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "range_with_values",
@@ -324,7 +323,9 @@ where
         .await
     }
 
-    async fn full_range(&self) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+    async fn full_range(
+        &self,
+    ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "full_range", self.store.full_range())
             .await
     }
@@ -333,7 +334,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
+    ) -> ReconResult<Option<Self::Key>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "middle",
@@ -345,7 +346,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<usize> {
+    ) -> ReconResult<usize> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "count",
@@ -357,7 +358,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
+    ) -> ReconResult<Option<Self::Key>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "first",
@@ -369,7 +370,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
+    ) -> ReconResult<Option<Self::Key>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "last",
@@ -382,7 +383,7 @@ where
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<Option<(Self::Key, Self::Key)>> {
+    ) -> ReconResult<Option<(Self::Key, Self::Key)>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "first_and_last",
@@ -391,15 +392,15 @@ where
         .await
     }
 
-    async fn len(&self) -> Result<usize> {
+    async fn len(&self) -> ReconResult<usize> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "len", self.store.len()).await
     }
 
-    async fn is_empty(&self) -> Result<bool> {
+    async fn is_empty(&self) -> ReconResult<bool> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "is_empty", self.store.is_empty()).await
     }
 
-    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
+    async fn value_for_key(&self, key: &Self::Key) -> ReconResult<Option<Vec<u8>>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "value_for_key",
@@ -410,7 +411,7 @@ where
     async fn keys_with_missing_values(
         &self,
         range: RangeOpen<Self::Key>,
-    ) -> Result<Vec<Self::Key>> {
+    ) -> ReconResult<Vec<Self::Key>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "keys_with_missing_values",

--- a/store/src/sql/entities/mod.rs
+++ b/store/src/sql/entities/mod.rs
@@ -3,9 +3,7 @@ mod event;
 mod query;
 
 pub use block::{BlockBytes, BlockRow};
-pub use event::{
-    rebuild_car, CountRow, DeliveredEvent, EventIdError, EventValueRaw, OrderKey, ReconHash,
-};
+pub use event::{rebuild_car, CountRow, DeliveredEvent, EventValueRaw, OrderKey, ReconHash};
 pub use query::{BlockQuery, EventBlockQuery, EventQuery, ReconQuery, ReconType, SqlBackend};
 
 #[derive(Debug, Clone, sqlx::FromRow)]

--- a/store/src/sql/event.rs
+++ b/store/src/sql/event.rs
@@ -1,9 +1,9 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, num::TryFromIntError};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use bytes::Bytes;
-use ceramic_core::{EventId, RangeOpen};
+use ceramic_core::{event_id::InvalidEventId, EventId, RangeOpen};
 
 use cid::Cid;
 use iroh_bitswap::Block;
@@ -16,10 +16,10 @@ use tracing::instrument;
 use crate::{
     sql::{
         rebuild_car, BlockBytes, BlockQuery, BlockRow, CountRow, DeliveredEvent, EventBlockQuery,
-        EventIdError, EventQuery, EventValueRaw, FirstAndLast, OrderKey, ReconHash, ReconQuery,
-        ReconType, SqlBackend, GLOBAL_COUNTER,
+        EventQuery, EventValueRaw, FirstAndLast, OrderKey, ReconHash, ReconQuery, ReconType,
+        SqlBackend, GLOBAL_COUNTER,
     },
-    DbTxSqlite, SqlitePool,
+    DbTxSqlite, Error, Result, SqlitePool,
 };
 
 /// Unified implementation of [`recon::Store`] and [`iroh_bitswap::Store`] that can expose the
@@ -44,8 +44,7 @@ impl SqliteEventStore {
         let max = max_delivered
             .res
             .checked_add(1)
-            .context("More than i64::MAX delivered events!")?;
-
+            .ok_or_else(|| Error::new_fatal(anyhow!("More than i64::MAX delivered events!")))?;
         GLOBAL_COUNTER.fetch_max(max, std::sync::atomic::Ordering::SeqCst);
 
         Ok(())
@@ -109,10 +108,12 @@ impl SqliteEventStore {
             .fetch_all(self.pool.reader())
             .await?;
 
-        Ok(row
+        let res = row
             .into_iter()
-            .map(|row| EventId::try_from(row.order_key))
-            .collect::<Result<Vec<EventId>, EventIdError>>()?)
+            .map(|row| EventId::try_from(row.order_key).map_err(|e| Error::new_app(anyhow!(e))))
+            .collect::<Result<Vec<EventId>>>()?;
+
+        Ok(res)
     }
 
     async fn value_for_key_int(&self, key: &EventId) -> Result<Option<Vec<u8>>> {
@@ -135,10 +136,16 @@ impl SqliteEventStore {
         if let Some(val) = item.value {
             // Put each block from the car file. Should we check if value already existed and skip this?
             // It will no-op but will still try to insert the blocks again
-            let mut reader = CarReader::new(val).await?;
+            let mut reader = CarReader::new(val)
+                .await
+                .map_err(|e| Error::new_app(anyhow!(e)))?;
             let roots: BTreeSet<Cid> = reader.header().roots().iter().cloned().collect();
             let mut idx = 0;
-            while let Some((cid, data)) = reader.next_block().await? {
+            while let Some((cid, data)) = reader
+                .next_block()
+                .await
+                .map_err(|e| Error::new_app(anyhow!(e)))?
+            {
                 self.insert_event_block_int(
                     item.key,
                     idx,
@@ -202,29 +209,34 @@ impl SqliteEventStore {
         let hash = match cid.hash().code() {
             0x12 => Code::Sha2_256.digest(blob),
             0x1b => Code::Keccak256.digest(blob),
-            0x11 => return Err(anyhow!("Sha1 not supported")),
+            0x11 => return Err(Error::new_app(anyhow!("Sha1 not supported"))),
             code => {
-                return Err(anyhow!(
+                return Err(Error::new_app(anyhow!(
                     "multihash type {:#x} not Sha2_256, Keccak256",
                     code,
-                ))
+                )))
             }
         };
         if cid.hash().to_bytes() != hash.to_bytes() {
-            return Err(anyhow!(
+            return Err(Error::new_app(anyhow!(
                 "cid did not match blob {} != {}",
                 hex::encode(cid.hash().to_bytes()),
                 hex::encode(hash.to_bytes())
-            ));
+            )));
         }
 
         let _new = self.put_block_tx(&hash, blob, conn).await?;
 
-        let code: i64 = cid.codec().try_into().context(format!(
-            "Invalid codec could not fit into an i64: {}",
-            cid.codec()
-        ))?;
-        let id = key.cid().context("Event CID is required")?.to_bytes();
+        let code: i64 = cid.codec().try_into().map_err(|e: TryFromIntError| {
+            Error::new_app(anyhow!(e).context(format!(
+                "Invalid codec could not fit into an i64: {}",
+                cid.codec()
+            )))
+        })?;
+        let id = key
+            .cid()
+            .ok_or_else(|| Error::new_app(anyhow!("Event CID is required")))?
+            .to_bytes();
         let multihash = hash.to_bytes();
         sqlx::query(EventBlockQuery::upsert())
             .bind(id)
@@ -254,7 +266,7 @@ impl SqliteEventStore {
         let cid = key
             .cid()
             .map(|cid| cid.to_bytes())
-            .context("Event CID is required")?;
+            .ok_or_else(|| Error::new_app(anyhow!("Event CID is required")))?;
         let hash = Sha256a::digest(key);
 
         let resp = sqlx::query(ReconQuery::insert_event())
@@ -331,20 +343,20 @@ impl recon::Store for SqliteEventStore {
     type Hash = Sha256a;
 
     /// Returns true if the key was new. The value is always updated if included
-    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> Result<bool> {
+    async fn insert(&self, item: &ReconItem<'_, Self::Key>) -> anyhow::Result<bool> {
         let (new, _new_val) = self.insert_item(item).await?;
         Ok(new)
     }
 
     /// Insert new keys into the key space.
     /// Returns true if a key did not previously exist.
-    async fn insert_many(&self, items: &[ReconItem<'_, Self::Key>]) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, EventId>]) -> anyhow::Result<InsertResult> {
         match items.len() {
             0 => Ok(InsertResult::new(vec![], 0)),
             _ => {
                 let mut results = vec![false; items.len()];
                 let mut new_val_cnt = 0;
-                let mut tx = self.pool.writer().begin().await?;
+                let mut tx = self.pool.writer().begin().await.map_err(Error::from)?;
 
                 for (idx, item) in items.iter().enumerate() {
                     let (new_key, new_val) = self.insert_item_int(item, &mut tx).await?;
@@ -353,7 +365,7 @@ impl recon::Store for SqliteEventStore {
                         new_val_cnt += 1;
                     }
                 }
-                tx.commit().await?;
+                tx.commit().await.map_err(Error::from)?;
                 Ok(InsertResult::new(results, new_val_cnt))
             }
         }
@@ -365,13 +377,14 @@ impl recon::Store for SqliteEventStore {
         &self,
         left_fencepost: &Self::Key,
         right_fencepost: &Self::Key,
-    ) -> Result<HashCount<Self::Hash>> {
+    ) -> anyhow::Result<HashCount<Self::Hash>> {
         let row: ReconHash =
             sqlx::query_as(ReconQuery::hash_range(ReconType::Event, SqlBackend::Sqlite))
                 .bind(left_fencepost.as_bytes())
                 .bind(right_fencepost.as_bytes())
                 .fetch_one(self.pool.reader())
-                .await?;
+                .await
+                .map_err(Error::from)?;
         Ok(HashCount::new(Self::Hash::from(row.hash()), row.count()))
     }
 
@@ -382,7 +395,7 @@ impl recon::Store for SqliteEventStore {
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
+    ) -> anyhow::Result<Box<dyn Iterator<Item = EventId> + Send + 'static>> {
         let offset: i64 = offset
             .try_into()
             .context("Offset too large to fit into i64")?;
@@ -393,11 +406,12 @@ impl recon::Store for SqliteEventStore {
             .bind(limit)
             .bind(offset)
             .fetch_all(self.pool.reader())
-            .await?;
+            .await
+            .map_err(Error::from)?;
         let rows = rows
             .into_iter()
-            .map(EventId::try_from)
-            .collect::<Result<Vec<Self::Key>, EventIdError>>()?;
+            .map(|k| EventId::try_from(k).map_err(|e: InvalidEventId| Error::new_app(anyhow!(e))))
+            .collect::<Result<Vec<EventId>>>()?;
         Ok(Box::new(rows.into_iter()))
     }
     #[instrument(skip(self))]
@@ -407,23 +421,25 @@ impl recon::Store for SqliteEventStore {
         right_fencepost: &Self::Key,
         offset: usize,
         limit: usize,
-    ) -> Result<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        self.range_with_values_int(left_fencepost, right_fencepost, offset, limit)
-            .await
+    ) -> anyhow::Result<Box<dyn Iterator<Item = (EventId, Vec<u8>)> + Send + 'static>> {
+        Ok(self
+            .range_with_values_int(left_fencepost, right_fencepost, offset, limit)
+            .await?)
     }
 
     /// Return the number of keys within the range.
     #[instrument(skip(self))]
     async fn count(
         &self,
-        left_fencepost: &Self::Key,
-        right_fencepost: &Self::Key,
-    ) -> Result<usize> {
+        left_fencepost: &EventId,
+        right_fencepost: &EventId,
+    ) -> anyhow::Result<usize> {
         let row: CountRow = sqlx::query_as(ReconQuery::count(ReconType::Event, SqlBackend::Sqlite))
             .bind(left_fencepost.as_bytes())
             .bind(right_fencepost.as_bytes())
             .fetch_one(self.pool.reader())
-            .await?;
+            .await
+            .map_err(Error::from)?;
         Ok(row.res as usize)
     }
 
@@ -431,39 +447,45 @@ impl recon::Store for SqliteEventStore {
     #[instrument(skip(self))]
     async fn first(
         &self,
-        left_fencepost: &Self::Key,
-        right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
+        left_fencepost: &EventId,
+        right_fencepost: &EventId,
+    ) -> anyhow::Result<Option<EventId>> {
         let row: Option<OrderKey> = sqlx::query_as(ReconQuery::first_key(ReconType::Event))
             .bind(left_fencepost.as_bytes())
             .bind(right_fencepost.as_bytes())
             .fetch_optional(self.pool.reader())
-            .await?;
-        let res = row.map(EventId::try_from).transpose()?;
+            .await
+            .map_err(Error::from)?;
+        let res = row
+            .map(|r| EventId::try_from(r).map_err(Error::new_app))
+            .transpose()?;
         Ok(res)
     }
 
     #[instrument(skip(self))]
     async fn last(
         &self,
-        left_fencepost: &Self::Key,
-        right_fencepost: &Self::Key,
-    ) -> Result<Option<Self::Key>> {
+        left_fencepost: &EventId,
+        right_fencepost: &EventId,
+    ) -> anyhow::Result<Option<EventId>> {
         let row: Option<OrderKey> = sqlx::query_as(ReconQuery::last_key(ReconType::Event))
             .bind(left_fencepost.as_bytes())
             .bind(right_fencepost.as_bytes())
             .fetch_optional(self.pool.reader())
-            .await?;
-        let res = row.map(EventId::try_from).transpose()?;
+            .await
+            .map_err(Error::from)?;
+        let res = row
+            .map(|r| EventId::try_from(r).map_err(Error::new_app))
+            .transpose()?;
         Ok(res)
     }
 
     #[instrument(skip(self))]
     async fn first_and_last(
         &self,
-        left_fencepost: &Self::Key,
-        right_fencepost: &Self::Key,
-    ) -> Result<Option<(Self::Key, Self::Key)>> {
+        left_fencepost: &EventId,
+        right_fencepost: &EventId,
+    ) -> anyhow::Result<Option<(EventId, EventId)>> {
         let row: Option<FirstAndLast> = sqlx::query_as(ReconQuery::first_and_last(
             ReconType::Event,
             SqlBackend::Sqlite,
@@ -473,7 +495,8 @@ impl recon::Store for SqliteEventStore {
         .bind(left_fencepost.as_bytes())
         .bind(right_fencepost.as_bytes())
         .fetch_optional(self.pool.reader())
-        .await?;
+        .await
+        .map_err(Error::from)?;
 
         if let Some(row) = row {
             let first = EventId::try_from(row.first_key)?;
@@ -485,22 +508,22 @@ impl recon::Store for SqliteEventStore {
     }
 
     #[instrument(skip(self))]
-    async fn value_for_key(&self, key: &Self::Key) -> Result<Option<Vec<u8>>> {
-        self.value_for_key_int(key).await
+    async fn value_for_key(&self, key: &EventId) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.value_for_key_int(key).await?)
     }
 
     #[instrument(skip(self))]
     async fn keys_with_missing_values(
         &self,
-        range: RangeOpen<Self::Key>,
-    ) -> Result<Vec<Self::Key>> {
-        self.keys_with_missing_values_int(range).await
+        range: RangeOpen<EventId>,
+    ) -> anyhow::Result<Vec<EventId>> {
+        Ok(self.keys_with_missing_values_int(range).await?)
     }
 }
 
 #[async_trait]
 impl iroh_bitswap::Store for SqliteEventStore {
-    async fn get_size(&self, cid: &Cid) -> Result<usize> {
+    async fn get_size(&self, cid: &Cid) -> anyhow::Result<usize> {
         let len: CountRow = sqlx::query_as(BlockQuery::length())
             .bind(cid.hash().to_bytes())
             .fetch_one(self.pool.reader())
@@ -508,7 +531,7 @@ impl iroh_bitswap::Store for SqliteEventStore {
         Ok(len.res as usize)
     }
 
-    async fn get(&self, cid: &Cid) -> Result<Block> {
+    async fn get(&self, cid: &Cid) -> anyhow::Result<Block> {
         let block: BlockBytes = sqlx::query_as(BlockQuery::get())
             .bind(cid.hash().to_bytes())
             .fetch_one(self.pool.reader())
@@ -516,7 +539,7 @@ impl iroh_bitswap::Store for SqliteEventStore {
         Ok(Block::new(block.bytes.into(), cid.to_owned()))
     }
 
-    async fn has(&self, cid: &Cid) -> Result<bool> {
+    async fn has(&self, cid: &Cid) -> anyhow::Result<bool> {
         let len: CountRow = sqlx::query_as(BlockQuery::has())
             .bind(cid.hash().to_bytes())
             .fetch_one(self.pool.reader())
@@ -524,7 +547,7 @@ impl iroh_bitswap::Store for SqliteEventStore {
         Ok(len.res > 0)
     }
 
-    async fn put(&self, block: &Block) -> Result<bool> {
+    async fn put(&self, block: &Block) -> anyhow::Result<bool> {
         Ok(self.put_block(block.cid().hash(), block.data()).await?)
     }
 }
@@ -537,9 +560,10 @@ impl iroh_bitswap::Store for SqliteEventStore {
 /// This guarantees that regardless of entry point (api or recon), the data is stored and retrieved in the same way.
 #[async_trait::async_trait]
 impl ceramic_api::AccessModelStore for SqliteEventStore {
-    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> Result<(bool, bool)> {
-        self.insert_item(&ReconItem::new(&key, value.as_deref()))
-            .await
+    async fn insert(&self, key: EventId, value: Option<Vec<u8>>) -> anyhow::Result<(bool, bool)> {
+        Ok(self
+            .insert_item(&ReconItem::new(&key, value.as_deref()))
+            .await?)
     }
 
     async fn range_with_values(
@@ -548,14 +572,14 @@ impl ceramic_api::AccessModelStore for SqliteEventStore {
         end: &EventId,
         offset: usize,
         limit: usize,
-    ) -> Result<Vec<(EventId, Vec<u8>)>> {
+    ) -> anyhow::Result<Vec<(EventId, Vec<u8>)>> {
         let res = self
             .range_with_values_int(start, end, offset, limit)
             .await?;
         Ok(res.collect())
     }
-    async fn value_for_key(&self, key: &EventId) -> Result<Option<Vec<u8>>> {
-        self.value_for_key_int(key).await
+    async fn value_for_key(&self, key: &EventId) -> anyhow::Result<Option<Vec<u8>>> {
+        Ok(self.value_for_key_int(key).await?)
     }
 
     async fn keys_since_highwater_mark(
@@ -563,6 +587,6 @@ impl ceramic_api::AccessModelStore for SqliteEventStore {
         highwater: i64,
         limit: i64,
     ) -> anyhow::Result<(i64, Vec<EventId>)> {
-        self.new_keys_since_value(highwater, limit).await
+        Ok(self.new_keys_since_value(highwater, limit).await?)
     }
 }


### PR DESCRIPTION
This adds a Error enum to the store and recon crates that allows for some error handling/decision making, rather than propagating all errors up as opaque failures. This doesn't actually handle or retry errors yet, just provides the types to do so. This is targeting #320 as it was originally on the postgres branch, and it simplified conflicts/rework (and I'm hoping that branch isn't too contentious, even though the commit is large).