### PR TITLE
feat: disallow events with unexpected fields via the http api

### DIFF
--- a/api/src/server/event.rs
+++ b/api/src/server/event.rs
@@ -16,11 +16,14 @@ where
     R: AsyncRead + Send + Unpin,
     S: EventStore,
 {
-    let (event_cid, event) = event_from_car(reader).await?;
+    let (event_cid, event) = event_from_car(reader, false).await?;
     event_id_for_event(event_cid, event, network, store).await
 }
 
-async fn event_from_car<R>(reader: R) -> Result<(Cid, unvalidated::Event<Ipld>)>
+async fn event_from_car<R>(
+    reader: R,
+    allow_unexpected_fields: bool,
+) -> Result<(Cid, unvalidated::Event<Ipld>)>
 where
     R: AsyncRead + Send + Unpin,
 {
@@ -42,7 +45,17 @@ where
         .ok_or_else(|| anyhow!("Event CAR data missing block for root CID"))?;
     let raw_event: unvalidated::RawEvent<Ipld> =
         serde_ipld_dagcbor::from_slice(event_bytes).context("decoding event")?;
-    // TODO(stbrody) add check for round-trip-ability to catch extra fields.
+
+    if !allow_unexpected_fields {
+        // Re-serialize the event and compare the bytes. This indirectly checks that there were no
+        // unexpected fields in the event sent by the client.
+        let event_bytes_reserialized = serde_ipld_dagcbor::to_vec(&raw_event)?;
+        if !event_bytes.eq(&event_bytes_reserialized) {
+            return Err(anyhow!(
+                "Event bytes do not round-trip. This mostly means the event contains unexpected fields."
+            ));
+        }
+    }
 
     match raw_event {
         unvalidated::RawEvent::Time(event) => Ok((event_cid, unvalidated::Event::Time(event))),
@@ -56,7 +69,15 @@ where
                 .ok_or_else(|| anyhow!("Signed Event CAR data missing block for payload"))?;
             let payload: unvalidated::Payload<Ipld> =
                 serde_ipld_dagcbor::from_slice(payload_bytes).context("decoding payload")?;
-            // TODO(stbrody) add check for round-trip-ability to catch extra fields.
+
+            if !allow_unexpected_fields {
+                // Re-serialize the payload and compare the bytes. This indirectly checks that there
+                // were no unexpected fields in the event sent by the client.
+                let payload_bytes_reserialized = serde_ipld_dagcbor::to_vec(&payload)?;
+                if !payload_bytes.eq(&payload_bytes_reserialized) {
+                    return Err(anyhow!("Signed event payload bytes do not round-trip. This mostly means the event contains unexpected fields."));
+                }
+            }
 
             Ok((
                 event_cid,

--- a/event/src/unvalidated/payload/init.rs
+++ b/event/src/unvalidated/payload/init.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct Payload<D> {
     header: Header,
-    #[serde(skip_serializing_if = "Option::is_none")]
     data: Option<D>,
 }
 


### PR DESCRIPTION
builds on https://github.com/ceramicnetwork/rust-ceramic/pull/362.

There was no easy way to unit test this change, but I have a PR ready for a test in ceramic-tests that will exercise this: https://github.com/3box/ceramic-tests/pull/129