### PR TITLE
fix: events incorrectly left undelivered

### DIFF
--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -17,17 +17,30 @@ async fn setup_service() -> CeramicEventService {
         .unwrap()
 }
 
+async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
+    let new = store
+        .insert_events_from_carfiles_remote_history(&[item])
+        .await
+        .unwrap();
+    let new = new.keys.into_iter().filter(|k| *k).count();
+    assert_eq!(1, new);
+}
+
+async fn add_and_assert_new_local_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
+    let new = store
+        .insert_events_from_carfiles_local_history(&[item])
+        .await
+        .unwrap();
+    let new = new.keys.into_iter().filter(|k| *k).count();
+    assert_eq!(1, new);
+}
+
 #[tokio::test]
 async fn test_init_event_delivered() {
     let store = setup_service().await;
     let events = get_events().await;
     let init = &events[0];
-    let new = store
-        .insert_events_from_carfiles_local_history(&[ReconItem::new(&init.0, &init.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(new, 1);
+    add_and_assert_new_local_event(&store, ReconItem::new(&init.0, &init.1)).await;
     check_deliverable(&store.pool, &init.0.cid().unwrap(), true).await;
 }
 
@@ -64,19 +77,10 @@ async fn test_prev_exists_history_required() {
     let events = get_events().await;
     let init: &(EventId, Vec<u8>) = &events[0];
     let data = &events[1];
-    let new = store
-        .insert_events_from_carfiles_local_history(&[ReconItem::new(&init.0, &init.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(1, new);
+    add_and_assert_new_local_event(&store, ReconItem::new(&init.0, &init.1)).await;
     check_deliverable(&store.pool, &init.0.cid().unwrap(), true).await;
-    let new = store
-        .insert_events_from_carfiles_local_history(&[ReconItem::new(&data.0, &data.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(1, new);
+
+    add_and_assert_new_local_event(&store, ReconItem::new(&data.0, &data.1)).await;
     check_deliverable(&store.pool, &data.0.cid().unwrap(), true).await;
 
     let (_, delivered) = store
@@ -121,12 +125,7 @@ async fn test_missing_prev_pending_recon() {
     let store = setup_service().await;
     let events = get_events().await;
     let data = &events[1];
-    let new = store
-        .insert_events_from_carfiles_remote_history(&[ReconItem::new(&data.0, &data.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(new, 1);
+    add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
     check_deliverable(&store.pool, &data.0.cid().unwrap(), false).await;
 
     let (_, delivered) = store
@@ -136,13 +135,8 @@ async fn test_missing_prev_pending_recon() {
     assert_eq!(0, delivered.len());
 
     let data = &events[2];
+    add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
 
-    let new = store
-        .insert_events_from_carfiles_remote_history(&[ReconItem::new(&data.0, &data.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(new, 1);
     check_deliverable(&store.pool, &data.0.cid().unwrap(), false).await;
 
     let (_, delivered) = store
@@ -152,12 +146,7 @@ async fn test_missing_prev_pending_recon() {
     assert_eq!(0, delivered.len());
     // now we add the init and we should see init, data 1 (first stored), data 2 (second stored) as highwater returns
     let data = &events[0];
-    let new = store
-        .insert_events_from_carfiles_remote_history(&[ReconItem::new(&data.0, &data.1)])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(new, 1);
+    add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
     check_deliverable(&store.pool, &data.0.cid().unwrap(), true).await;
 
     // This happens out of band, so give it a moment to make sure everything is updated
@@ -173,6 +162,107 @@ async fn test_missing_prev_pending_recon() {
         events[0].0.cid().unwrap(),
         events[1].0.cid().unwrap(),
         events[2].0.cid().unwrap(),
+    ];
+    assert_eq!(expected, delivered);
+}
+
+#[tokio::test]
+async fn missing_prev_pending_recon_should_deliver_without_stream_update() {
+    let store = setup_service().await;
+    let events = get_events().await;
+
+    let data = &events[0];
+    add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
+    check_deliverable(&store.pool, &data.0.cid().unwrap(), true).await;
+
+    // now we add the second event, it should quickly become deliverable
+    let data = &events[1];
+    add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
+    check_deliverable(&store.pool, &data.0.cid().unwrap(), false).await;
+    // This happens out of band, so give it a moment to make sure everything is updated
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let (_, delivered) = store
+        .events_since_highwater_mark(0, i64::MAX)
+        .await
+        .unwrap();
+    assert_eq!(2, delivered.len());
+
+    let expected = vec![events[0].0.cid().unwrap(), events[1].0.cid().unwrap()];
+    assert_eq!(expected, delivered);
+}
+
+#[tokio::test]
+async fn multiple_streams_missing_prev_recon_should_deliver_without_stream_update() {
+    let store = setup_service().await;
+    let stream_1 = get_events().await;
+    let stream_2 = get_events().await;
+
+    let s1_init = &stream_1[0];
+    let s1_2 = &stream_1[1];
+    let s1_3 = &stream_1[2];
+
+    let s2_init = &stream_2[0];
+    let s2_2 = &stream_2[1];
+    let s2_3 = &stream_2[2];
+
+    // store the first event in both streams.
+    // we could do insert as a list, but to make sure we have the ordering we expect at the end we do them one by one
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s1_init.0, &s1_init.1)).await;
+    check_deliverable(&store.pool, &s1_init.0.cid().unwrap(), true).await;
+
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s2_init.0, &s2_init.1)).await;
+    check_deliverable(&store.pool, &s2_init.0.cid().unwrap(), true).await;
+
+    // now we add the third event for both and they should be stuck in pending
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s1_3.0, &s1_3.1)).await;
+    check_deliverable(&store.pool, &s1_3.0.cid().unwrap(), false).await;
+
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s2_3.0, &s2_3.1)).await;
+    check_deliverable(&store.pool, &s2_3.0.cid().unwrap(), false).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let (_, delivered) = store
+        .events_since_highwater_mark(0, i64::MAX)
+        .await
+        .unwrap();
+    assert_eq!(2, delivered.len());
+
+    // now we add the second event for stream 1, it should unlock the first stream completely but not the second
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s1_2.0, &s1_2.1)).await;
+
+    // this _could_ be deliverable immediately if we checked but for now we just send to the other task,
+    // so `check_deliverable` could return true or false depending on timing (but probably false).
+    // as this is an implementation detail and we'd prefer true, we just use HW ordering to make sure it's been delivered
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let (_, delivered) = store
+        .events_since_highwater_mark(0, i64::MAX)
+        .await
+        .unwrap();
+    assert_eq!(4, delivered.len());
+    let expected: Vec<cid::CidGeneric<64>> = vec![
+        s1_init.0.cid().unwrap(),
+        s2_init.0.cid().unwrap(),
+        s1_2.0.cid().unwrap(),
+        s1_3.0.cid().unwrap(),
+    ];
+    assert_eq!(expected, delivered);
+
+    // now discover the second event for the second stream and everything will be stored
+    add_and_assert_new_recon_event(&store, ReconItem::new(&s2_2.0, &s2_2.1)).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    let (_, delivered) = store
+        .events_since_highwater_mark(0, i64::MAX)
+        .await
+        .unwrap();
+    let expected = vec![
+        s1_init.0.cid().unwrap(),
+        s2_init.0.cid().unwrap(),
+        s1_2.0.cid().unwrap(),
+        s1_3.0.cid().unwrap(),
+        s2_2.0.cid().unwrap(),
+        s2_3.0.cid().unwrap(),
     ];
     assert_eq!(expected, delivered);
 }


### PR DESCRIPTION
Before, an event might be left hanging undelivered until an additional event came in for the stream. Now we check undelivered events for a stream any time something is added to it (whether we expect it to unblock something or not).

Originally, I naively used interval loops to check all pending streams, and checked all events in cases that were unnecessary. So I decided to be more clever and only check a stream when something impacted it directly, and remove the silly interval looping that was checking things we _knew_ we couldn't process. Only I overlooked the fact that I removed checking incoming events when they had a `prev` *at all* until a write came in that we expected might unblock something. This left an entire set of events (i.e. the SECOND one) unchecked, and without the interval or gratuitous looping to save my bacon, the stream could sit undelivered indefinitely. 

Now that doesn't happen and they get checked right away. I simplified the `select!` logic, removing most logic from the handlers to make it easier to reason about. This will cause us to read and parse the events from the database when we may not have strictly needed to, but it keeps all branches consistent and ensures that the database is indeed as we expect. I also modified the function that marks events deliverable to be cancel safe at the cost of cloning the cid array.

Most of the changes are adding and cleaning up the tests. I still would like to consider interval/expiration logic to make sure things aren't stuck forever and smarter memory pruning etc, but I feel like I've already overcomplicated this and would like to make sure it works and see if it's possible to simplify before adding more. The napkin math I did makes me feel okay about it.

With this commit applied after the original [IOD PR@34b270f](https://github.com/ceramicnetwork/rust-ceramic/commit/34b270f6942493105988adf4a2095e343e91563d) all the js-ceramic tests pass for me locally. There is however a second bug I suspect caused by #356 that I haven't quite pinned it down yet. It appears that in the tests, nodes can start talking and find that they share no interests, have interests added, but never discover that those interests are now in common (or maybe it's something else, but they don't sync properly and there seemed to be a lot of "waiting for peer" after `interests=[]`).