### PR TITLE
fix: recon protocol hang with large diffs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6649,6 +6649,7 @@ name = "recon"
 version = "0.18.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "asynchronous-codec 0.6.2",
  "ceramic-core",

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+async-stream.workspace = true
 async-trait.workspace = true
 asynchronous-codec = { version = "0.6.1", features = ["cbor", "json"] }
 ceramic-core.workspace = true
@@ -19,11 +20,13 @@ hex = "0.4.3"
 libp2p-identity.workspace = true
 libp2p.workspace = true
 multihash-codetable.workspace = true
+pin-project = "1.1.3"
 prometheus-client.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 tracing.workspace = true
 uuid = { version = "1.8.0", features = ["v4"] }
 void.workspace = true
@@ -34,7 +37,6 @@ expect-test.workspace = true
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 libp2p = { workspace = true, features = ["ping"] }
 libp2p-swarm-test = "0.3.0"
-pin-project = "1.1.3"
 pretty = "0.12.1"
 quickcheck = "1.0.3"
 regex = "1"

--- a/recon/Cargo.toml
+++ b/recon/Cargo.toml
@@ -20,7 +20,6 @@ hex = "0.4.3"
 libp2p-identity.workspace = true
 libp2p.workspace = true
 multihash-codetable.workspace = true
-pin-project = "1.1.3"
 prometheus-client.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -37,6 +36,7 @@ expect-test.workspace = true
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 libp2p = { workspace = true, features = ["ping"] }
 libp2p-swarm-test = "0.3.0"
+pin-project = "1.1.3"
 pretty = "0.12.1"
 quickcheck = "1.0.3"
 regex = "1"

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -14,7 +14,7 @@ use libp2p::{
     },
 };
 use libp2p_identity::PeerId;
-use tracing::{debug, trace};
+use tracing::trace;
 
 use crate::{
     libp2p::{protocol, stream_set::StreamSet, upgrade::MultiReadyUpgrade, Recon},
@@ -58,7 +58,7 @@ where
     // should map to exactly one call of this transition_state function.
     //
     fn transition_state(&mut self, state: State) {
-        debug!(
+        trace!(
             %self.remote_peer_id,
             ?self.connection_id,
             previous_state = ?self.state,

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -14,7 +14,7 @@ use libp2p::{
     },
 };
 use libp2p_identity::PeerId;
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::{
     libp2p::{protocol, stream_set::StreamSet, upgrade::MultiReadyUpgrade, Recon},
@@ -58,7 +58,7 @@ where
     // should map to exactly one call of this transition_state function.
     //
     fn transition_state(&mut self, state: State) {
-        trace!(
+        debug!(
             %self.remote_peer_id,
             ?self.connection_id,
             previous_state = ?self.state,

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -21,7 +21,7 @@ pub async fn initiate_synchronize<S, R>(
 ) -> Result<StreamSet>
 where
     R: Recon,
-    S: AsyncRead + AsyncWrite + Unpin + Send,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let codec = CborCodec::new();
     let stream = Framed::new(stream, codec);
@@ -39,7 +39,7 @@ pub async fn respond_synchronize<S, R>(
 ) -> Result<StreamSet>
 where
     R: Recon,
-    S: AsyncRead + AsyncWrite + Unpin + Send,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     let codec = CborCodec::new();
     let stream = Framed::new(stream, codec);

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use ceramic_metrics::init_local_tracing;
 use libp2p::{metrics::Registry, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
+use test_log::test;
 use tracing::info;
 
 fn start_recon<K, H, S, I>(recon: Recon<K, H, S, I>) -> crate::Client<K, H>
@@ -124,8 +124,6 @@ where
 // use a hackro to avoid setting all the generic types we'd need if using functions
 macro_rules! setup_test {
     ($alice_store: expr, $alice_interests: expr, $bob_store: expr, $bob_interest: expr,) => {{
-        let _ = init_local_tracing();
-
         let alice = Recon::new(
             $alice_store,
             FullInterests::default(),
@@ -174,7 +172,7 @@ macro_rules! setup_test {
     }};
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn in_sync_no_overlap() {
     let (mut swarm1, mut swarm2) = setup_test!(
         BTreeStoreErrors::default(),
@@ -202,7 +200,7 @@ async fn in_sync_no_overlap() {
     fut.await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn initiator_model_error() {
     let mut alice_model_store = BTreeStoreErrors::default();
     alice_model_store.set_error(Error::new_transient(anyhow::anyhow!(
@@ -241,7 +239,7 @@ async fn initiator_model_error() {
     fut.await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn responder_model_error() {
     let mut bob_model_store = BTreeStoreErrors::default();
     bob_model_store.set_error(Error::new_transient(anyhow::anyhow!(
@@ -258,20 +256,18 @@ async fn responder_model_error() {
         swarm1.listen().with_memory_addr_external().await;
         swarm2.connect(&mut swarm1).await;
 
-        let ([p1_e1, p1_e2, p1_e3], [p2_e1, p2_e2, p2_e3]): (
-            [crate::libp2p::Event; 3],
-            [crate::libp2p::Event; 3],
+        let ([p1_e1, p1_e2, p1_e3, p1_e4], [p2_e1, p2_e2, p2_e3, p2_e4]): (
+            [crate::libp2p::Event; 4],
+            [crate::libp2p::Event; 4],
         ) = libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await;
 
-        for ev in &[p1_e1, p1_e2, p1_e3, p2_e1, p2_e2, p2_e3] {
+        for ev in [
+            &p1_e1, &p1_e2, &p1_e3, &p1_e4, &p2_e1, &p2_e2, &p2_e3, &p2_e4,
+        ] {
             info!("{:?}", ev);
         }
-        let ([], [failed_peer]): ([crate::libp2p::Event; 0], [crate::libp2p::Event; 1]) =
-            libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await;
-
-        info!("{:?}", failed_peer);
         assert_eq!(
-            failed_peer,
+            p2_e4,
             crate::libp2p::Event::PeerEvent(PeerEvent {
                 remote_peer_id: swarm1.local_peer_id().to_owned(),
                 status: PeerStatus::Failed

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 
 use async_trait::async_trait;
+use ceramic_metrics::init_local_tracing;
 use libp2p::{metrics::Registry, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
-use test_log::test;
 use tracing::info;
 
 fn start_recon<K, H, S, I>(recon: Recon<K, H, S, I>) -> crate::Client<K, H>
@@ -124,7 +124,7 @@ where
 // use a hackro to avoid setting all the generic types we'd need if using functions
 macro_rules! setup_test {
     ($alice_store: expr, $alice_interests: expr, $bob_store: expr, $bob_interest: expr,) => {{
-        //let _ = init_local_tracing();
+        let _ = init_local_tracing();
 
         let alice = Recon::new(
             $alice_store,
@@ -174,7 +174,7 @@ macro_rules! setup_test {
     }};
 }
 
-#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn in_sync_no_overlap() {
     let (mut swarm1, mut swarm2) = setup_test!(
         BTreeStoreErrors::default(),

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 
 use async_trait::async_trait;
-use ceramic_metrics::init_local_tracing;
 use libp2p::{metrics::Registry, PeerId, Swarm};
 use libp2p_swarm_test::SwarmExt;
+use test_log::test;
 use tracing::info;
 
 fn start_recon<K, H, S, I>(recon: Recon<K, H, S, I>) -> crate::Client<K, H>
@@ -124,7 +124,7 @@ where
 // use a hackro to avoid setting all the generic types we'd need if using functions
 macro_rules! setup_test {
     ($alice_store: expr, $alice_interests: expr, $bob_store: expr, $bob_interest: expr,) => {{
-        let _ = init_local_tracing();
+        //let _ = init_local_tracing();
 
         let alice = Recon::new(
             $alice_store,
@@ -174,7 +174,7 @@ macro_rules! setup_test {
     }};
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn in_sync_no_overlap() {
     let (mut swarm1, mut swarm2) = setup_test!(
         BTreeStoreErrors::default(),

--- a/recon/src/metrics.rs
+++ b/recon/src/metrics.rs
@@ -12,7 +12,7 @@ use prometheus_client::{
 };
 
 use crate::{
-    protocol::{InitiatorMessage, ReconMessage, ResponderMessage},
+    protocol::{InitiatorMessage, ResponderMessage},
     AssociativeHash, Key,
 };
 
@@ -22,11 +22,8 @@ pub struct Metrics {
     protocol_message_received_count: Family<MessageLabels, Counter>,
     protocol_message_sent_count: Family<MessageLabels, Counter>,
 
-    protocol_range_enqueue_failed_count: Counter,
-    protocol_range_enqueued_count: Counter,
-    protocol_range_dequeued_count: Counter,
-
-    protocol_loop_count: Counter,
+    protocol_read_loop_count: Counter,
+    protocol_write_loop_count: Counter,
     protocol_run_duration: Histogram,
 }
 
@@ -35,9 +32,9 @@ pub(crate) struct MessageLabels {
     pub(crate) message_type: &'static str,
 }
 
-impl<K: Key, H: AssociativeHash> From<&ReconMessage<InitiatorMessage<K, H>>> for MessageLabels {
-    fn from(value: &ReconMessage<InitiatorMessage<K, H>>) -> Self {
-        match value.body {
+impl<K: Key, H: AssociativeHash> From<&InitiatorMessage<K, H>> for MessageLabels {
+    fn from(value: &InitiatorMessage<K, H>) -> Self {
+        match value {
             InitiatorMessage::Value(_) => Self {
                 message_type: "Value",
             },
@@ -54,9 +51,9 @@ impl<K: Key, H: AssociativeHash> From<&ReconMessage<InitiatorMessage<K, H>>> for
     }
 }
 
-impl<K: Key, H: AssociativeHash> From<&ReconMessage<ResponderMessage<K, H>>> for MessageLabels {
-    fn from(value: &ReconMessage<ResponderMessage<K, H>>) -> Self {
-        match value.body {
+impl<K: Key, H: AssociativeHash> From<&ResponderMessage<K, H>> for MessageLabels {
+    fn from(value: &ResponderMessage<K, H>) -> Self {
+        match value {
             ResponderMessage::Value(_) => Self {
                 message_type: "Value",
             },
@@ -88,31 +85,15 @@ impl Metrics {
             Family::<MessageLabels, Counter>::default(),
             sub_registry
         );
-
         register!(
-            protocol_range_enqueue_failed_count,
-            "Number times a range is dropped when enqueing into the ranges queue",
+            protocol_read_loop_count,
+            "Number times the protocol read loop has iterated",
             Counter::default(),
             sub_registry
         );
-
         register!(
-            protocol_range_enqueued_count,
-            "Number times a range is enqued into the ranges queue",
-            Counter::default(),
-            sub_registry
-        );
-
-        register!(
-            protocol_range_dequeued_count,
-            "Number times a range is dequed from the ranges queue",
-            Counter::default(),
-            sub_registry
-        );
-
-        register!(
-            protocol_loop_count,
-            "Number times the protocol loop has iterated",
+            protocol_write_loop_count,
+            "Number times the protocol write loop has iterated",
             Counter::default(),
             sub_registry
         );
@@ -126,10 +107,8 @@ impl Metrics {
         Self {
             protocol_message_received_count,
             protocol_message_sent_count,
-            protocol_range_enqueue_failed_count,
-            protocol_range_enqueued_count,
-            protocol_range_dequeued_count,
-            protocol_loop_count,
+            protocol_read_loop_count,
+            protocol_write_loop_count,
             protocol_run_duration,
         }
     }
@@ -161,34 +140,20 @@ where
     }
 }
 
-pub(crate) struct RangeEnqueueFailed;
-impl Recorder<RangeEnqueueFailed> for Metrics {
-    fn record(&self, _event: &RangeEnqueueFailed) {
-        self.protocol_range_enqueue_failed_count.inc();
+pub(crate) struct ProtocolReadLoop;
+impl Recorder<ProtocolReadLoop> for Metrics {
+    fn record(&self, _event: &ProtocolReadLoop) {
+        self.protocol_read_loop_count.inc();
     }
 }
 
-pub(crate) struct RangeEnqueued;
-impl Recorder<RangeEnqueued> for Metrics {
-    fn record(&self, _event: &RangeEnqueued) {
-        self.protocol_range_enqueued_count.inc();
+pub(crate) struct ProtocolWriteLoop;
+impl Recorder<ProtocolWriteLoop> for Metrics {
+    fn record(&self, _event: &ProtocolWriteLoop) {
+        self.protocol_write_loop_count.inc();
     }
 }
 
-pub(crate) struct RangeDequeued;
-impl Recorder<RangeDequeued> for Metrics {
-    fn record(&self, _event: &RangeDequeued) {
-        self.protocol_range_dequeued_count.inc();
-    }
-}
-
-pub(crate) struct ProtocolLoop;
-
-impl Recorder<ProtocolLoop> for Metrics {
-    fn record(&self, _event: &ProtocolLoop) {
-        self.protocol_loop_count.inc();
-    }
-}
 pub(crate) struct ProtocolRun(pub Duration);
 impl Recorder<ProtocolRun> for Metrics {
     fn record(&self, event: &ProtocolRun) {

--- a/recon/src/metrics.rs
+++ b/recon/src/metrics.rs
@@ -22,7 +22,6 @@ pub struct Metrics {
     protocol_message_received_count: Family<MessageLabels, Counter>,
     protocol_message_sent_count: Family<MessageLabels, Counter>,
 
-    protocol_read_loop_count: Counter,
     protocol_write_loop_count: Counter,
     protocol_run_duration: Histogram,
 }
@@ -86,12 +85,6 @@ impl Metrics {
             sub_registry
         );
         register!(
-            protocol_read_loop_count,
-            "Number times the protocol read loop has iterated",
-            Counter::default(),
-            sub_registry
-        );
-        register!(
             protocol_write_loop_count,
             "Number times the protocol write loop has iterated",
             Counter::default(),
@@ -107,7 +100,6 @@ impl Metrics {
         Self {
             protocol_message_received_count,
             protocol_message_sent_count,
-            protocol_read_loop_count,
             protocol_write_loop_count,
             protocol_run_duration,
         }
@@ -137,13 +129,6 @@ where
         self.protocol_message_sent_count
             .get_or_create(&labels)
             .inc();
-    }
-}
-
-pub(crate) struct ProtocolReadLoop;
-impl Recorder<ProtocolReadLoop> for Metrics {
-    fn record(&self, _event: &ProtocolReadLoop) {
-        self.protocol_read_loop_count.inc();
     }
 }
 

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -191,7 +191,7 @@ where
         metrics.clone(),
     );
 
-    let read = read(sync_id.clone(), stream, role, to_writer_tx, metrics.clone());
+    let read = read(sync_id, stream, role, to_writer_tx, metrics.clone());
 
     // In a recon conversation there are 4 futures being polled:
     //
@@ -682,9 +682,8 @@ where
                     .range(range.first, range.last, 0, usize::MAX)
                     .await?;
                 for key in keys {
-                    if let Some(value) = recon.value_for_key(key.clone()).await? {
-                        yield Value { key, value };
-                    }
+                    let value = recon.value_for_key(key.clone()).await?.ok_or_else(|| anyhow!("recon key does not have a value: key={}", key))?;
+                    yield Value { key, value };
                 }
             }
         }

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -218,7 +218,7 @@ where
 {
     if let Some(sync_id) = &sync_id {
         // Record sync_id on the tracing span
-        tracing::Span::current().record("sync_id", &sync_id);
+        tracing::Span::current().record("sync_id", sync_id);
     }
 
     pin_mut!(stream);
@@ -277,7 +277,7 @@ where
 {
     if let Some(sync_id) = &sync_id {
         // Record sync_id on the tracing span
-        tracing::Span::current().record("sync_id", &sync_id);
+        tracing::Span::current().record("sync_id", sync_id);
     }
     pin_mut!(sink);
 
@@ -418,7 +418,7 @@ where
                     .send(ToWriter::SendAll(
                         self.common
                             .process_remote_missing_ranges(ranges.clone())
-                            .map(move |value| value.map(|value| InitiatorMessage::Value(value)))
+                            .map(|value| value.map(InitiatorMessage::Value))
                             .boxed(),
                     ))
                     .await
@@ -441,9 +441,7 @@ where
         self.pending_ranges += ranges.len();
         to_writer
             .send(ToWriter::SendWIPLimited(
-                ranges
-                    .map(move |range| InitiatorMessage::RangeRequest(range))
-                    .collect(),
+                ranges.map(InitiatorMessage::RangeRequest).collect(),
             ))
             .await
             .map_err(|err| anyhow!("{err}"))?;
@@ -556,7 +554,7 @@ where
                     .send(ToWriter::SendAll(
                         self.common
                             .process_remote_missing_ranges(ranges.clone())
-                            .map(move |value| value.map(|value| ResponderMessage::Value(value)))
+                            .map(move |value| value.map(ResponderMessage::Value))
                             // Send the range hash after we have sent all keys so the remote learns we are in
                             // sync.
                             .chain(once(Ok(ResponderMessage::RangeResponse(ranges))))

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -259,7 +259,8 @@ where
                 to_writer_tx
                     .send(ToWriter::SyncId(remote_sync_id.clone()))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending sync id")?;
                 sync_id = Some(remote_sync_id);
             }
         }
@@ -441,7 +442,8 @@ where
                             .boxed(),
                     ))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending missing values for ranges")?;
                 self.send_ranges(ranges.into_iter(), to_writer).await?;
             }
             SyncState::Unsynchronized { ranges } => {
@@ -462,7 +464,8 @@ where
                 ranges.map(InitiatorMessage::RangeRequest).collect(),
             ))
             .await
-            .map_err(|err| anyhow!("{err}"))?;
+            .map_err(|err| anyhow!("{err}"))
+            .context("sending range requests")?;
 
         Ok(())
     }
@@ -511,7 +514,8 @@ where
                 to_writer
                     .send(ToWriter::WIPCompleted(1))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending wip completed")?;
                 for range in ranges {
                     self.process_range(to_writer, range)
                         .await
@@ -523,7 +527,8 @@ where
                     to_writer
                         .send(ToWriter::Finish)
                         .await
-                        .map_err(|err| anyhow!("{err}"))?;
+                        .map_err(|err| anyhow!("{err}"))
+                        .context("sending finish")?;
                 }
             }
             ResponderMessage::Value(Value { key, value }) => {
@@ -569,7 +574,8 @@ where
                         once(Ok(ResponderMessage::RangeResponse(vec![range]))).boxed(),
                     ))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending range response synchronized")?;
             }
             SyncState::RemoteMissing { ranges } => {
                 to_writer
@@ -583,7 +589,8 @@ where
                             .boxed(),
                     ))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending missing values and range response")?;
             }
             SyncState::Unsynchronized { ranges: splits } => {
                 to_writer
@@ -591,7 +598,8 @@ where
                         once(Ok(ResponderMessage::RangeResponse(splits))).boxed(),
                     ))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending range response splits")?;
             }
         }
         Ok(())
@@ -627,7 +635,8 @@ where
                         once(Ok(ResponderMessage::InterestResponse(ranges))).boxed(),
                     ))
                     .await
-                    .map_err(|err| anyhow!("{err}"))?;
+                    .map_err(|err| anyhow!("{err}"))
+                    .context("sending interest response")?;
                 Ok(RemoteStatus::Active)
             }
             InitiatorMessage::RangeRequest(range) => {

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -1274,12 +1274,12 @@ async fn disjoint() {
             dog: [a, b, c, e, f, g]
         -> range_req({f 0 g})
             cat: [a, b, c]
+        -> range_req({g 0 𝛀 })
+            cat: [a, b, c]
         <- value(e: e)
             dog: [a, b, c, e, f, g]
         <- range_resp({e h(e)#1 f})
             dog: [a, b, c, e, f, g]
-        -> range_req({g 0 𝛀 })
-            cat: [a, b, c, e]
         <- value(f: f)
             dog: [a, b, c, e, f, g]
         <- range_resp({f h(f)#1 g})
@@ -1408,36 +1408,36 @@ async fn paper() {
             cat: [ape, eel, fox, gnu]
         <- range_resp({𝚨 0 ape})
             dog: [bee, cot, doe, eel, fox, hog]
+        -> range_req({eel h(eel)#1 fox})
+            cat: [ape, eel, fox, gnu]
+        -> range_req({fox h(fox)#1 gnu})
+            cat: [ape, eel, fox, gnu]
+        -> range_req({gnu h(gnu)#1 𝛀 })
+            cat: [ape, eel, fox, gnu]
         <- value(bee: bee)
             dog: [bee, cot, doe, eel, fox, hog]
         <- value(cot: cot)
             dog: [bee, cot, doe, eel, fox, hog]
-        -> range_req({eel h(eel)#1 fox})
-            cat: [ape, bee, eel, fox, gnu]
         <- value(doe: doe)
             dog: [bee, cot, doe, eel, fox, hog]
-        -> range_req({fox h(fox)#1 gnu})
-            cat: [ape, bee, cot, eel, fox, gnu]
         <- range_resp({ape 0 bee}, {bee h(bee, cot, doe)#3 eel})
             dog: [bee, cot, doe, eel, fox, hog]
-        -> range_req({gnu h(gnu)#1 𝛀 })
-            cat: [ape, bee, cot, doe, eel, fox, gnu]
+        <- range_resp({eel h(eel)#1 fox})
+            dog: [bee, cot, doe, eel, fox, hog]
         -> value(ape: ape)
             cat: [ape, bee, cot, doe, eel, fox, gnu]
-        <- range_resp({eel h(eel)#1 fox})
+        <- range_resp({fox h(fox)#1 gnu})
             dog: [bee, cot, doe, eel, fox, hog]
         -> range_req({ape h(ape)#1 bee})
             cat: [ape, bee, cot, doe, eel, fox, gnu]
-        <- range_resp({fox h(fox)#1 gnu})
-            dog: [ape, bee, cot, doe, eel, fox, hog]
         <- value(hog: hog)
             dog: [ape, bee, cot, doe, eel, fox, hog]
         <- range_resp({gnu 0 hog}, {hog h(hog)#1 𝛀 })
             dog: [ape, bee, cot, doe, eel, fox, hog]
+        <- range_resp({ape h(ape)#1 bee})
+            dog: [ape, bee, cot, doe, eel, fox, hog]
         -> value(gnu: gnu)
             cat: [ape, bee, cot, doe, eel, fox, gnu, hog]
-        <- range_resp({ape h(ape)#1 bee})
-            dog: [ape, bee, cot, doe, eel, fox, gnu, hog]
         -> range_req({gnu h(gnu)#1 hog})
             cat: [ape, bee, cot, doe, eel, fox, gnu, hog]
         <- range_resp({gnu h(gnu)#1 hog})
@@ -1483,30 +1483,30 @@ async fn small_diff() {
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
         -> range_req({p h(p)#1 q})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        -> range_req({t h(t)#1 u})
-            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({o h(o)#1 p})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({u h(u)#1 v})
+        -> range_req({t h(t)#1 u})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({p h(p)#1 q})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({v h(v)#1 w})
+        -> range_req({u h(u)#1 v})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({t h(t)#1 u})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({w h(w)#1 x})
+        -> range_req({v h(v)#1 w})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({u h(u)#1 v})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
-        -> value(n: n)
+        -> range_req({w h(w)#1 x})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({v 0 w})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({n h(n)#1 o})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, q, r, s, t, u, w, x, y, z]
+        -> value(n: n)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({w h(w)#1 x})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
+        -> range_req({n h(n)#1 o})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         -> value(v: v)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({n h(n)#1 o})
@@ -1559,26 +1559,26 @@ async fn small_diff_off_by_one() {
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
         -> range_req({t h(t)#1 u})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        -> range_req({u h(u)#1 v})
-            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({p h(p)#1 q})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({v h(v)#1 w})
+        -> range_req({u h(u)#1 v})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({t h(t)#1 u})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({w h(w)#1 x})
+        -> range_req({v h(v)#1 w})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({u h(u)#1 v})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> value(o: o)
+        -> range_req({w h(w)#1 x})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({v 0 w})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({o h(o)#1 p})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
+        -> value(o: o)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({w h(w)#1 x})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
+        -> range_req({o h(o)#1 p})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         -> value(v: v)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({o h(o)#1 p})
@@ -1619,128 +1619,128 @@ async fn alternating() {
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> value(a: a)
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
+        <- range_resp({g 0 h}, {h h(h)#1 j}, {j h(j)#1 l}, {l h(l)#1 n})
+            dog: [a, c, d, f, h, j, l, n, p, q, s, u, w, y, z]
         -> value(b: b)
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> range_req({a h(a, b)#2 c})
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> value(e: e)
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        <- range_resp({g 0 h}, {h h(h)#1 j}, {j h(j)#1 l}, {l h(l)#1 n})
-            dog: [a, b, c, d, e, f, h, j, l, n, p, q, s, u, w, y, z]
+        <- range_resp({n h(n)#1 p}, {p h(p)#1 q}, {q h(q)#1 s}, {s h(s)#1 t})
+            dog: [a, b, c, d, f, h, j, l, n, p, q, s, u, w, y, z]
         -> range_req({d 0 e})
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> range_req({e h(e)#1 f})
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
+        <- range_resp({t 0 u}, {u h(u)#1 w}, {w h(w)#1 y}, {y h(y)#1 z}, {z h(z)#1 𝛀 })
+            dog: [a, b, c, d, e, f, h, j, l, n, p, q, s, u, w, y, z]
         -> range_req({f 0 g})
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> value(g: g)
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
         -> range_req({g h(g)#1 h})
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
+        <- range_resp({a h(a, b)#2 c})
+            dog: [a, b, c, d, e, f, g, h, j, l, n, p, q, s, u, w, y, z]
         -> value(i: i)
             cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        <- range_resp({n h(n)#1 p}, {p h(p)#1 q}, {q h(q)#1 s}, {s h(s)#1 t})
+        <- value(d: d)
             dog: [a, b, c, d, e, f, g, h, i, j, l, n, p, q, s, u, w, y, z]
         -> range_req({h 0 i})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> range_req({i h(i)#1 j})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> value(k: k)
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> range_req({j 0 k})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        <- range_resp({t 0 u}, {u h(u)#1 w}, {w h(w)#1 y}, {y h(y)#1 z}, {z h(z)#1 𝛀 })
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, n, p, q, s, u, w, y, z]
-        -> range_req({k h(k)#1 l})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> value(m: m)
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> range_req({l 0 m})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> range_req({m h(m)#1 n})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> value(o: o)
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        -> range_req({n 0 o})
-            cat: [a, b, c, e, g, i, k, m, o, p, r, t, v, x, z]
-        <- range_resp({a h(a, b)#2 c})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
-        <- value(d: d)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
-        -> range_req({o h(o)#1 p})
             cat: [a, b, c, d, e, g, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({d h(d)#1 e})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
-        -> value(r: r)
+            dog: [a, b, c, d, e, f, g, h, i, j, l, n, p, q, s, u, w, y, z]
+        -> range_req({i h(i)#1 j})
             cat: [a, b, c, d, e, g, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({e h(e)#1 f})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
-        -> range_req({q 0 r})
+            dog: [a, b, c, d, e, f, g, h, i, j, l, n, p, q, s, u, w, y, z]
+        -> value(k: k)
             cat: [a, b, c, d, e, g, i, k, m, o, p, r, t, v, x, z]
         <- value(f: f)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, n, p, q, s, u, w, y, z]
+        -> range_req({j 0 k})
+            cat: [a, b, c, d, e, f, g, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({f h(f)#1 g})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
-        -> range_req({r h(r)#1 s})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, n, p, q, s, u, w, y, z]
+        -> range_req({k h(k)#1 l})
             cat: [a, b, c, d, e, f, g, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({g h(g)#1 h})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
-        -> range_req({s 0 t})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, n, p, q, s, u, w, y, z]
+        -> value(m: m)
             cat: [a, b, c, d, e, f, g, i, k, m, o, p, r, t, v, x, z]
         <- value(h: h)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, s, u, w, y, z]
+        -> range_req({l 0 m})
+            cat: [a, b, c, d, e, f, g, h, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({h h(h)#1 i})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
-        -> value(t: t)
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, s, u, w, y, z]
+        -> range_req({m h(m)#1 n})
             cat: [a, b, c, d, e, f, g, h, i, k, m, o, p, r, t, v, x, z]
         <- range_resp({i h(i)#1 j})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
-        -> range_req({t h(t)#1 u})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, s, u, w, y, z]
+        -> value(o: o)
             cat: [a, b, c, d, e, f, g, h, i, k, m, o, p, r, t, v, x, z]
         <- value(j: j)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, y, z]
-        -> value(v: v)
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
+        -> range_req({n 0 o})
             cat: [a, b, c, d, e, f, g, h, i, j, k, m, o, p, r, t, v, x, z]
         <- range_resp({j h(j)#1 k})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, y, z]
-        -> range_req({u 0 v})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
+        -> range_req({o h(o)#1 p})
             cat: [a, b, c, d, e, f, g, h, i, j, k, m, o, p, r, t, v, x, z]
         <- range_resp({k h(k)#1 l})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, s, u, w, y, z]
+        -> value(r: r)
+            cat: [a, b, c, d, e, f, g, h, i, j, k, m, o, p, r, t, v, x, z]
         <- value(l: l)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
-        -> range_req({v h(v)#1 w})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+        -> range_req({q 0 r})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, r, t, v, x, z]
         <- range_resp({l h(l)#1 m})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
-        -> value(x: x)
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+        -> range_req({r h(r)#1 s})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, r, t, v, x, z]
         <- range_resp({m h(m)#1 n})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
-        -> range_req({w 0 x})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+        -> range_req({s 0 t})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, o, p, r, t, v, x, z]
         <- value(n: n)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, u, w, y, z]
+        -> value(t: t)
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, r, t, v, x, z]
         <- range_resp({n h(n)#1 o})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        -> range_req({x h(x)#1 y})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, y, z]
+        -> range_req({t h(t)#1 u})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, r, t, v, x, z]
         <- range_resp({o h(o)#1 p})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        -> range_req({y 0 z})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, y, z]
+        -> value(v: v)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, r, t, v, x, z]
         <- value(q: q)
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
+        -> range_req({u 0 v})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, t, v, x, z]
         <- range_resp({q h(q)#1 r})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
+        -> range_req({v h(v)#1 w})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, t, v, x, z]
         <- range_resp({r h(r)#1 s})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, y, z]
+        -> value(x: x)
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, t, v, x, z]
         <- value(s: s)
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+        -> range_req({w 0 x})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, v, x, z]
         <- range_resp({s h(s)#1 t})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+        -> range_req({y 0 z})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, v, x, z]
         <- range_resp({t h(t)#1 u})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+        -> range_req({x h(x)#1 y})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, v, x, z]
         <- value(u: u)
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({u h(u)#1 v})
@@ -1751,11 +1751,11 @@ async fn alternating() {
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({w h(w)#1 x})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        <- range_resp({x h(x)#1 y})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- value(y: y)
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         <- range_resp({y h(y)#1 z})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+        <- range_resp({x h(x)#1 y})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
         -> finished
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
@@ -1802,48 +1802,48 @@ async fn small_diff_zz() {
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
         -> range_req({t h(t)#1 u})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
-        -> range_req({u h(u)#1 v})
-            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({p h(p)#1 q})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({v h(v)#1 w})
+        -> range_req({u h(u)#1 v})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({t h(t)#1 u})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({w h(w)#1 x})
+        -> range_req({v h(v)#1 w})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({u h(u)#1 v})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({x h(x)#1 y})
+        -> range_req({w h(w)#1 x})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({v 0 w})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({y h(y)#1 z})
-            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
-        -> range_req({z h(z)#1 zz})
+        -> range_req({x h(x)#1 y})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({w h(w)#1 x})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> range_req({zz h(zz)#1 𝛀 })
+        -> range_req({y h(y)#1 z})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({x h(x)#1 y})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
-        -> value(o: o)
+        -> range_req({z h(z)#1 zz})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({y h(y)#1 z})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
+        -> range_req({zz h(zz)#1 𝛀 })
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
+        <- range_resp({z h(z)#1 zz})
+            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, p, q, r, s, t, u, w, x, y, z]
+        -> value(o: o)
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
+        <- range_resp({zz 0 𝛀 })
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
         -> range_req({o h(o)#1 p})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
-        <- range_resp({z h(z)#1 zz})
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, w, x, y, z]
         -> value(v: v)
-            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
-        <- range_resp({zz 0 𝛀 })
-            dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
-        -> range_req({v h(v)#1 w})
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({o h(o)#1 p})
             dog: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]
+        -> range_req({v h(v)#1 w})
+            cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         -> value(zz: zz)
             cat: [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, zz]
         <- range_resp({v h(v)#1 w})
@@ -1946,32 +1946,32 @@ async fn subset_interest() {
             cat: [c, f, g, r]
         <- range_resp({b h(b, c, d)#3 e}, {e h(e, f, g, h)#4 i})
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
-        <- value(m: m)
-            dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
         -> range_req({b 0 c})
             cat: [c, f, g, r]
-        <- value(n: n)
-            dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
-        <- range_resp({m h(m, n)#2 r})
+        <- value(m: m)
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
         -> range_req({c h(c)#1 e})
+            cat: [c, f, g, m, r]
+        <- value(n: n)
+            dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
+        -> range_req({e 0 f})
+            cat: [c, f, g, m, n, r]
+        <- range_resp({m h(m, n)#2 r})
+            dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
+        -> range_req({f h(f)#1 g})
             cat: [c, f, g, m, n, r]
         <- value(b: b)
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
+        -> range_req({g h(g)#1 i})
+            cat: [b, c, f, g, m, n, r]
         <- range_resp({b h(b)#1 c})
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
-        -> range_req({e 0 f})
-            cat: [b, c, f, g, m, n, r]
         <- value(c: c)
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
         <- value(d: d)
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
-        -> range_req({f h(f)#1 g})
-            cat: [b, c, d, f, g, m, n, r]
         <- range_resp({c h(c, d)#2 e})
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
-        -> range_req({g h(g)#1 i})
-            cat: [b, c, d, f, g, m, n, r]
         <- value(e: e)
             dog: [b, c, d, e, f, g, h, i, j, k, l, m, n]
         <- range_resp({e h(e)#1 f})


### PR DESCRIPTION
If two nodes each had 2K+ events that the other node did not have it was possible for the protocol to deadlock as both nodes tried to write those events without read the values from the other node.

The fix was accomplished by splitting the protocol into two loops, a read loop and a write loop. They communicate with each other using message passing. The code now has both a clean separation of concerns as well as the behavior that we concurrently read and write from the network so we do not enter a state where we are exclusively writing to the network.