### PR TITLE
chore: spawn tokio task instead of std thread 

### DIFF
--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1171,7 +1171,6 @@ mod tests {
     use rand_chacha::ChaCha8Rng;
     use recon::{Range, Sha256a, SyncState};
     use ssh_key::private::Ed25519Keypair;
-    use test_log::test;
 
     use libp2p::{identity::Keypair as Libp2pKeypair, kad::RecordKey};
 
@@ -1511,7 +1510,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_local_peer_id() -> Result<()> {
         let test_runner = TestRunnerBuilder::new().no_bootstrap().build().await?;
         let got_peer_id = test_runner.client.local_peer_id().await?;
@@ -1616,7 +1615,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_cancel_listen_for_identify() -> Result<()> {
         let mut test_runner_a = TestRunnerBuilder::new().no_bootstrap().build().await?;
         let peer_id: PeerId = "12D3KooWFma2D63TG9ToSiRsjFkoNm2tTihScTBAEdXxinYk5rwE"
@@ -1639,7 +1638,7 @@ mod tests {
         Ok(())
     }
 
-    #[test(tokio::test)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[cfg_attr(target_os = "macos", ignore = "on MacOS")]
     async fn test_dht() -> Result<()> {
         // set up three nodes

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -85,17 +85,18 @@ where
 {
     let keypair = keypair.clone();
     let config = config.clone();
-    let handle = tokio::runtime::Handle::current();
-    std::thread::spawn(move || {
-        handle.block_on(NodeBehaviour::new(
-            &keypair,
-            &config,
-            relay_client,
-            recons,
-            block_store,
-            metrics,
-        ))
+    tokio::task::block_in_place(|| {
+        let handle = tokio::runtime::Handle::current();
+        handle.block_on(async move {
+            NodeBehaviour::new(
+                &keypair,
+                &config,
+                relay_client,
+                recons,
+                block_store,
+                metrics,
+            )
+            .await
+        })
     })
-    .join()
-    .unwrap()
 }


### PR DESCRIPTION
Use a tokio task instead of spawning a `std::thread`. This should help with starvation/resource utilization as the runtime is aware and able to schedule it. There is more work to be done refactoring/adjusting/simplifying the libp2p code, but this is a small change to start. I actually removed it from #307 because I thought it caused errors, but misunderstood the test failures as a simply the single threaded runtime 🤦.

Decided to drop the recon ConnectionHandler waker implementation I added as it didn't seem to make much difference, and after review yesterday, it seems like the behavior will poll its connections. Again, this may be adjusted as part of fixing the "one side errors and the other side waits forever" issue, and the broader changes we've been discussing.