### PR TITLE
chore: rename prometheus registry and metrics for better consistency

### DIFF
--- a/metrics/src/core.rs
+++ b/metrics/src/core.rs
@@ -16,7 +16,7 @@ pub(crate) struct Core {
 
 impl Default for Core {
     fn default() -> Self {
-        let mut reg = Registry::default();
+        let mut reg = Registry::with_prefix("ceramic_one");
         Core {
             bitswap_metrics: bitswap::Metrics::new(&mut reg),
             libp2p_metrics: libp2p::metrics::Metrics::new(&mut reg),

--- a/one/src/http_metrics.rs
+++ b/one/src/http_metrics.rs
@@ -62,11 +62,7 @@ impl Metrics {
             api_version: ceramic_api_server::API_VERSION,
             kubo_api_version: ceramic_kubo_rpc_server::API_VERSION,
         });
-        sub_registry.register(
-            "http_api",
-            "Information about the Ceramic and Kubo APIs",
-            info,
-        );
+        sub_registry.register("info", "Information about the Ceramic and Kubo APIs", info);
 
         Self {
             requests,

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -43,13 +43,13 @@ impl From<&StorageQuery> for QueryLabels {
 pub struct Metrics {
     key_value_insert_count: Counter,
 
-    store_query_durations: Family<QueryLabels, Histogram>,
+    query_durations: Family<QueryLabels, Histogram>,
 }
 
 impl Metrics {
     /// Register and construct Metrics
     pub fn register(registry: &mut Registry) -> Self {
-        let sub_registry = registry.sub_registry_with_prefix("ceramic_store");
+        let sub_registry = registry.sub_registry_with_prefix("store");
 
         register!(
             key_value_insert_count,
@@ -59,7 +59,7 @@ impl Metrics {
         );
 
         register!(
-            store_query_durations,
+            query_durations,
             "Durations of store queries in seconds",
             Family::<QueryLabels, Histogram>::new_with_constructor(|| {
                 Histogram::new(exponential_buckets(0.005, 2.0, 20))
@@ -69,7 +69,7 @@ impl Metrics {
 
         Self {
             key_value_insert_count,
-            store_query_durations,
+            query_durations,
         }
     }
 }
@@ -83,7 +83,7 @@ impl Recorder<InsertEvent> for Metrics {
 impl Recorder<StorageQuery> for Metrics {
     fn record(&self, event: &StorageQuery) {
         let labels: QueryLabels = event.into();
-        self.store_query_durations
+        self.query_durations
             .get_or_create(&labels)
             .observe(event.duration.as_secs_f64());
     }


### PR DESCRIPTION
This will break existing dashboards (of which there are few well defined examples I believe), but it will make building new ones much easier as all metrics will start with `ceramic_one_` now. This also renamed `http_api_http_api` to `ceramic_one_http_api_info` and `ceramic_store_store_query_durations` will now be `ceramic_one_store_query_durations`, and other store metrics will be under `ceramic_one_store`.

The existing tokio, recon, libp2p, bitswap subregistries are all under ceramic_one now:
<img width="351" alt="image" src="https://github.com/ceramicnetwork/rust-ceramic/assets/5317198/594e47ad-2da5-46e7-97ca-5ca6d49af943">
