### PR TITLE
chore: version v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.20.0] - 2024-05-24
+
+### 🚀 Features
+
+- Add interests endpoint for inspecting interests of a node (#353)
+
+### 🐛 Bug Fixes
+
+- Add context to init event header (#360)
+- Events incorrectly left undelivered (#366)
+- Recon protocol stall with no shared interests (#367)
+
 ## [0.19.0] - 2024-05-20
 
 ### 🚀 Features
@@ -35,6 +47,7 @@ All notable changes to this project will be documented in this file.
 - Review and test fixes
 - Unused deps
 - Make event struct fields private (#359)
+- Version v0.19.0 (#361)
 
 ## [0.18.0] - 2024-05-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "built",
  "project-root",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1233,7 +1233,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1324,7 +1324,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-service"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1357,7 +1357,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3744,7 +3744,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -6628,7 +6628,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.19.0
-- Build date: 2024-05-21T13:44:55.207918-06:00[America/Denver]
+- API version: 0.20.0
+- Build date: 2024-05-24T16:16:25.931823455Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.19.0
+  version: 0.20.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.19.0";
+pub const API_VERSION: &str = "0.20.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.19.0
+  version: 0.20.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.19.0
-- Build date: 2024-05-20T19:03:01.091569782Z[Etc/UTC]
+- API version: 0.20.0
+- Build date: 2024-05-24T16:16:28.027842851Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.19.0
+  version: 0.20.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.19.0";
+pub const API_VERSION: &str = "0.20.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.19.0
+  version: 0.20.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.20.0] - 2024-05-24

### 🚀 Features

- Add interests endpoint for inspecting interests of a node (#353)

### 🐛 Bug Fixes

- Add context to init event header (#360)
- Events incorrectly left undelivered (#366)
- Recon protocol stall with no shared interests (#367)