### PR TITLE
fix: IOD long streams could remain undelivered

### DIFF
--- a/service/src/event/migration.rs
+++ b/service/src/event/migration.rs
@@ -327,11 +327,7 @@ impl EventBuilder {
             .build();
         Ok(EventInsertable::try_new(
             event_id,
-            EventInsertableBody {
-                cid: self.event_cid,
-                deliverable: false,
-                blocks: self.blocks,
-            },
+            EventInsertableBody::new(self.event_cid, self.blocks, false),
         )?)
     }
 }

--- a/service/src/event/mod.rs
+++ b/service/src/event/mod.rs
@@ -1,4 +1,5 @@
 mod migration;
+mod order_events;
 mod ordering_task;
 mod service;
 mod store;

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -1,0 +1,100 @@
+use std::collections::HashSet;
+
+use ceramic_store::{CeramicOneEvent, EventInsertable, SqlitePool};
+use cid::Cid;
+
+use crate::Result;
+
+use super::service::EventHeader;
+
+pub(crate) struct OrderEvents {
+    pub(crate) deliverable: Vec<(EventInsertable, EventHeader)>,
+    pub(crate) missing_history: Vec<(EventInsertable, EventHeader)>,
+}
+
+impl OrderEvents {
+    /// Groups the events into lists of those with a delivered prev and those without. This can be used to return an error if the event is required to have history.
+    /// The events will be marked as deliverable so that they can be passed directly to the store to be persisted.
+    /// Will look up the prev from the database if needed to check if it's deliverable (could possibly change this for recon and allow the ordering task to handle it?)
+    pub async fn try_new(
+        pool: &SqlitePool,
+        mut candidate_events: Vec<(EventInsertable, EventHeader)>,
+    ) -> Result<Self> {
+        let new_cids: HashSet<Cid> =
+            HashSet::from_iter(candidate_events.iter().map(|(e, _)| e.cid()));
+        let mut deliverable = Vec::with_capacity(candidate_events.len());
+        candidate_events.retain(|(e, h)| {
+            if e.deliverable() {
+                deliverable.push((e.clone(), h.clone()));
+                false
+            } else {
+                true
+            }
+        });
+        if candidate_events.is_empty() {
+            return Ok(OrderEvents {
+                deliverable,
+                missing_history: Vec::new(),
+            });
+        }
+
+        let mut prevs_in_memory = Vec::with_capacity(candidate_events.len());
+        let mut missing_history = Vec::with_capacity(candidate_events.len());
+
+        while let Some((mut event, header)) = candidate_events.pop() {
+            match header.prev() {
+                None => {
+                    unreachable!("Init events should have been filtered out since they're always deliverable");
+                }
+                Some(prev) => {
+                    if new_cids.contains(&prev) {
+                        prevs_in_memory.push((event, header));
+                        continue;
+                    } else {
+                        let (_exists, prev_deliverable) =
+                            CeramicOneEvent::deliverable_by_cid(pool, &prev).await?;
+                        if prev_deliverable {
+                            event.body.set_deliverable(true);
+                            deliverable.push((event, header));
+                        } else {
+                            // technically, we may have the "rosetta stone" event in memory that could unlock this chain, if we loaded everything and recursed,
+                            // but the immediate prev is not in this set and has not been delivered to the client yet, so they shouldn't have known how to
+                            // construct this event so we'll consider this missing history. This can be used to return an error if the event is required to have history.
+                            missing_history.push((event, header));
+                        }
+                    }
+                }
+            }
+        }
+
+        // We add the events to the deliverable list until nothing changes
+        while let Some((mut event, header)) = prevs_in_memory.pop() {
+            let mut made_changes = false;
+            match header.prev() {
+                None => {
+                    unreachable!("Init events should have been filtered out of the in memory set");
+                }
+                Some(prev) => {
+                    // a hashset would be better loopkup but we're not going to have that many events so hashing
+                    // for a handful of lookups and then convert back to a vec probably isn't worth it.
+                    if deliverable.iter().any(|(e, _)| e.cid() == prev) {
+                        event.body.set_deliverable(true);
+                        deliverable.push((event, header));
+                        made_changes = true;
+                    } else {
+                        prevs_in_memory.push((event, header));
+                    }
+                }
+            }
+            if !made_changes {
+                missing_history.extend(prevs_in_memory);
+                break;
+            }
+        }
+
+        Ok(OrderEvents {
+            deliverable,
+            missing_history,
+        })
+    }
+}

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -50,8 +50,8 @@ impl OrderEvents {
                     unreachable!("Init events should have been filtered out since they're always deliverable");
                 }
                 Some(prev) => {
-                    if let Some(in_mem) = new_cids.get(&prev) {
-                        if *in_mem {
+                    if let Some(in_mem_is_deliverable) = new_cids.get(&prev) {
+                        if *in_mem_is_deliverable {
                             event.body.set_deliverable(true);
                             *new_cids.get_mut(&event.cid()).expect("CID must exist") = true;
                             deliverable.push((event, header));

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 
+use ceramic_core::Cid;
 use ceramic_store::{CeramicOneEvent, EventInsertable, SqlitePool};
-use cid::Cid;
 
 use crate::Result;
 
@@ -15,7 +15,15 @@ pub(crate) struct OrderEvents {
 impl OrderEvents {
     /// Groups the events into lists of those with a delivered prev and those without. This can be used to return an error if the event is required to have history.
     /// The events will be marked as deliverable so that they can be passed directly to the store to be persisted.
-    /// Will look up the prev from the database if needed to check if it's deliverable (could possibly change this for recon and allow the ordering task to handle it?)
+    ///
+    /// The job of this function is different than the `ordering_task` module. That module recurses indefinitely attempting to build history. This
+    /// will only traverse a single prev outside of the initial set of events (that is, to the database). This is important because we don't want to
+    /// allow API users to write an event they haven't yet seen the prev for, and for recon we can allow the other task to sort it out.
+    ///
+    /// The `missing_history` set means that the prev is not deliverable or in the `candidate_events` vec with a deliverable prev. For example,
+    /// with new events [C, D] (in any order), if D.prev = C, C.prev = B, then C and D are deliverable if B is in the database as deliverable.
+    /// Given the same situation, where B is not yet deliverable, but B.prev = A and A is deliverable (shouldn't happen, but as an example), we
+    /// *could* mark B deliverable and then C and D, but we DO NOT want to do this here to prevent API users from writing events that they haven't seen.
     pub async fn try_new(
         pool: &SqlitePool,
         mut candidate_events: Vec<(EventInsertable, EventMetadata)>,
@@ -23,7 +31,7 @@ impl OrderEvents {
         let mut new_cids: HashMap<Cid, bool> = HashMap::from_iter(
             candidate_events
                 .iter()
-                .map(|(e, _)| (e.cid(), e.body.deliverable())),
+                .map(|(e, _)| (e.cid(), e.deliverable())),
         );
         let mut deliverable = Vec::with_capacity(candidate_events.len());
         candidate_events.retain(|(e, h)| {
@@ -78,8 +86,10 @@ impl OrderEvents {
         // we may loop through multiple times putting things back in the queue, but it should be a short list
         // and it will shrink every time we move something to the deliverable set, so it should be acceptable.
         // We can't quite get rid of this loop because we may have discovered our prev's prev from the database in the previous pass.
+        let max_iterations = undelivered_prevs_in_memory.len();
+        let mut iteration = 0;
         while let Some((mut event, header)) = undelivered_prevs_in_memory.pop_front() {
-            let mut made_changes = false;
+            iteration += 1;
             match header.prev() {
                 None => {
                     unreachable!("Init events should have been filtered out of the in memory set");
@@ -89,13 +99,14 @@ impl OrderEvents {
                         *new_cids.get_mut(&event.cid()).expect("CID must exist") = true;
                         event.body.set_deliverable(true);
                         deliverable.push((event, header));
-                        made_changes = true;
+                        // reset the iteration count since we made changes. once it doesn't change for a loop through the queue we're done
+                        iteration = 0;
                     } else {
                         undelivered_prevs_in_memory.push_back((event, header));
                     }
                 }
             }
-            if !made_changes {
+            if iteration >= max_iterations {
                 missing_history.extend(undelivered_prevs_in_memory);
                 break;
             }
@@ -105,5 +116,195 @@ impl OrderEvents {
             deliverable,
             missing_history,
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ceramic_core::EventId;
+    use rand::seq::SliceRandom;
+    use rand::thread_rng;
+    use test_log::test;
+
+    use super::*;
+
+    use crate::{tests::get_n_events, CeramicEventService};
+
+    async fn get_2_streams() -> (
+        Vec<(EventId, Vec<u8>)>,
+        Vec<(EventId, Vec<u8>)>,
+        Vec<(EventInsertable, EventMetadata)>,
+    ) {
+        let stream_2 = get_n_events(10).await;
+        let stream_1 = get_n_events(10).await;
+        let mut to_insert = Vec::with_capacity(10);
+        for event in stream_1.iter().chain(stream_2.iter()) {
+            let insertable = CeramicEventService::validate_discovered_event(
+                event.0.to_owned(),
+                event.1.as_slice(),
+            )
+            .await
+            .unwrap();
+            to_insert.push(insertable);
+        }
+        (stream_1, stream_2, to_insert)
+    }
+
+    #[test(tokio::test)]
+    async fn out_of_order_streams_valid() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+
+        let (stream_1, stream_2, mut to_insert) = get_2_streams().await;
+        to_insert.shuffle(&mut thread_rng());
+
+        let ordered = OrderEvents::try_new(&pool, to_insert).await.unwrap();
+        assert!(
+            ordered.missing_history.is_empty(),
+            "Missing history: len={} {:?}",
+            ordered.missing_history.len(),
+            ordered.missing_history
+        );
+        let mut after_1 = Vec::with_capacity(10);
+        let mut after_2 = Vec::with_capacity(10);
+        for (event, _) in ordered.deliverable {
+            assert!(event.deliverable());
+            if stream_1.iter().any(|e| e.0 == event.order_key) {
+                after_1.push(event.order_key.clone());
+            } else {
+                after_2.push(event.order_key.clone());
+            }
+        }
+
+        assert_eq!(
+            stream_1.into_iter().map(|e| e.0).collect::<Vec<_>>(),
+            after_1
+        );
+        assert_eq!(
+            stream_2.into_iter().map(|e| e.0).collect::<Vec<_>>(),
+            after_2
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn missing_history_in_memory() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+
+        let (stream_1, stream_2, mut to_insert) = get_2_streams().await;
+        // if event 2 is missing from stream_1, we will sort stream_2 but stream_1 will be "missing history" after the init event
+        to_insert.remove(1);
+        to_insert.shuffle(&mut thread_rng());
+
+        let ordered = OrderEvents::try_new(&pool, to_insert).await.unwrap();
+        assert_eq!(
+            8,
+            ordered.missing_history.len(),
+            "Missing history: {:?}",
+            ordered.missing_history
+        );
+        let mut after_1 = Vec::with_capacity(10);
+        let mut after_2 = Vec::with_capacity(10);
+        for (event, _) in ordered.deliverable {
+            assert!(event.deliverable());
+            if stream_1.iter().any(|e| e.0 == event.order_key) {
+                after_1.push(event.order_key.clone());
+            } else {
+                after_2.push(event.order_key.clone());
+            }
+        }
+
+        assert_eq!(vec![stream_1[0].0.clone()], after_1);
+        assert_eq!(
+            stream_2.into_iter().map(|e| e.0).collect::<Vec<_>>(),
+            after_2
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn missing_history_not_recursed() {
+        // this test validates that even though it's possible to build the history as deliverable, we don't do it here
+        // so that an API write that had never seen event 2, would not able to write event 3 or after
+        // the recon ordering task would sort this and mark all deliverable
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+
+        let stream_1 = get_n_events(10).await;
+        let mut insertable = Vec::with_capacity(10);
+        for event in stream_1.iter() {
+            let new = CeramicEventService::validate_discovered_event(
+                event.0.to_owned(),
+                event.1.as_slice(),
+            )
+            .await
+            .unwrap();
+            insertable.push(new);
+        }
+        let to_insert = insertable
+            .iter()
+            .take(3)
+            .map(|(i, _)| i.clone())
+            .collect::<Vec<_>>();
+        let mut remaining = insertable.into_iter().skip(3).collect::<Vec<_>>();
+        CeramicOneEvent::insert_many(&pool, &to_insert[..])
+            .await
+            .unwrap();
+
+        remaining.shuffle(&mut thread_rng());
+
+        let ordered = OrderEvents::try_new(&pool, remaining).await.unwrap();
+        assert_eq!(
+            7,
+            ordered.missing_history.len(),
+            "Missing history: {:?}",
+            ordered.missing_history
+        );
+    }
+
+    #[test(tokio::test)]
+    async fn database_deliverable_is_valid() {
+        // this test validates we can order in memory events with each other if one of them has a prev
+        // in the database that is deliverable, in which case the entire chain is deliverable
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+
+        let stream_1 = get_n_events(10).await;
+        let mut insertable = Vec::with_capacity(10);
+        for event in stream_1.iter() {
+            let new = CeramicEventService::validate_discovered_event(
+                event.0.to_owned(),
+                event.1.as_slice(),
+            )
+            .await
+            .unwrap();
+            insertable.push(new);
+        }
+        let to_insert = insertable
+            .iter_mut()
+            .take(3)
+            .map(|(i, _)| {
+                i.body.set_deliverable(true);
+                i.clone()
+            })
+            .collect::<Vec<_>>();
+        let mut remaining = insertable.into_iter().skip(3).collect::<Vec<_>>();
+        CeramicOneEvent::insert_many(&pool, &to_insert[..])
+            .await
+            .unwrap();
+
+        let expected = remaining
+            .iter()
+            .map(|(i, _)| i.order_key.clone())
+            .collect::<Vec<_>>();
+        remaining.shuffle(&mut thread_rng());
+
+        let ordered = OrderEvents::try_new(&pool, remaining).await.unwrap();
+        assert!(
+            ordered.missing_history.is_empty(),
+            "Missing history: {:?}",
+            ordered.missing_history
+        );
+        let after = ordered
+            .deliverable
+            .iter()
+            .map(|(e, _)| e.order_key.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(expected, after);
     }
 }

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -77,7 +77,7 @@ impl OrderEvents {
         // If our prev is in this list, we won't find it until it's added to the deliverable set. This means
         // we may loop through multiple times putting things back in the queue, but it should be a short list
         // and it will shrink every time we move something to the deliverable set, so it should be acceptable.
-        // We can't quite get rid of this loop because we may have discovered the prev from the database in the previous pass.
+        // We can't quite get rid of this loop because we may have discovered our prev's prev from the database in the previous pass.
         while let Some((mut event, header)) = undelivered_prevs_in_memory.pop_front() {
             let mut made_changes = false;
             match header.prev() {

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -5,11 +5,11 @@ use cid::Cid;
 
 use crate::Result;
 
-use super::service::EventHeader;
+use super::service::EventMetadata;
 
 pub(crate) struct OrderEvents {
-    pub(crate) deliverable: Vec<(EventInsertable, EventHeader)>,
-    pub(crate) missing_history: Vec<(EventInsertable, EventHeader)>,
+    pub(crate) deliverable: Vec<(EventInsertable, EventMetadata)>,
+    pub(crate) missing_history: Vec<(EventInsertable, EventMetadata)>,
 }
 
 impl OrderEvents {
@@ -18,7 +18,7 @@ impl OrderEvents {
     /// Will look up the prev from the database if needed to check if it's deliverable (could possibly change this for recon and allow the ordering task to handle it?)
     pub async fn try_new(
         pool: &SqlitePool,
-        mut candidate_events: Vec<(EventInsertable, EventHeader)>,
+        mut candidate_events: Vec<(EventInsertable, EventMetadata)>,
     ) -> Result<Self> {
         let mut new_cids: HashMap<Cid, bool> = HashMap::from_iter(
             candidate_events

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -1,73 +1,33 @@
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, VecDeque};
 
-use anyhow::anyhow;
+use ceramic_core::EventId;
 use ceramic_store::{CeramicOneEvent, SqlitePool};
 use cid::Cid;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{CeramicEventService, Error, Result};
 
+use super::service::{EventHeader, InsertableBodyWithHeader};
+
 /// How many events to select at once to see if they've become deliverable when we have downtime
 /// Used at startup and occassionally in case we ever dropped something
 /// We keep the number small for now as we may need to traverse many prevs for each one of these and load them into memory.
-const DELIVERABLE_EVENTS_BATCH_SIZE: usize = 1000;
+const DELIVERABLE_EVENTS_BATCH_SIZE: u32 = 1000;
+
 /// How many batches of undelivered events are we willing to process on start up?
 /// To avoid an infinite loop. It's going to take a long time to process `DELIVERABLE_EVENTS_BATCH_SIZE * MAX_ITERATIONS` events
 const MAX_ITERATIONS: usize = 100_000_000;
 
-/// How often should we try to process all undelivered events in case we missed something
-const CHECK_ALL_INTERVAL_SECONDS: u64 = 60 * 10; // 10 minutes
-
-type InitCid = cid::Cid;
-type PrevCid = cid::Cid;
-type EventCid = cid::Cid;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DeliveredEvent {
-    pub(crate) cid: Cid,
-    pub(crate) init_cid: InitCid,
-}
-
-impl DeliveredEvent {
-    pub fn new(cid: Cid, init_cid: InitCid) -> Self {
-        Self { cid, init_cid }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct DeliverableMetadata {
-    pub(crate) init_cid: InitCid,
-    pub(crate) prev: PrevCid,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DeliverableEvent {
-    pub(crate) cid: EventCid,
-    pub(crate) meta: DeliverableMetadata,
-    attempts: usize,
-    last_attempt: std::time::Instant,
-    started: std::time::Instant,
-    expires: Option<std::time::Instant>,
-}
-
-impl DeliverableEvent {
-    pub fn new(cid: Cid, meta: DeliverableMetadata, expires: Option<std::time::Instant>) -> Self {
-        Self {
-            cid,
-            meta,
-            attempts: 0,
-            last_attempt: std::time::Instant::now(),
-            started: std::time::Instant::now(),
-            expires,
-        }
-    }
-}
+type StreamCid = Cid;
+type EventCid = Cid;
+type PrevCid = Cid;
 
 #[derive(Debug)]
 pub struct DeliverableTask {
     pub(crate) _handle: tokio::task::JoinHandle<()>,
-    pub(crate) tx: tokio::sync::mpsc::Sender<DeliverableEvent>,
-    pub(crate) tx_new: tokio::sync::mpsc::Sender<DeliveredEvent>,
+    /// Currently events discovered over recon that are out of order and need to be marked ready (deliverable)
+    /// when their prev chain is discovered and complete (i.e. my prev is deliverable then I am deliverable).
+    pub(crate) tx_inserted: tokio::sync::mpsc::Sender<InsertableBodyWithHeader>,
 }
 
 #[derive(Debug)]
@@ -75,30 +35,33 @@ pub struct OrderingTask {}
 
 impl OrderingTask {
     pub async fn run(pool: SqlitePool, q_depth: usize, load_delivered: bool) -> DeliverableTask {
-        let (tx, rx) = tokio::sync::mpsc::channel::<DeliverableEvent>(q_depth);
-        let (tx_new, rx_new) = tokio::sync::mpsc::channel::<DeliveredEvent>(q_depth);
+        let (tx_inserted, rx_inserted) =
+            tokio::sync::mpsc::channel::<InsertableBodyWithHeader>(q_depth);
 
         let handle =
-            tokio::spawn(async move { Self::run_loop(pool, load_delivered, rx, rx_new).await });
+            tokio::spawn(async move { Self::run_loop(pool, load_delivered, rx_inserted).await });
 
         DeliverableTask {
             _handle: handle,
-            tx,
-            tx_new,
+            tx_inserted,
         }
     }
 
     async fn run_loop(
         pool: SqlitePool,
         load_undelivered: bool,
-        mut rx: tokio::sync::mpsc::Receiver<DeliverableEvent>,
-        mut rx_new: tokio::sync::mpsc::Receiver<DeliveredEvent>,
+        mut rx_inserted: tokio::sync::mpsc::Receiver<InsertableBodyWithHeader>,
     ) {
         // before starting, make sure we've updated any events in the database we missed
+        // this could take a long time. possibly we want to put it in another task so we can start processing events immediately
         let mut state = OrderingState::new();
         if load_undelivered
             && state
-                .process_all_undelivered_events(&pool, MAX_ITERATIONS)
+                .process_all_undelivered_events(
+                    &pool,
+                    MAX_ITERATIONS,
+                    DELIVERABLE_EVENTS_BATCH_SIZE,
+                )
                 .await
                 .map_err(Self::log_error)
                 .is_err()
@@ -106,53 +69,37 @@ impl OrderingTask {
             return;
         }
 
-        let mut last_processed = std::time::Instant::now();
         loop {
-            let mut modified: Option<HashSet<InitCid>> = None;
-            let mut need_prev_buf = Vec::with_capacity(100);
-            let mut newly_added_buf = Vec::with_capacity(100);
+            let mut recon_events = Vec::with_capacity(100);
+            // consider trying to recv in a loop until X or 10ms whatever comes first and then process
+            // the more events we get in memory, the fewer queries we need to run.
+            if rx_inserted.recv_many(&mut recon_events, 100).await > 0 {
+                trace!(?recon_events, "new events discovered!");
+                state.add_inserted_events(recon_events);
 
-            tokio::select! {
-                incoming = rx.recv_many(&mut need_prev_buf, 100) => {
-                    if incoming > 0 {
-                        modified = Some(state.add_incoming_batch(need_prev_buf));
-                    }
-                }
-                new = rx_new.recv_many(&mut newly_added_buf, 100) => {
-                    if new > 0 {
-                        modified = Some(newly_added_buf.into_iter().map(|ev| ev.init_cid).collect::<HashSet<InitCid>>());
-                    }
-                }
-                else => {
-                    info!(stream_count=%state.pending_by_stream.len(), "Server dropped the ordering task. Processing once more before exiting...");
-                    let _ = state
-                        .process_events(&pool, None)
-                        .await
-                        .map_err(Self::log_error);
-                    return;
-                }
-            };
-            // Given the math on OrderingState and the generally low number of updates to streams, we are going
-            // to ignore pruning until there's  more of an indication that it's necessary. Just log some stats.
-            if last_processed.elapsed().as_secs() > CHECK_ALL_INTERVAL_SECONDS {
-                let stream_count = state.pending_by_stream.len();
-                if stream_count > 1000 {
-                    info!(%stream_count, "Over 1000 pending streams without recent updates.");
-                } else {
-                    debug!(%stream_count, "Fewer than 1000 streams pending without recent updates.");
-                }
-            }
-
-            if modified.is_some()
-                && state
-                    .process_events(&pool, modified)
+                if state
+                    .process_streams(&pool)
                     .await
                     .map_err(Self::log_error)
                     .is_err()
-            {
-                return;
+                {
+                    return;
+                }
+            } else if rx_inserted.is_closed() {
+                debug!(
+                "Server dropped the delivered events channel. Attempting to processing streams in memory once more before exiting."
+                );
+
+                if state
+                    .process_streams(&pool)
+                    .await
+                    .map_err(Self::log_error)
+                    .is_err()
+                {
+                    return;
+                }
+                break;
             }
-            last_processed = std::time::Instant::now();
         }
     }
 
@@ -175,188 +122,310 @@ impl OrderingTask {
     }
 }
 
-#[derive(Debug)]
-/// Rough size estimate:
-///     pending_by_stream: 96 * stream_cnt + 540 * event_cnt
-///     ready_events: 96 * ready_event_cnt
-/// so for stream_cnt = 1000, event_cnt = 2, ready_event_cnt = 1000
-/// we get about 1 MB of memory used.
-pub struct OrderingState {
-    /// Map of undelivered events by init CID (i.e. the stream CID).
-    pending_by_stream: HashMap<InitCid, StreamEvents>,
-    /// Queue of events that can be marked ready to deliver.
-    /// Can be added as long as their prev is stored or in this list ahead of them.
-    ready_events: VecDeque<EventCid>,
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum StreamEvent {
+    InitEvent(EventCid),
+    /// An event that is known to be deliverable from the database
+    KnownDeliverable(StreamEventMetadata),
+    /// An event that needs more history to be deliverable
+    Undelivered(StreamEventMetadata),
+}
+
+impl StreamEvent {
+    /// Builds a stream event from the database if it exists.
+    async fn load_by_cid(pool: &SqlitePool, cid: EventCid) -> Result<Option<Self>> {
+        // TODO: one query
+        let (exists, deliverable) = CeramicOneEvent::deliverable_by_cid(pool, &cid).await?;
+        if exists {
+            let parsed_body =
+                if let Some(body) = CeramicEventService::load_by_cid(pool, cid).await? {
+                    body
+                } else {
+                    warn!(%cid, "No event body found for event that should exist");
+                    return Ok(None);
+                };
+
+            let known_prev = match &parsed_body.header {
+                EventHeader::Init { cid, .. } => {
+                    if !deliverable {
+                        warn!(%cid,"Found init event in database that wasn't previously marked as deliverable. Updating now...");
+                        let mut tx = pool.begin_tx().await?;
+                        CeramicOneEvent::mark_ready_to_deliver(&mut tx, cid).await?;
+                        tx.commit().await?;
+                    }
+                    StreamEvent::InitEvent(*cid)
+                }
+                EventHeader::Data { prev, .. } | EventHeader::Time { prev, .. } => {
+                    if deliverable {
+                        trace!(%cid, "Found deliverable event in database");
+                        StreamEvent::KnownDeliverable(StreamEventMetadata::new(cid, *prev))
+                    } else {
+                        trace!(%cid, "Found undelivered event in database");
+                        StreamEvent::Undelivered(StreamEventMetadata::new(cid, *prev))
+                    }
+                }
+            };
+            Ok(Some(known_prev))
+        } else {
+            trace!(%cid, "Missing event in database");
+            Ok(None)
+        }
+    }
+}
+
+impl From<InsertableBodyWithHeader> for StreamEvent {
+    fn from(ev: InsertableBodyWithHeader) -> Self {
+        match ev.header {
+            EventHeader::Init { cid, .. } => StreamEvent::InitEvent(cid),
+            EventHeader::Data { cid, prev, .. } | EventHeader::Time { cid, prev, .. } => {
+                let meta = StreamEventMetadata::new(cid, prev);
+                if ev.body.deliverable() {
+                    StreamEvent::KnownDeliverable(meta)
+                } else {
+                    StreamEvent::Undelivered(meta)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct StreamEventMetadata {
+    cid: EventCid,
+    prev: PrevCid,
+}
+
+impl StreamEventMetadata {
+    fn new(cid: EventCid, prev: PrevCid) -> Self {
+        Self { cid, prev }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
 /// ~540 bytes per event in this struct
 pub(crate) struct StreamEvents {
+    /// Map of `event.prev` to `event.cid` to find the previous event easily.
     prev_map: HashMap<PrevCid, EventCid>,
-    cid_map: HashMap<EventCid, DeliverableEvent>,
-}
-
-impl FromIterator<DeliverableEvent> for StreamEvents {
-    fn from_iter<T: IntoIterator<Item = DeliverableEvent>>(iter: T) -> Self {
-        let mut stream = Self::new();
-        for item in iter {
-            stream.add_event(item);
-        }
-        stream
-    }
+    /// Map of `event.cid` to `metadata` for quick lookup of the event metadata.
+    cid_map: HashMap<EventCid, StreamEvent>,
+    /// whether we should process this stream because new events have been added
+    skip_processing: bool,
+    /// The newly discovered events that are deliverable and should be processed.
+    new_deliverable: VecDeque<EventCid>,
 }
 
 impl StreamEvents {
-    pub fn new() -> Self {
-        Self::default()
+    fn new(event: StreamEvent) -> Self {
+        let mut new = Self::default();
+        new.add_event(event);
+        new
     }
 
-    /// returns Some(Stream Init CID) if this is a new event, else None.
-    pub fn add_event(&mut self, event: DeliverableEvent) -> Option<InitCid> {
-        let res = if self.prev_map.insert(event.meta.prev, event.cid).is_none() {
-            Some(event.meta.init_cid)
-        } else {
-            None
-        };
-        self.cid_map.insert(event.cid, event);
-        res
-    }
-
-    pub fn is_empty(&self) -> bool {
-        // these should always match
-        self.prev_map.is_empty() && self.cid_map.is_empty()
-    }
-
-    fn remove_by_event_cid(&mut self, cid: &Cid) -> Option<DeliverableEvent> {
-        if let Some(cid) = self.cid_map.remove(cid) {
-            self.prev_map.remove(&cid.meta.prev);
-            Some(cid)
-        } else {
-            None
+    // we'll be processed if something in memory depends on this event
+    fn update_should_process_for_new_delivered(&mut self, new_cid: &EventCid) {
+        // don't reset a true flag to false
+        if self.skip_processing {
+            self.skip_processing = !self.prev_map.contains_key(new_cid);
         }
     }
 
-    fn remove_by_prev_cid(&mut self, cid: &Cid) -> Option<EventCid> {
-        if let Some(cid) = self.prev_map.remove(cid) {
+    /// returns true if this is a new event.
+    fn add_event(&mut self, event: StreamEvent) -> bool {
+        let cid = match &event {
+            StreamEvent::InitEvent(cid) => {
+                self.update_should_process_for_new_delivered(cid);
+                *cid
+            }
+            StreamEvent::KnownDeliverable(meta) => {
+                self.prev_map.insert(meta.prev, meta.cid);
+                self.update_should_process_for_new_delivered(&meta.cid);
+                meta.cid
+            }
+            StreamEvent::Undelivered(meta) => {
+                self.prev_map.insert(meta.prev, meta.cid);
+                if self.skip_processing {
+                    // we depend on something in memory
+                    self.skip_processing = !self.prev_map.contains_key(&meta.prev)
+                }
+                meta.cid
+            }
+        };
+
+        self.cid_map.insert(cid, event).is_none()
+    }
+
+    fn remove_by_prev_cid(&mut self, prev: &Cid) -> Option<EventCid> {
+        if let Some(cid) = self.prev_map.remove(prev) {
             self.cid_map.remove(&cid);
             Some(cid)
         } else {
             None
         }
     }
-}
 
-impl OrderingState {
-    pub fn new() -> Self {
-        Self {
-            pending_by_stream: HashMap::new(),
-            ready_events: VecDeque::new(),
-        }
-    }
+    /// Called when we've persisted the deliverable events to the database and can clean up our state.
+    /// Returns true if we should be retained for future processing (i.e we have more we need to discover)
+    /// and false if we can be dropped from memory.
+    fn completed_processing(&mut self) -> bool {
+        self.skip_processing = true;
 
-    /// This will review all the events for any streams known to have undelivered events and see if any of them are now deliverable.
-    /// If `streams_to_process` is None, all streams will be processed, otherwise only the streams in the set will be processed.
-    /// Processing all streams could take a long time and not necessarily do anything productive (if we're missing a key event, we're still blocked).
-    /// However, passing a value for `streams_to_process` when we know something has changed is likely to have positive results and be much faster.
-    pub(crate) async fn process_events(
-        &mut self,
-        pool: &SqlitePool,
-        streams_to_process: Option<HashSet<InitCid>>,
-    ) -> Result<()> {
-        self.persist_ready_events(pool).await?;
-        for (cid, stream_events) in self.pending_by_stream.iter_mut() {
-            if streams_to_process
-                .as_ref()
-                .map_or(false, |to_do| !to_do.contains(cid))
-            {
-                continue;
-            }
-            let deliverable = Self::discover_deliverable_events(pool, stream_events).await?;
-            if !deliverable.is_empty() {
-                self.ready_events.extend(deliverable)
-            }
-        }
-        if !self.ready_events.is_empty() {
-            self.persist_ready_events(pool).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Removes deliverable events from the `prev_map` and returns them. This means prev is already delivered or in the
-    /// list to be marked as delivered. The input is expected to be a list of CIDs for a given stream that are waiting
-    /// to be processed. It will still work if it's intermixed for multiple streams, but it's not the most efficient way to use it.
-    /// The returned CIDs in the VeqDeque are for events that are expected to be updated FIFO i.e. vec.pop_front()
-    ///
-    /// This breaks with multi-prev as we expect a single prev for each event. The input map is expected to contain the
-    /// (prev <- event) relationship (that is, the value is the event that depends on the key).
-    pub(crate) async fn discover_deliverable_events(
-        pool: &SqlitePool,
-        stream_map: &mut StreamEvents,
-    ) -> Result<VecDeque<EventCid>> {
-        if stream_map.is_empty() {
-            return Ok(VecDeque::new());
-        }
-
-        let mut deliverable = VecDeque::new();
-        let prev_map_cln = stream_map.prev_map.clone();
-        for (prev, ev_cid) in prev_map_cln {
-            if stream_map.cid_map.contains_key(&prev) {
-                trace!(
-                    ?prev,
-                    cid=?ev_cid,
-                    "Found event that depends on another event in memory"
-                );
-                // we have it in memory so we need to order it related to others to insert correctly
-                // although it may not be possible if the chain just goes back to some unknown event
-                // once we find the first event that's deliverable, we can go back through and find the rest
-                continue;
-            } else {
-                let (exists, delivered) = CeramicOneEvent::deliverable_by_cid(pool, &prev).await?;
-                if delivered {
-                    trace!(deliverable=?ev_cid, "Found delivered prev in database. Adding to ready list");
-                    deliverable.push_back(ev_cid);
-                    stream_map.remove_by_event_cid(&ev_cid);
-                } else if exists {
-                    trace!("Found undelivered prev in database. Building data to check for deliverable.");
-                    // if it's not in memory, we need to read it from the db and parse it for the prev value to add it to our set
-                    let data = CeramicOneEvent::value_by_cid(pool, &prev)
-                        .await?
-                        .ok_or_else(|| {
-                            Error::new_app(anyhow!(
-                                "Missing data for event that exists should be impossible"
-                            ))
-                        })?;
-                    let (insertable_body, maybe_prev) =
-                        CeramicEventService::parse_event_carfile(prev, &data).await?;
-
-                    if let Some(prev) = maybe_prev {
-                        let event = DeliverableEvent::new(insertable_body.cid, prev, None);
-                        trace!(cid=%event.cid, "Adding event discovered in database to stream pending list");
-                        stream_map.add_event(event);
-                    } else {
-                        warn!(event_cid=%insertable_body.cid,"Found undelivered event with no prev while processing pending. Should not happen.");
-                        deliverable.push_back(insertable_body.cid);
-                        stream_map.remove_by_event_cid(&ev_cid);
+        for cid in self.new_deliverable.iter() {
+            if let Some(ev) = self.cid_map.get_mut(cid) {
+                match ev {
+                    StreamEvent::InitEvent(_) => {}
+                    StreamEvent::KnownDeliverable(_) => {
+                        warn!(
+                                ?ev,
+                                "Found event in deliverable queue that was already marked as deliverable."
+                            )
                     }
-                } else {
-                    trace!(
-                        ?ev_cid,
-                        "Found event that depends on unknown event. Will check later."
-                    );
+                    StreamEvent::Undelivered(meta) => {
+                        // we're delivered now
+                        *ev = StreamEvent::KnownDeliverable(meta.clone());
+                    }
                 }
             }
         }
-        let mut newly_ready = deliverable.clone();
+        self.new_deliverable.clear();
+        self.cid_map
+            .iter()
+            .any(|(_, ev)| matches!(ev, StreamEvent::Undelivered(_)))
+    }
+
+    async fn order_events(&mut self, pool: &SqlitePool) -> Result<()> {
+        // We collect everything we can into memory and then order things.
+        // If our prev is the init event or already been delivered, we can mark ourselves as deliverable.
+        // If our prev wasn't deliverable yet, we track it and repeat (i.e. follow its prev if we don't have it)
+
+        let mut deliverable_queue = VecDeque::new();
+        let mut undelivered =
+            VecDeque::from_iter(self.cid_map.iter().filter_map(|(cid, ev)| match ev {
+                StreamEvent::Undelivered(meta) => {
+                    assert_eq!(meta.cid, *cid);
+                    Some((meta.cid, meta.prev))
+                }
+                _ => None,
+            }));
+
+        while let Some((cid, prev)) = undelivered.pop_front() {
+            if let Some(prev_event) = self.cid_map.get(&prev) {
+                match prev_event {
+                    StreamEvent::InitEvent(_) | StreamEvent::KnownDeliverable(_) => {
+                        trace!(
+                            %prev,
+                            %cid,
+                            "Found event whose prev is already in memory and IS deliverable!"
+                        );
+                        deliverable_queue.push_back(cid)
+                    }
+                    StreamEvent::Undelivered(_) => {
+                        trace!(
+                            %prev,
+                            %cid,
+                            "Found event whose prev is already in memory but NOT deliverable."
+                        );
+                        // nothing to do until it arrives on the channel
+                    }
+                }
+
+                continue;
+            }
+
+            let prev_event = StreamEvent::load_by_cid(pool, prev).await?;
+            if let Some(known_prev) = prev_event {
+                match &known_prev {
+                    StreamEvent::InitEvent(_) | StreamEvent::KnownDeliverable(_) => {
+                        deliverable_queue.push_back(cid);
+                    }
+                    StreamEvent::Undelivered(undelivered_ev) => {
+                        // we'll try to follow this back to something deliverable
+                        undelivered.push_back((undelivered_ev.cid, undelivered_ev.prev));
+                    }
+                }
+                self.add_event(known_prev);
+            } else {
+                trace!("Found event that depends on another event we haven't discovered yet");
+            }
+        }
+
+        let mut newly_ready = deliverable_queue.clone();
         while let Some(cid) = newly_ready.pop_front() {
-            if let Some(now_ready_ev) = stream_map.remove_by_prev_cid(&cid) {
-                deliverable.push_back(now_ready_ev);
+            if let Some(now_ready_ev) = self.remove_by_prev_cid(&cid) {
+                if let Some(ev) = self.cid_map.get(&now_ready_ev) {
+                    match ev {
+                        StreamEvent::InitEvent(_) | StreamEvent::KnownDeliverable(_) => {
+                            warn!(?ev, "should not have found a deliverable event when we expected only undelivered events!");
+                        }
+                        StreamEvent::Undelivered(_) => {
+                            newly_ready.push_back(now_ready_ev);
+                        }
+                    }
+                }
+                deliverable_queue.push_back(now_ready_ev);
                 newly_ready.push_back(now_ready_ev);
             }
         }
-        debug!(?deliverable, "deliverable events discovered");
+        self.new_deliverable = deliverable_queue;
+        debug!(count=%self.new_deliverable.len(), "deliverable events discovered");
+        Ok(())
+    }
+}
 
-        Ok(deliverable)
+#[derive(Debug)]
+pub struct OrderingState {
+    pending_by_stream: HashMap<StreamCid, StreamEvents>,
+    deliverable: VecDeque<EventCid>,
+}
+
+impl OrderingState {
+    fn new() -> Self {
+        Self {
+            pending_by_stream: HashMap::new(),
+            deliverable: VecDeque::new(),
+        }
+    }
+
+    /// Add a stream to the list of streams to process.
+    /// We ignore delivered events for streams we're not tracking as we can look them up later if we need them.
+    /// We will get lots of init events we can ignore unless we need them, otherwise they'll be stuck in memory for a long time.
+    fn add_inserted_events(&mut self, events: Vec<InsertableBodyWithHeader>) {
+        for ev in events {
+            let stream_cid = ev.header.stream_cid();
+            let event = ev.into();
+            self.add_stream_event(stream_cid, event);
+        }
+    }
+
+    fn add_stream_event(&mut self, stream_cid: StreamCid, event: StreamEvent) {
+        if let Some(stream) = self.pending_by_stream.get_mut(&stream_cid) {
+            stream.add_event(event);
+        } else if matches!(event, StreamEvent::Undelivered(_)) {
+            let stream = StreamEvents::new(event);
+            self.pending_by_stream.insert(stream_cid, stream);
+        }
+    }
+
+    /// Process every stream we know about that has undelivered events that should be "unlocked" now. This could be adjusted to commit things in batches,
+    /// but for now it assumes it can process all the streams and events in one go. It should be idempotent, so if it fails, it can be retried.
+    async fn process_streams(&mut self, pool: &SqlitePool) -> Result<()> {
+        for (_stream_cid, stream_events) in self.pending_by_stream.iter_mut() {
+            if stream_events.skip_processing {
+                continue;
+            }
+            stream_events.order_events(pool).await?;
+            self.deliverable
+                .extend(stream_events.new_deliverable.iter());
+        }
+
+        self.persist_ready_events(pool).await?;
+        // keep things that still have missing history but don't process them again until we get something new
+        self.pending_by_stream
+            .retain(|_, stream_events| stream_events.completed_processing());
+
+        debug!(remaining_streams=%self.pending_by_stream.len(), "Finished processing streams");
+        trace!(stream_state=?self, "Finished processing streams");
+
+        Ok(())
     }
 
     /// Process all undelivered events in the database. This is a blocking operation that could take a long time.
@@ -365,112 +434,96 @@ impl OrderingState {
         &mut self,
         pool: &SqlitePool,
         max_iterations: usize,
-    ) -> Result<()> {
-        let mut cnt = 0;
-        let mut offset: usize = 0;
-        while cnt < max_iterations {
-            cnt += 1;
-            let (new, found) = self
-                .add_undelivered_batch(pool, offset, DELIVERABLE_EVENTS_BATCH_SIZE)
-                .await?;
-            if new == 0 {
+        batch_size: u32,
+    ) -> Result<usize> {
+        let mut iter_cnt = 0;
+        let mut event_cnt = 0;
+        let mut highwater = 0;
+        while iter_cnt < max_iterations {
+            iter_cnt += 1;
+            let (undelivered, new_hw) =
+                CeramicOneEvent::undelivered_with_values(pool, batch_size.into(), highwater)
+                    .await?;
+            highwater = new_hw;
+            if undelivered.is_empty() {
                 break;
             } else {
                 // We can start processing and we'll follow the stream history if we have it. In that case, we either arrive
                 // at the beginning and mark them all delivered, or we find a gap and stop processing and leave them in memory.
                 // In this case, we won't discover them until we start running recon with a peer, so maybe we should drop them
                 // or otherwise mark them ignored somehow.
-                self.process_events(pool, None).await?;
-                if new < DELIVERABLE_EVENTS_BATCH_SIZE {
+                let found_all = undelivered.len() < batch_size as usize;
+                event_cnt += self
+                    .process_undelivered_events_batch(pool, undelivered)
+                    .await?;
+                if found_all {
                     break;
                 }
-                offset = offset.saturating_add(found);
-            }
-            if cnt >= max_iterations {
-                warn!(batch_size=DELIVERABLE_EVENTS_BATCH_SIZE, iterations=%max_iterations, "Exceeded max iterations for finding undelivered events!");
-                break;
             }
         }
-        if self.ready_events.is_empty() {
-            Ok(())
-        } else {
-            self.persist_ready_events(pool).await?;
-            Ok(())
+        if iter_cnt > max_iterations {
+            info!(%batch_size, iterations=%iter_cnt, "Exceeded max iterations for finding undelivered events!");
         }
+
+        Ok(event_cnt)
     }
 
-    /// Add a batch of events from the database to the pending list to be processed.
-    /// Returns the (#events new events found , #events returned by query)
-    async fn add_undelivered_batch(
+    async fn process_undelivered_events_batch(
         &mut self,
         pool: &SqlitePool,
-        offset: usize,
-        limit: usize,
-    ) -> Result<(usize, usize)> {
-        let undelivered = CeramicOneEvent::undelivered_with_values(pool, offset, limit).await?;
-        trace!(count=%undelivered.len(), "Found undelivered events to process");
-        if undelivered.is_empty() {
-            return Ok((0, 0));
-        }
-        let found = undelivered.len();
-        let mut new = 0;
-        for (key, data) in undelivered {
-            let event_cid = key.cid().ok_or_else(|| {
-                Error::new_invalid_arg(anyhow::anyhow!("EventID is missing a CID: {}", key))
+        event_data: Vec<(EventId, Vec<u8>)>,
+    ) -> Result<usize> {
+        trace!(cnt=%event_data.len(), "Processing undelivered events batch");
+        let mut to_store_asap = Vec::new();
+        let mut event_cnt = 0;
+        for (event_id, carfile) in event_data {
+            let event_cid = event_id.cid().ok_or_else(|| {
+                Error::new_invalid_arg(anyhow::anyhow!("EventID is missing a CID: {}", event_id))
             })?;
-            let (insertable_body, maybe_prev) =
-                CeramicEventService::parse_event_carfile(event_cid, &data).await?;
-            if let Some(prev) = maybe_prev {
-                let event = DeliverableEvent::new(insertable_body.cid, prev, None);
-                if self.track_pending(event).is_some() {
-                    new += 1;
+
+            let loaded = CeramicEventService::parse_event_carfile_cid(event_cid, &carfile).await?;
+
+            let event = match &loaded.header {
+                EventHeader::Init { cid, .. } => {
+                    warn!(%cid,"Found init event in database that wasn't previously marked as deliverable. Updating now...");
+                    to_store_asap.push(*cid);
+                    StreamEvent::InitEvent(*cid)
                 }
-            } else {
-                // safe to ignore in tests, shows up because when we mark init events as undelivered even though they don't have a prev
-                info!(event_cid=%insertable_body.cid, "Found undelivered event with no prev while processing undelivered. Should not happen. Likely means events were dropped before.");
-                self.ready_events.push_back(insertable_body.cid);
-                new += 1; // we treat this as new since it might unlock something else but it's not actually going in our queue is it's a bit odd
-            }
+                EventHeader::Data { cid, prev, .. } | EventHeader::Time { cid, prev, .. } => {
+                    StreamEvent::Undelivered(StreamEventMetadata::new(*cid, *prev))
+                }
+            };
+
+            event_cnt += 1;
+            self.add_stream_event(loaded.header.stream_cid(), event);
         }
-        trace!(%new, %found, "Adding undelivered events to pending set");
-        Ok((new, found))
-    }
 
-    fn add_incoming_batch(&mut self, events: Vec<DeliverableEvent>) -> HashSet<InitCid> {
-        let mut updated_streams = HashSet::with_capacity(events.len());
-        for event in events {
-            if let Some(updated_stream) = self.track_pending(event) {
-                updated_streams.insert(updated_stream);
+        if !to_store_asap.is_empty() {
+            info!("storing init events that were somehow missed previously");
+            let mut tx = pool.begin_tx().await?;
+            for cid in to_store_asap {
+                CeramicOneEvent::mark_ready_to_deliver(&mut tx, &cid).await?;
             }
+            tx.commit().await?;
         }
-        updated_streams
-    }
+        self.process_streams(pool).await?;
 
-    /// returns the init event CID (stream CID) if this is a new event
-    fn track_pending(&mut self, event: DeliverableEvent) -> Option<InitCid> {
-        self.pending_by_stream
-            .entry(event.meta.init_cid)
-            .or_default()
-            .add_event(event)
+        Ok(event_cnt)
     }
-
-    /// Modify all the events that are ready to be marked as delivered.
 
     /// We should improve the error handling and likely add some batching if the number of ready events is very high.
     /// We copy the events up front to avoid losing any events if the task is cancelled.
     async fn persist_ready_events(&mut self, pool: &SqlitePool) -> Result<()> {
-        if !self.ready_events.is_empty() {
-            let mut to_process = self.ready_events.clone(); // to avoid cancel loss
-            tracing::debug!(count=%self.ready_events.len(), "Marking events as ready to deliver");
+        if !self.deliverable.is_empty() {
+            tracing::debug!(count=%self.deliverable.len(), "Marking events as ready to deliver");
             let mut tx = pool.begin_tx().await?;
-
-            // We process the ready events as a FIFO queue so they are marked delivered before events
-            // that were added after and depend on them.
-            while let Some(cid) = to_process.pop_front() {
-                CeramicOneEvent::mark_ready_to_deliver(&mut tx, &cid).await?;
+            // We process the ready events as a FIFO queue so they are marked delivered before events that were added after and depend on them.
+            // Could use `pop_front` but we want to make sure we commit and then clear everything at once.
+            for cid in &self.deliverable {
+                CeramicOneEvent::mark_ready_to_deliver(&mut tx, cid).await?;
             }
             tx.commit().await?;
-            self.ready_events.clear(); // safe to clear since we are past any await points and hold exclusive access
+            self.deliverable.clear();
         }
         Ok(())
     }
@@ -479,289 +532,166 @@ impl OrderingState {
 #[cfg(test)]
 mod test {
     use ceramic_store::EventInsertable;
-    use multihash_codetable::{Code, MultihashDigest};
-    use recon::ReconItem;
     use test_log::test;
 
-    use crate::tests::{build_event, check_deliverable, random_block, TestEventInfo};
+    use crate::tests::get_n_events;
 
     use super::*;
 
-    /// these events are init events so they should have been delivered
-    /// need to build with data events that have the prev stored already
-    async fn build_insertable_undelivered() -> EventInsertable {
-        let TestEventInfo {
-            event_id: id, car, ..
-        } = build_event().await;
-        let cid = id.cid().unwrap();
-
-        let (body, _meta) = CeramicEventService::parse_event_carfile(cid, &car)
-            .await
-            .unwrap();
-        assert!(!body.deliverable);
-        EventInsertable::try_new(id, body).unwrap()
-    }
-
-    fn assert_stream_map_elems(map: &StreamEvents, size: usize) {
-        assert_eq!(size, map.cid_map.len(), "{:?}", map);
-        assert_eq!(size, map.prev_map.len(), "{:?}", map);
-    }
-
-    fn build_linked_events(
-        number: usize,
-        stream_cid: Cid,
-        first_prev: Cid,
-    ) -> Vec<DeliverableEvent> {
-        let mut events = Vec::with_capacity(number);
-
-        let first_cid = random_block().cid;
-        events.push(DeliverableEvent::new(
-            first_cid,
-            DeliverableMetadata {
-                init_cid: stream_cid,
-                prev: first_prev,
-            },
-            None,
-        ));
-
-        for i in 1..number {
-            let random = random_block();
-            let ev = DeliverableEvent::new(
-                random.cid,
-                DeliverableMetadata {
-                    init_cid: stream_cid,
-                    prev: events[i - 1].cid,
-                },
-                None,
-            );
-            events.push(ev);
+    async fn get_n_insertable_events(n: usize) -> Vec<EventInsertable> {
+        let mut res = Vec::with_capacity(n);
+        let events = get_n_events(n).await;
+        for event in events {
+            let (event, _) =
+                CeramicEventService::parse_event_carfile_order_key(event.0.to_owned(), &event.1)
+                    .await
+                    .unwrap();
+            res.push(event);
         }
-
-        events
-    }
-
-    #[test(tokio::test)]
-    async fn test_none_deliverable_without_first() {
-        // they events all point to the one before but A has never been delivered so we can't do anything
-        let stream_cid = Cid::new_v1(0x71, Code::Sha2_256.digest(b"arbitrary"));
-        let missing = Cid::new_v1(0x71, Code::Sha2_256.digest(b"missing"));
-        let events = build_linked_events(4, stream_cid, missing);
-        let mut prev_map = StreamEvents::from_iter(events);
-
-        let pool = SqlitePool::connect_in_memory().await.unwrap();
-
-        let deliverable = super::OrderingState::discover_deliverable_events(&pool, &mut prev_map)
-            .await
-            .unwrap();
-
-        assert_eq!(0, deliverable.len());
-    }
-
-    #[test(tokio::test)]
-    async fn test_all_deliverable_one_stream() {
-        let TestEventInfo {
-            event_id: one_id,
-            car: one_car,
-            ..
-        } = build_event().await;
-        let one_cid = one_id.cid().unwrap();
-        let store = CeramicEventService::new(SqlitePool::connect_in_memory().await.unwrap())
-            .await
-            .unwrap();
-        recon::Store::insert(&store, &ReconItem::new(&one_id, &one_car))
-            .await
-            .unwrap();
-
-        check_deliverable(&store.pool, &one_cid, true).await;
-
-        let stream_cid = Cid::new_v1(0x71, Code::Sha2_256.digest(b"arbitrary"));
-
-        let events = build_linked_events(4, stream_cid, one_cid);
-        let expected = VecDeque::from_iter(events.iter().map(|ev| ev.cid));
-        let mut prev_map = StreamEvents::from_iter(events);
-
-        assert_stream_map_elems(&prev_map, 4);
-        let deliverable =
-            super::OrderingState::discover_deliverable_events(&store.pool, &mut prev_map)
-                .await
-                .unwrap();
-
-        assert_eq!(4, deliverable.len());
-        assert_eq!(expected, deliverable);
-        assert_stream_map_elems(&prev_map, 0);
-    }
-
-    #[test(tokio::test)]
-    async fn test_some_deliverable_one_stream() {
-        let TestEventInfo {
-            event_id: one_id,
-            car: one_car,
-            ..
-        } = build_event().await;
-        let one_cid = one_id.cid().unwrap();
-        let store = CeramicEventService::new(SqlitePool::connect_in_memory().await.unwrap())
-            .await
-            .unwrap();
-        recon::Store::insert(&store, &ReconItem::new(&one_id, &one_car))
-            .await
-            .unwrap();
-
-        check_deliverable(&store.pool, &one_cid, true).await;
-
-        let stream_cid = Cid::new_v1(0x71, Code::Sha2_256.digest(b"arbitrary"));
-        let missing = Cid::new_v1(0x71, Code::Sha2_256.digest(b"missing"));
-
-        let mut deliverable_events = build_linked_events(6, stream_cid, one_cid);
-        let stuck_events = build_linked_events(8, stream_cid, missing);
-        let expected = VecDeque::from_iter(deliverable_events.iter().map(|ev| ev.cid));
-        deliverable_events.extend(stuck_events);
-        let mut prev_map = StreamEvents::from_iter(deliverable_events);
-
-        assert_stream_map_elems(&prev_map, 14);
-        let deliverable =
-            super::OrderingState::discover_deliverable_events(&store.pool, &mut prev_map)
-                .await
-                .unwrap();
-
-        assert_eq!(6, deliverable.len());
-        assert_eq!(expected, deliverable);
-        assert_stream_map_elems(&prev_map, 8);
-    }
-
-    #[test(tokio::test)]
-    // expected to be per stream but all events are combined for the history required version currently so
-    // this needs to work as well
-    async fn test_all_deliverable_multiple_streams() {
-        let TestEventInfo {
-            event_id: one_id,
-            car: one_car,
-            ..
-        } = build_event().await;
-        let TestEventInfo {
-            event_id: two_id,
-            car: two_car,
-            ..
-        } = build_event().await;
-        let one_cid = one_id.cid().unwrap();
-        let two_cid = two_id.cid().unwrap();
-        let store = CeramicEventService::new(SqlitePool::connect_in_memory().await.unwrap())
-            .await
-            .unwrap();
-        recon::Store::insert_many(
-            &store,
-            &[
-                ReconItem::new(&one_id, &one_car),
-                ReconItem::new(&two_id, &two_car),
-            ],
-        )
-        .await
-        .unwrap();
-
-        check_deliverable(&store.pool, &one_cid, true).await;
-        check_deliverable(&store.pool, &two_cid, true).await;
-
-        let stream_cid = Cid::new_v1(0x71, Code::Sha2_256.digest(b"arbitrary-one"));
-        let stream_cid_2 = Cid::new_v1(0x71, Code::Sha2_256.digest(b"arbitrary-two"));
-
-        let mut events_a = build_linked_events(4, stream_cid, one_cid);
-        let mut events_b = build_linked_events(10, stream_cid_2, two_cid);
-        let expected_a = VecDeque::from_iter(events_a.iter().map(|ev| ev.cid));
-        let expected_b = VecDeque::from_iter(events_b.iter().map(|ev| ev.cid));
-        // we expect the events to be in the prev chain order, but they can be intervleaved across streams
-        // we reverse the items in the input to proov this (it's a hashmap internally so there is no order, but still)
-        events_a.reverse();
-        events_b.reverse();
-        events_a.extend(events_b);
-        assert_eq!(14, events_a.len());
-        let mut prev_map = StreamEvents::from_iter(events_a);
-
-        assert_stream_map_elems(&prev_map, 14);
-        let deliverable =
-            super::OrderingState::discover_deliverable_events(&store.pool, &mut prev_map)
-                .await
-                .unwrap();
-
-        assert_eq!(14, deliverable.len());
-        assert_eq!(0, prev_map.cid_map.len(), "{:?}", prev_map);
-        assert_eq!(0, prev_map.prev_map.len(), "{:?}", prev_map);
-
-        let mut split_a = VecDeque::new();
-        let mut split_b = VecDeque::new();
-        for cid in deliverable {
-            if expected_a.contains(&cid) {
-                split_a.push_back(cid);
-            } else if expected_b.contains(&cid) {
-                split_b.push_back(cid);
-            } else {
-                panic!("Unexpected CID in deliverable list: {:?}", cid);
-            }
-        }
-
-        assert_eq!(expected_a, split_a);
-        assert_eq!(expected_b, split_b);
+        res
     }
 
     #[test(tokio::test)]
     async fn test_undelivered_batch_empty() {
         let pool = SqlitePool::connect_in_memory().await.unwrap();
-        let (new, found) = OrderingState::new()
-            .add_undelivered_batch(&pool, 0, 10)
+        let processed = OrderingState::new()
+            .process_all_undelivered_events(&pool, 10, 100)
             .await
             .unwrap();
-        assert_eq!(0, new);
-        assert_eq!(0, found);
+        assert_eq!(0, processed);
+    }
+
+    async fn insert_10_with_9_undelivered(pool: &SqlitePool) {
+        let insertable = get_n_insertable_events(10).await;
+        let init = insertable.first().unwrap().to_owned();
+        let undelivered = insertable.into_iter().skip(1).collect::<Vec<_>>();
+
+        let new = CeramicOneEvent::insert_many(pool, &undelivered[..])
+            .await
+            .unwrap();
+
+        assert_eq!(9, new.inserted.len());
+        assert_eq!(0, new.inserted.iter().filter(|e| e.deliverable).count());
+
+        let new = CeramicOneEvent::insert_many(pool, &[init]).await.unwrap();
+        assert_eq!(1, new.inserted.len());
+        assert_eq!(1, new.inserted.iter().filter(|e| e.deliverable).count());
     }
 
     #[test(tokio::test)]
     async fn test_undelivered_batch_offset() {
         let pool = SqlitePool::connect_in_memory().await.unwrap();
-        let insertable = build_insertable_undelivered().await;
 
-        let _new = CeramicOneEvent::insert_many(&pool, &[insertable])
+        insert_10_with_9_undelivered(&pool).await;
+        let (_, events) = CeramicOneEvent::new_events_since_value(&pool, 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(1, events.len());
+
+        let processed = OrderingState::new()
+            .process_all_undelivered_events(&pool, 1, 5)
+            .await
+            .unwrap();
+        assert_eq!(5, processed);
+        let (_, events) = CeramicOneEvent::new_events_since_value(&pool, 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(6, events.len());
+        // the last 5 are processed and we have 10 delivered
+        let processed = OrderingState::new()
+            .process_all_undelivered_events(&pool, 1, 5)
+            .await
+            .unwrap();
+        assert_eq!(4, processed);
+        let (_, events) = CeramicOneEvent::new_events_since_value(&pool, 0, 100)
+            .await
+            .unwrap();
+        assert_eq!(10, events.len());
+
+        // nothing left
+        let processed = OrderingState::new()
+            .process_all_undelivered_events(&pool, 1, 100)
             .await
             .unwrap();
 
-        let mut state = OrderingState::new();
-        let (new, found) = state.add_undelivered_batch(&pool, 0, 10).await.unwrap();
-        assert_eq!(1, found);
-        assert_eq!(1, new);
-        let (new, found) = state.add_undelivered_batch(&pool, 10, 10).await.unwrap();
-        assert_eq!(0, new);
-        assert_eq!(0, found);
-        state.persist_ready_events(&pool).await.unwrap();
-        let (new, found) = state.add_undelivered_batch(&pool, 0, 10).await.unwrap();
-        assert_eq!(0, new);
-        assert_eq!(0, found);
+        assert_eq!(0, processed);
     }
 
     #[test(tokio::test)]
-    async fn test_undelivered_batch_all() {
+    async fn test_undelivered_batch_iterations_ends_early() {
         let pool = SqlitePool::connect_in_memory().await.unwrap();
-        let mut undelivered = Vec::with_capacity(10);
-        for _ in 0..10 {
-            let insertable = build_insertable_undelivered().await;
-            undelivered.push(insertable);
-        }
+        // create 5 streams with 9 undelivered events each
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
 
-        let (hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
+        let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
             .await
             .unwrap();
-        assert_eq!(0, hw);
-        assert!(event.is_empty());
-
-        let _new = CeramicOneEvent::insert_many(&pool, &undelivered[..])
-            .await
-            .unwrap();
-
+        assert_eq!(5, event.len());
         let mut state = OrderingState::new();
         state
-            .process_all_undelivered_events(&pool, 1)
+            .process_all_undelivered_events(&pool, 4, 10)
             .await
             .unwrap();
 
         let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
             .await
             .unwrap();
-        assert_eq!(event.len(), 10);
+        assert_eq!(45, event.len());
+    }
+
+    #[test(tokio::test)]
+    async fn test_undelivered_batch_iterations_ends_when_all_found() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        // create 5 streams with 9 undelivered events each
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+
+        let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
+            .await
+            .unwrap();
+        assert_eq!(5, event.len());
+        let mut state = OrderingState::new();
+        state
+            .process_all_undelivered_events(&pool, 100_000_000, 5)
+            .await
+            .unwrap();
+
+        let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
+            .await
+            .unwrap();
+        assert_eq!(50, event.len());
+    }
+
+    #[test(tokio::test)]
+    async fn test_process_all_undelivered_one_batch() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        // create 5 streams with 9 undelivered events each
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+        insert_10_with_9_undelivered(&pool).await;
+
+        let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
+            .await
+            .unwrap();
+        assert_eq!(5, event.len());
+        let mut state = OrderingState::new();
+        state
+            .process_all_undelivered_events(&pool, 1, 100)
+            .await
+            .unwrap();
+
+        let (_hw, event) = CeramicOneEvent::new_events_since_value(&pool, 0, 1000)
+            .await
+            .unwrap();
+        assert_eq!(50, event.len());
     }
 }

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -245,7 +245,7 @@ impl StreamEvents {
                     // as we could sit in the channel for a while and streams can fork, we can't rely
                     // on our in memory state to know what happened between enqueue and dequeque
                     // and need to try to process. We could add an LRU cache in the future to
-                    // avoid looking up that were processed while were were enqueued.
+                    // avoid looking up events that were processed while were were enqueued.
                     self.should_process = true;
                 }
                 meta.cid

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -184,7 +184,7 @@ async fn missing_prev_pending_recon_should_deliver_without_stream_update() {
     assert_eq!(expected, delivered);
 }
 
-#[test(tokio::test)]
+#[test(test(tokio::test))]
 async fn multiple_streams_missing_prev_recon_should_deliver_without_stream_update() {
     let store = setup_service().await;
     let stream_1 = get_events().await;
@@ -279,7 +279,7 @@ async fn validate_all_delivered(store: &CeramicEventService, expected_delivered:
     }
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn recon_lots_of_streams() {
     // adds `per_stream` events to `num_streams` streams, mixes up the event order for each stream, inserts half
     // the events for each stream before mixing up the stream order and inserting the rest

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -1,5 +1,9 @@
+use std::collections::HashMap;
+
 use ceramic_api::EventStore;
 use ceramic_core::EventId;
+use rand::seq::SliceRandom;
+use rand::thread_rng;
 use recon::ReconItem;
 use test_log::test;
 
@@ -12,12 +16,14 @@ async fn setup_service() -> CeramicEventService {
     let conn = ceramic_store::SqlitePool::connect_in_memory()
         .await
         .unwrap();
+
     CeramicEventService::new_without_undelivered(conn)
         .await
         .unwrap()
 }
 
 async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
+    tracing::trace!("inserted event: {}", item.key.cid().unwrap());
     let new = store
         .insert_events_from_carfiles_recon(&[item])
         .await
@@ -45,30 +51,17 @@ async fn test_init_event_delivered() {
 }
 
 #[test(tokio::test)]
-async fn test_missing_prev_error_history_required() {
+async fn test_missing_prev_history_required_not_inserted() {
     let store = setup_service().await;
     let events = get_events().await;
     let data = &events[1];
 
     let new = store
         .insert_events_from_carfiles_local_api(&[ReconItem::new(&data.0, &data.1)])
-        .await;
-    match new {
-        Ok(v) => panic!("should have errored: {:?}", v),
-        Err(e) => {
-            match e {
-                crate::Error::InvalidArgument { error } => {
-                    // yes fragile, but we want to make sure it's not a parsing error or something unexpected
-                    assert!(error
-                        .to_string()
-                        .contains("Missing required `prev` event CIDs"));
-                }
-                e => {
-                    panic!("unexpected error: {:?}", e);
-                }
-            };
-        }
-    };
+        .await
+        .unwrap();
+    assert!(new.store_result.inserted.is_empty());
+    assert_eq!(1, new.missing_history.len());
 }
 
 #[test(tokio::test)]
@@ -150,7 +143,7 @@ async fn test_missing_prev_pending_recon() {
     check_deliverable(&store.pool, &data.0.cid().unwrap(), true).await;
 
     // This happens out of band, so give it a moment to make sure everything is updated
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let (_, delivered) = store
         .events_since_highwater_mark(0, i64::MAX)
@@ -178,9 +171,8 @@ async fn missing_prev_pending_recon_should_deliver_without_stream_update() {
     // now we add the second event, it should quickly become deliverable
     let data = &events[1];
     add_and_assert_new_recon_event(&store, ReconItem::new(&data.0, &data.1)).await;
-    check_deliverable(&store.pool, &data.0.cid().unwrap(), false).await;
     // This happens out of band, so give it a moment to make sure everything is updated
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
     let (_, delivered) = store
         .events_since_highwater_mark(0, i64::MAX)
@@ -234,7 +226,7 @@ async fn multiple_streams_missing_prev_recon_should_deliver_without_stream_updat
     // this _could_ be deliverable immediately if we checked but for now we just send to the other task,
     // so `check_deliverable` could return true or false depending on timing (but probably false).
     // as this is an implementation detail and we'd prefer true, we just use HW ordering to make sure it's been delivered
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     let (_, delivered) = store
         .events_since_highwater_mark(0, i64::MAX)
         .await
@@ -265,4 +257,119 @@ async fn multiple_streams_missing_prev_recon_should_deliver_without_stream_updat
         s2_3.0.cid().unwrap(),
     ];
     assert_eq!(expected, delivered);
+}
+
+async fn validate_all_delivered(store: &CeramicEventService, expected_delivered: usize) {
+    loop {
+        let (_, delivered) = store
+            .events_since_highwater_mark(0, i64::MAX)
+            .await
+            .unwrap();
+        let total = delivered.len();
+        if total < expected_delivered {
+            tracing::trace!(
+                "found {} delivered, waiting for {}",
+                total,
+                expected_delivered
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        } else {
+            break;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recon_lots_of_streams() {
+    // adds `per_stream` events to `num_streams` streams, mixes up the event order for each stream, inserts half
+    // the events for each stream before mixing up the stream order and inserting the rest
+    // took like a minute on my machine to run 100 streams with 1000 events each, mostly inserting :( since ordering only gets 5 seconds
+    let per_stream = 100;
+    let num_streams = 10;
+    let store = setup_service().await;
+    let expected = per_stream * num_streams;
+    let mut streams = Vec::new();
+    let mut all_cids = Vec::new();
+    let mut expected_stream_order = Vec::new();
+    let mut cid_to_stream_map = HashMap::new();
+
+    for i in 0..num_streams {
+        let mut events = crate::tests::get_n_events(per_stream).await;
+        let cids = events
+            .iter()
+            .map(|e| e.0.cid().unwrap())
+            .collect::<Vec<_>>();
+        cids.iter().for_each(|cid| {
+            cid_to_stream_map.insert(*cid, i);
+        });
+        expected_stream_order.push(cids.clone());
+        all_cids.extend(cids);
+        assert_eq!(per_stream, events.len());
+        events.shuffle(&mut thread_rng());
+        streams.push(events);
+    }
+    let mut total_added = 0;
+
+    assert_eq!(expected, all_cids.len());
+
+    tracing::debug!(?all_cids, "starting test");
+    for stream in streams.iter_mut() {
+        while let Some(event) = stream.pop() {
+            if stream.len() > per_stream / 2 {
+                total_added += 1;
+                add_and_assert_new_recon_event(&store, ReconItem::new(&event.0, &event.1)).await;
+            } else {
+                total_added += 1;
+                add_and_assert_new_recon_event(&store, ReconItem::new(&event.0, &event.1)).await;
+                break;
+            }
+        }
+    }
+    streams.shuffle(&mut thread_rng());
+    for stream in streams.iter_mut() {
+        while let Some(event) = stream.pop() {
+            total_added += 1;
+            add_and_assert_new_recon_event(&store, ReconItem::new(&event.0, &event.1)).await;
+        }
+    }
+    // first just make sure they were all inserted (not delivered yet)
+    for (i, cid) in all_cids.iter().enumerate() {
+        let (exists, _delivered) =
+            ceramic_store::CeramicOneEvent::deliverable_by_cid(&store.pool, cid)
+                .await
+                .unwrap();
+        assert!(exists, "idx: {}. missing cid: {}", i, cid);
+    }
+
+    assert_eq!(expected, total_added);
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        validate_all_delivered(&store, expected),
+    )
+    .await
+    .unwrap();
+
+    let (_, delivered) = store
+        .events_since_highwater_mark(0, i64::MAX)
+        .await
+        .unwrap();
+
+    assert_eq!(expected, delivered.len());
+    let mut streams_at_the_end = Vec::new();
+    for _ in 0..num_streams {
+        streams_at_the_end.push(Vec::with_capacity(per_stream));
+    }
+    for cid in delivered {
+        let stream = cid_to_stream_map.get(&cid).unwrap();
+        let stream = streams_at_the_end.get_mut(*stream).unwrap();
+        stream.push(cid);
+    }
+    // now we check that all the events are deliverable
+    for cid in all_cids.iter() {
+        check_deliverable(&store.pool, cid, true).await;
+    }
+    // and make sure the events were delivered for each stream streams in the same order as they were at the start
+    for (i, stream) in expected_stream_order.iter().enumerate() {
+        assert_eq!(*stream, streams_at_the_end[i]);
+    }
 }

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -13,19 +13,21 @@ anyhow.workspace = true
 async-trait.workspace = true
 ceramic-api.workspace = true
 ceramic-core.workspace = true
+ceramic-event.workspace = true
 ceramic-metrics.workspace = true
 cid.workspace = true
 futures.workspace = true
 hex.workspace = true
+ipld-core.workspace = true
 iroh-bitswap.workspace = true
 iroh-car.workspace = true
 itertools = "0.12.0"
-multihash.workspace = true
 multihash-codetable.workspace = true
+multihash.workspace = true
 prometheus-client.workspace = true
-thiserror.workspace = true
 recon.workspace = true
 sqlx.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 
 [dev-dependencies]

--- a/store/benches/sqlite_store.rs
+++ b/store/benches/sqlite_store.rs
@@ -75,7 +75,7 @@ async fn model_setup(tpe: ModelType, cnt: usize) -> ModelSetup {
         let body = EventInsertableBody::try_from_carfile(init.0.cid().unwrap(), &init.1)
             .await
             .unwrap();
-        events.push(EventInsertable::try_new(init.0, body).unwrap());
+        events.push(EventInsertable::try_from_carfile(init.0, body).unwrap());
     }
 
     let pool = SqlitePool::connect_in_memory().await.unwrap();

--- a/store/src/sql/test.rs
+++ b/store/src/sql/test.rs
@@ -123,10 +123,11 @@ async fn range_query() {
 #[test(tokio::test)]
 async fn undelivered_with_values() {
     let pool = SqlitePool::connect_in_memory().await.unwrap();
-    let res = CeramicOneEvent::undelivered_with_values(&pool, 0, 10000)
+    let (res, hw) = CeramicOneEvent::undelivered_with_values(&pool, 0, 10000)
         .await
         .unwrap();
     assert_eq!(res.len(), 0);
+    assert_eq!(hw, 0);
 }
 
 #[test(tokio::test)]


### PR DESCRIPTION
Address AES-83 and replaces part of #375 and incorporates a lot of the feedback from that one. Depends on #390.

This changes the initial "deliver all undelivered events" process to happen when creating a `CeramicEventService`, which means it could take a while, and will block (or prevent if it fails) the server from starting rather than happen in the background.

There are new/better tests. Some where deleted/replaced that were specific to the IOD implementation details and the higher API is now tested exclusively. The general premise is to send recon events to the task, and it will track them in memory if they need history. Delivered events will be be stored if we have the stream in memory, and will trigger a review of the stream if they unblock something we have. If we don't have the stream, we drop them (but we need to learn about them jic we needed them). 

When reviewing streams, we order as many events as we can and then insert them. We use mutable state, but things should be cancel and retry safe, as we don't drop things until we've successfully committed to the database. The previous bugs were due to some state management mistakes about when to keep things around, when to trigger a review, when to look things up (so pretty much everything 😞). This implementation should be simpler, handles these situations correctly, does less work and uses an enum rather than flags to make things harder to mess up but is pretty much a rewrite of `ordering_task.rs`.

I'm not happy with the structs needed to wrap different varieties of the event (unvalidated, store with order key or without, etc). Cleaning that up will make event validation easier. This should fix the test in https://github.com/ceramicnetwork/js-ceramic/pull/3205. 