### PR TITLE
chore: version v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2024-04-29
+
+### 🚀 Features
+
+- Validate time events (#289)
+- Add workflow for custom images
+- Migrations with new table format to de-dup blocks and support out of order delivery (#292)
+- Don't mark peers failed when we error during sync (#300)
+- Jemalloc (#319)
+- Store bench (#303)
+- Disable mdns,bitswap,kad,relay,dcutr protocols (#323)
+
+### 🐛 Bug Fixes
+
+- Use TAG_LATEST (#294)
+- Set the js-ceramic image when scheduling k8 deploy (#298)
+- Gh workflow syntax
+- Cd-to-infra workflow quote fix (#314)
+- Tokio vs std thread is okay (#318)
+- Rust-jemalloc-pprof is only supported on linux (#321)
+
+### ⚙️ Miscellaneous Tasks
+
+- Remove mut from store traits (#305)
+- Adjust types to allow dynamic usage (#306)
+- Don't hang the executor (#307)
+- Recon libp2p e2e tests (#310)
+- Add debug image builds (#311)
+- Update debug tags when not releasing (#313)
+- Fix docker build for debug mode (#315)
+- Add a release build with debug symbols and tokio console (#316)
+- Update open telemetry and tokio-console dependencies (#322)
+- Refactor to to lay groundwork for postgres support (#320)
+- Add variants for error handling (#317)
+
 ## [0.14.0] - 2024-03-26
 
 ### 🚀 Features
@@ -17,6 +52,10 @@ All notable changes to this project will be documented in this file.
 ### 📚 Documentation
 
 - Added explicit deps to build steps (#291)
+
+### ⚙️ Miscellaneous Tasks
+
+- Version v0.14.0 (#297)
 
 ## [0.13.0] - 2024-03-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1138,7 +1138,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ceramic-core",
@@ -1158,7 +1158,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "built",
  "project-root",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1250,7 +1250,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1337,7 +1337,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3410,7 +3410,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cid 0.10.1",
  "futures",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "cid 0.10.1",
  "nix 0.26.4",
@@ -6670,7 +6670,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9465,7 +9465,7 @@ version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca229916c5ee38c2f2bc1e9d8f04df975b4bd93f9955dc69fabb5d91270045c9"
 dependencies = [
- "windows-core 0.51.1",
+ "windows-core",
  "windows-targets 0.48.5",
 ]
 
@@ -9476,15 +9476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
 dependencies = [
  "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.14.0
-- Build date: 2024-04-24T13:37:37.597565436-06:00[America/Denver]
+- API version: 0.15.0
+- Build date: 2024-04-29T17:53:06.595190991Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.14.0
+  version: 0.15.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.14.0";
+pub const API_VERSION: &str = "0.15.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.14.0
+  version: 0.15.0
   title: Ceramic API
     #license:
     #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.14.0
-- Build date: 2024-03-26T12:19:17.274907-06:00[America/Denver]
+- API version: 0.15.0
+- Build date: 2024-04-29T17:53:08.662597085Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.14.0
+  version: 0.15.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.14.0";
+pub const API_VERSION: &str = "0.15.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.14.0
+  version: 0.15.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.15.0] - 2024-04-29

### 🚀 Features

- Validate time events (#289)
- Add workflow for custom images
- Migrations with new table format to de-dup blocks and support out of order delivery (#292)
- Don't mark peers failed when we error during sync (#300)
- Jemalloc (#319)
- Store bench (#303)
- Disable mdns,bitswap,kad,relay,dcutr protocols (#323)

### 🐛 Bug Fixes

- Use TAG_LATEST (#294)
- Set the js-ceramic image when scheduling k8 deploy (#298)
- Gh workflow syntax
- Cd-to-infra workflow quote fix (#314)
- Tokio vs std thread is okay (#318)
- Rust-jemalloc-pprof is only supported on linux (#321)

### ⚙️ Miscellaneous Tasks

- Remove mut from store traits (#305)
- Adjust types to allow dynamic usage (#306)
- Don't hang the executor (#307)
- Recon libp2p e2e tests (#310)
- Add debug image builds (#311)
- Update debug tags when not releasing (#313)
- Fix docker build for debug mode (#315)
- Add a release build with debug symbols and tokio console (#316)
- Update open telemetry and tokio-console dependencies (#322)
- Refactor to to lay groundwork for postgres support (#320)
- Add variants for error handling (#317)