### PR TITLE
fix: parse unsigned init events

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.15.0
-- Build date: 2024-05-03T15:19:18.651366885-06:00[America/Denver]
+- Build date: 2024-05-08T08:01:26.708057872-06:00[America/Denver]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -353,7 +353,7 @@ components:
         id: id
       properties:
         id:
-          description: Multibase encoding of event id bytes.
+          description: Multibase encoding of event root CID bytes.
           type: string
         data:
           description: Multibase encoding of event data.

--- a/api-server/docs/Event.md
+++ b/api-server/docs/Event.md
@@ -3,7 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **String** | Multibase encoding of event id bytes. | 
+**id** | **String** | Multibase encoding of event root CID bytes. | 
 **data** | **String** | Multibase encoding of event data. | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -281,7 +281,7 @@ impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderVal
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct Event {
-    /// Multibase encoding of event id bytes.
+    /// Multibase encoding of event root CID bytes.
     #[serde(rename = "id")]
     pub id: String,
 

--- a/api/src/server/event.rs
+++ b/api/src/server/event.rs
@@ -36,7 +36,7 @@ where
     let event_bytes = get_block(&event_cid, &car_blocks, store).await?;
     let event: unvalidated::Event<Ipld> =
         serde_ipld_dagcbor::from_slice(&event_bytes).context("decoding event")?;
-    let (init_id, payload) = match event {
+    let (init_id, init_payload) = match event {
         unvalidated::Event::Time(event) => (
             event.id(),
             get_init_event_payload(&event.id(), &car_blocks, store).await?,
@@ -63,9 +63,9 @@ where
 
     Ok(EventId::new(
         &network,
-        payload.header().sep(),
-        payload.header().model().as_slice(),
-        payload
+        init_payload.header().sep(),
+        init_payload.header().model().as_slice(),
+        init_payload
             .header()
             .controllers()
             .first()

--- a/event/src/unvalidated.rs
+++ b/event/src/unvalidated.rs
@@ -11,13 +11,15 @@ use crate::bytes::Bytes;
 /// Ceramic Event
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Event {
+pub enum Event<D> {
     /// Time event in a stream
     // NOTE: TimeEvent has several CIDs so its a relatively large struct (~312 bytes according to
     // the compiler). Therefore we box it here to keep the Event enum small.
     Time(Box<TimeEvent>),
     /// Signed event in a stream
     Signed(JWS),
+    /// Unsigned event in a stream
+    Unsigned(InitPayload<D>),
 }
 
 /// Signed event


### PR DESCRIPTION
Parses unsigned init events and can construct an EventId from its car file.