### PR TITLE
fix: Add context to init event header

### DIFF
--- a/event/src/unvalidated/builder.rs
+++ b/event/src/unvalidated/builder.rs
@@ -61,6 +61,7 @@ pub struct InitBuilderWithSep<D> {
     unique: Option<Vec<u8>>,
     data: Option<D>,
     should_index: Option<bool>,
+    context: Option<Vec<u8>>,
 }
 impl<D> InitBuilderState for InitBuilderWithSep<D> {}
 impl InitBuilder<InitBuilderWithController> {
@@ -73,6 +74,7 @@ impl InitBuilder<InitBuilderWithController> {
                 unique: None,
                 data: None,
                 should_index: None,
+                context: None,
             },
         }
     }
@@ -82,6 +84,12 @@ impl<D> InitBuilder<InitBuilderWithSep<D>> {
     /// Specify the unique bytes.
     pub fn with_unique(mut self, unique: Vec<u8>) -> Self {
         self.state.unique = Some(unique);
+        self
+    }
+
+    /// Specify the context.
+    pub fn with_context(mut self, context: Vec<u8>) -> Self {
+        self.state.context = Some(context);
         self
     }
 
@@ -104,6 +112,7 @@ impl<D> InitBuilder<InitBuilderWithSep<D>> {
             self.state.sep.value,
             self.state.should_index,
             self.state.unique,
+            self.state.context,
         );
         unvalidated::init::Payload::new(header, self.state.data)
     }

--- a/event/src/unvalidated/payload/init.rs
+++ b/event/src/unvalidated/payload/init.rs
@@ -39,6 +39,8 @@ pub struct Header {
     should_index: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     unique: Option<Bytes>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    context: Option<Bytes>,
 }
 
 impl Header {
@@ -49,6 +51,7 @@ impl Header {
         model: Vec<u8>,
         should_index: Option<bool>,
         unique: Option<Vec<u8>>,
+        context: Option<Vec<u8>>,
     ) -> Self {
         Self {
             controllers,
@@ -56,6 +59,7 @@ impl Header {
             model: Bytes::from(model),
             should_index,
             unique: unique.map(Bytes::from),
+            context: context.map(Bytes::from),
         }
     }
 


### PR DESCRIPTION
The "context" field was added to support OrbisDB, see [forum.ceramic.network/t/asking-for-support-of-the-context-field-in-the-metadata-object-for-streams/1425](https://forum.ceramic.network/t/asking-for-support-of-the-context-field-in-the-metadata-object-for-streams/1425) for more info.