### PR TITLE
fix: rust-jemalloc-pprof is only supported on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust-builder:latest as builder
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
+FROM rust-builder:latest as builder
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -24,6 +24,8 @@ swagger.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 prometheus-client.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
 jemalloc_pprof = "0.1.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -447,19 +447,28 @@ where
         &self,
         _context: &C,
     ) -> std::result::Result<DebugHeapGetResponse, ApiError> {
+        #[cfg(not(target_env = "msvc"))]
         epoch::advance().unwrap();
 
-        let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
-        if !prof_ctl.activated() {
-            return Ok(DebugHeapGetResponse::BadRequest(BadRequestResponse {
-                message: "heap profiling not enabled".to_string(),
-            }));
+        // might be on BSD and others
+        #[cfg(target_os = "linux")]
+        {
+            let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
+            if !prof_ctl.activated() {
+                return Ok(DebugHeapGetResponse::BadRequest(BadRequestResponse {
+                    message: "heap profiling not enabled".to_string(),
+                }));
+            }
+            prof_ctl
+                .dump_pprof()
+                .map_err(|e| ErrorResponse::new(format!("failed to dump profile: {e}")))
+                .map(|pprof| DebugHeapGetResponse::Success(ByteArray(pprof)))
+                .or_else(|err| Ok(DebugHeapGetResponse::InternalServerError(err)))
         }
-        prof_ctl
-            .dump_pprof()
-            .map_err(|e| ErrorResponse::new(format!("failed to dump profile: {e}")))
-            .map(|pprof| DebugHeapGetResponse::Success(ByteArray(pprof)))
-            .or_else(|err| Ok(DebugHeapGetResponse::InternalServerError(err)))
+        #[cfg(not(target_os = "linux"))]
+        Ok(DebugHeapGetResponse::BadRequest(
+            "unsupported platform".to_string(),
+        ))
     }
 
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -467,7 +467,7 @@ where
         }
         #[cfg(not(target_os = "linux"))]
         Ok(DebugHeapGetResponse::BadRequest(
-            "unsupported platform".to_string(),
+            models::BadRequestResponse::new("unsupported platform".to_string()),
         ))
     }
 


### PR DESCRIPTION
jemalloc-pprof is only supported on linux (i.e. uses `dl_iterate_phdr` from libc) and doesn't compile on osx. I added a simple config check, not sure if this could/should be more sophisticated. It seems that this is likely supported on BSD and a handful of other platforms but I didn't investigate.