### PR TITLE
chore: version v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.16.0] - 2024-05-06
+## [0.17.0] - 2024-05-09
+
+### 🚀 Features
+
+- Update events GET API to return event CID instead of EventID
+- Return event root cid instead of EventID from feed
+- Update experimental API for getting a range of events to return event root CID, not EventID (#337)
+- Simplify event id
+- Add serde methods for Events
+- Make event creation endpoint infer EventID from event CAR file data (#341)
+- Remove id argument from events POST endpoint (#347)
+
+### 🐛 Bug Fixes
+
+- Parse unsigned init events
+- Handle data events with unsigned init events (#348)
+
+### 🚜 Refactor
+
+- Rename payload -> init_payload
+
+### ⚙️ Miscellaneous Tasks
+
+- SQL queries for event blocks dont need order_key
+- Update comment for Event type in API (#338)
+- Make gen-api-server
+
+## [0.16.0] - 2024-05-08
 
 ### 🚀 Features
 
@@ -16,11 +43,13 @@ All notable changes to this project will be documented in this file.
 ### 🚜 Refactor
 
 - Update deps cid, multihash, and ipld (#309)
+- Update recon word list test to make it easier to debug (#342)
 
 ### ⚙️ Miscellaneous Tasks
 
 - Add bad request response to get events API (#329)
 - Run build/test/check CI on all PRs (#333)
+- Version v0.16.0 (#336)
 
 ## [0.15.0] - 2024-04-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "ceramic-core",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1204,7 +1204,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "built",
  "project-root",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3762,7 +3762,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -6647,7 +6647,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,7 +205,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.16.0
-- Build date: 2024-05-09T10:16:59.415295720-06:00[America/Denver]
+- API version: 0.17.0
+- Build date: 2024-05-09T17:10:14.357128797Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.16.0
+  version: 0.17.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.16.0";
+pub const API_VERSION: &str = "0.17.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.16.0
+  version: 0.17.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.16.0
-- Build date: 2024-05-06T17:47:32.418154163Z[Etc/UTC]
+- API version: 0.17.0
+- Build date: 2024-05-09T17:10:16.378384439Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.16.0
+  version: 0.17.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.16.0";
+pub const API_VERSION: &str = "0.17.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.16.0
+  version: 0.17.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.17.0] - 2024-05-09

### 🚀 Features

- Update events GET API to return event CID instead of EventID
- Return event root cid instead of EventID from feed
- Update experimental API for getting a range of events to return event root CID, not EventID (#337)
- Simplify event id
- Add serde methods for Events
- Make event creation endpoint infer EventID from event CAR file data (#341)
- Remove id argument from events POST endpoint (#347)

### 🐛 Bug Fixes

- Parse unsigned init events
- Handle data events with unsigned init events (#348)

### 🚜 Refactor

- Rename payload -> init_payload

### ⚙️ Miscellaneous Tasks

- SQL queries for event blocks dont need order_key
- Update comment for Event type in API (#338)
- Make gen-api-server