### PR TITLE
chore: version v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.22.0] - 2024-06-10
+
+### 🚀 Features
+
+- Get feed highwater mark to start from "now" (#370)
+
+### ⚙️ Miscellaneous Tasks
+
+- Fix prom cardinality for test path (#372)
+
 ## [0.21.0] - 2024-06-03
 
 ### 🚀 Features
@@ -13,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 - Rename store traits to InterestStore and EventStore (#365)
 - Deserialize CAR into Event before extracting EventID. (#362)
+- Version v0.21.0 (#371)
 
 ## [0.20.0] - 2024-05-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "built",
  "project-root",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "ceramic-api",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-service"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3726,7 +3726,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3741,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -6625,7 +6625,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.21.0
-- Build date: 2024-06-03T09:28:50.638487-06:00[America/Denver]
+- API version: 0.22.0
+- Build date: 2024-06-10T17:23:37.394284270Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.21.0
+  version: 0.22.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.21.0";
+pub const API_VERSION: &str = "0.22.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.21.0
+  version: 0.22.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.21.0
-- Build date: 2024-06-03T14:31:03.706447593Z[Etc/UTC]
+- API version: 0.22.0
+- Build date: 2024-06-10T17:23:39.459803517Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.21.0
+  version: 0.22.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.21.0";
+pub const API_VERSION: &str = "0.22.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.21.0
+  version: 0.22.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.22.0] - 2024-06-10

### 🚀 Features

- Get feed highwater mark to start from "now" (#370)

### ⚙️ Miscellaneous Tasks

- Fix prom cardinality for test path (#372)