### PR TITLE
chore: version v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.16.0] - 2024-05-06
+
+### 🚀 Features
+
+- Remove deprecated http API for getting events for a single interest (#332)
+
+### 🐛 Bug Fixes
+
+- Changes to improve sync and ingest performance (#324)
+- Fix clippy (#334)
+
+### 🚜 Refactor
+
+- Update deps cid, multihash, and ipld (#309)
+
+### ⚙️ Miscellaneous Tasks
+
+- Add bad request response to get events API (#329)
+- Run build/test/check CI on all PRs (#333)
+
 ## [0.15.0] - 2024-04-29
 
 ### 🚀 Features
@@ -36,6 +56,7 @@ All notable changes to this project will be documented in this file.
 - Update open telemetry and tokio-console dependencies (#322)
 - Refactor to to lay groundwork for postgres support (#320)
 - Add variants for error handling (#317)
+- Version v0.15.0 (#325)
 
 ## [0.14.0] - 2024-03-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "ceramic-core",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "built",
  "project-root",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1306,7 +1306,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3706,7 +3706,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -6640,7 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.15.0
-- Build date: 2024-05-03T15:19:18.651366885-06:00[America/Denver]
+- API version: 0.16.0
+- Build date: 2024-05-06T17:47:30.342451480Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.15.0
+  version: 0.16.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.15.0";
+pub const API_VERSION: &str = "0.16.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.15.0
+  version: 0.16.0
   title: Ceramic API
     #license:
     #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.15.0
-- Build date: 2024-05-03T15:19:59.819535006-06:00[America/Denver]
+- API version: 0.16.0
+- Build date: 2024-05-06T17:47:32.418154163Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.15.0
+  version: 0.16.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.15.0";
+pub const API_VERSION: &str = "0.16.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.15.0
+  version: 0.16.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.16.0] - 2024-05-06

### 🚀 Features

- Remove deprecated http API for getting events for a single interest (#332)

### 🐛 Bug Fixes

- Changes to improve sync and ingest performance (#324)
- Fix clippy (#334)

### 🚜 Refactor

- Update deps cid, multihash, and ipld (#309)

### ⚙️ Miscellaneous Tasks

- Add bad request response to get events API (#329)
- Run build/test/check CI on all PRs (#333)