### PR TITLE
fix: api batch with one invalid event could fail all

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -3,7 +3,7 @@ mod server;
 
 pub use resume_token::ResumeToken;
 
-pub use server::{EventStore, InterestStore, Server};
+pub use server::{EventInsertResult, EventStore, InterestStore, Server};
 
 #[cfg(test)]
 mod tests;

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -6,6 +6,7 @@
 
 mod event;
 
+use std::collections::HashMap;
 use std::time::Duration;
 use std::{future::Future, ops::Range};
 use std::{marker::PhantomData, ops::RangeBounds};
@@ -162,11 +163,40 @@ impl<S: InterestStore> InterestStore for Arc<S> {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum EventInsertResult {
+    Success(EventId),
+    Failed(EventId, String),
+}
+
+impl EventInsertResult {
+    pub fn new_ok(id: EventId) -> Self {
+        Self::Success(id)
+    }
+    pub fn new_failed(id: EventId, reason: String) -> Self {
+        Self::Failed(id, reason)
+    }
+
+    pub fn id(&self) -> &EventId {
+        match self {
+            Self::Success(id) => id,
+            Self::Failed(id, _) => id,
+        }
+    }
+
+    pub fn success(&self) -> bool {
+        match self {
+            Self::Success(_) => true,
+            Self::Failed(_, _) => false,
+        }
+    }
+}
+
 /// Trait for accessing persistent storage of Events
 #[async_trait]
 pub trait EventStore: Send + Sync {
     /// Returns (new_key, new_value) where true if was newly inserted, false if it already existed.
-    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> Result<Vec<bool>>;
+    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> Result<Vec<EventInsertResult>>;
     async fn range_with_values(
         &self,
         range: Range<EventId>,
@@ -199,7 +229,7 @@ pub trait EventStore: Send + Sync {
 
 #[async_trait::async_trait]
 impl<S: EventStore> EventStore for Arc<S> {
-    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> Result<Vec<bool>> {
+    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> Result<Vec<EventInsertResult>> {
         self.as_ref().insert_many(items).await
     }
 
@@ -241,7 +271,7 @@ impl<S: EventStore> EventStore for Arc<S> {
 struct EventInsert {
     id: EventId,
     data: Vec<u8>,
-    tx: tokio::sync::oneshot::Sender<Result<bool>>,
+    tx: tokio::sync::oneshot::Sender<Result<EventInsertResult>>,
 }
 
 struct InsertTask {
@@ -325,25 +355,36 @@ where
         if events.is_empty() {
             return;
         }
-        let mut oneshots = Vec::with_capacity(events.len());
+        let mut oneshots = HashMap::with_capacity(events.len());
         let mut items = Vec::with_capacity(events.len());
         events.drain(..).for_each(|req: EventInsert| {
-            oneshots.push(req.tx);
+            oneshots.insert(req.id.to_bytes(), req.tx);
             items.push((req.id, req.data));
         });
         tracing::trace!("calling insert many with {} items.", items.len());
         match event_store.insert_many(&items).await {
             Ok(results) => {
                 tracing::debug!("insert many returned {} results.", results.len());
-                for (tx, result) in oneshots.into_iter().zip(results.into_iter()) {
-                    if let Err(e) = tx.send(Ok(result)) {
-                        tracing::warn!("failed to send success response to api listener: {:?}", e);
+                for result in results {
+                    let id = result.id();
+                    if let Some(tx) = oneshots.remove(&id.to_bytes()) {
+                        if let Err(e) = tx.send(Ok(result)) {
+                            tracing::warn!(
+                                "failed to send success response to api listener: {:?}",
+                                e
+                            );
+                        }
+                    } else {
+                        tracing::warn!(
+                            "lost channel to respond to API listener for event ID: {:?}",
+                            id
+                        );
                     }
                 }
             }
             Err(e) => {
                 tracing::warn!("failed to insert events: {e}");
-                for tx in oneshots.into_iter() {
+                for tx in oneshots.into_values() {
                     if let Err(e) = tx.send(Err(anyhow::anyhow!("Failed to insert event: {e}"))) {
                         tracing::warn!("failed to send failed response to api listener: {:?}", e);
                     }
@@ -495,7 +536,7 @@ where
         .await?
         .map_err(|_| ErrorResponse::new("Database service not available".to_owned()))?;
 
-        let _new = tokio::time::timeout(INSERT_REQUEST_TIMEOUT, rx)
+        let new = tokio::time::timeout(INSERT_REQUEST_TIMEOUT, rx)
             .await
             .map_err(|_| {
                 ErrorResponse::new("Timeout waiting for database service response".to_owned())
@@ -503,7 +544,12 @@ where
             .map_err(|_| ErrorResponse::new("No response. Database service crashed".to_owned()))?
             .map_err(|e| ErrorResponse::new(format!("Failed to insert event: {e}")))?;
 
-        Ok(EventsPostResponse::Success)
+        match new {
+            EventInsertResult::Success(_) => Ok(EventsPostResponse::Success),
+            EventInsertResult::Failed(_, reason) => Ok(EventsPostResponse::BadRequest(
+                BadRequestResponse::new(reason),
+            )),
+        }
     }
 
     pub async fn post_interests(

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -395,3 +395,20 @@ pub struct InsertResult {
     pub(crate) store_result: ceramic_store::InsertResult,
     pub(crate) missing_history: Vec<EventId>,
 }
+
+impl From<InsertResult> for Vec<ceramic_api::EventInsertResult> {
+    fn from(res: InsertResult) -> Self {
+        let mut api_res =
+            Vec::with_capacity(res.store_result.inserted.len() + res.missing_history.len());
+        for ev in res.store_result.inserted {
+            api_res.push(ceramic_api::EventInsertResult::new_ok(ev.order_key));
+        }
+        for ev in res.missing_history {
+            api_res.push(ceramic_api::EventInsertResult::new_failed(
+                ev,
+                "Failed to insert event as `prev` event was missing".to_owned(),
+            ));
+        }
+        api_res
+    }
+}

--- a/service/src/event/store.rs
+++ b/service/src/event/store.rs
@@ -107,7 +107,10 @@ impl iroh_bitswap::Store for CeramicEventService {
 
 #[async_trait::async_trait]
 impl ceramic_api::EventStore for CeramicEventService {
-    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> anyhow::Result<Vec<bool>> {
+    async fn insert_many(
+        &self,
+        items: &[(EventId, Vec<u8>)],
+    ) -> anyhow::Result<Vec<ceramic_api::EventInsertResult>> {
         let items = items
             .iter()
             .map(|(key, val)| ReconItem::new(key, val.as_slice()))
@@ -115,12 +118,8 @@ impl ceramic_api::EventStore for CeramicEventService {
         let res = self
             .insert_events_from_carfiles_local_api(&items[..])
             .await?;
-        Ok(res
-            .store_result
-            .inserted
-            .iter()
-            .map(|r| r.new_key)
-            .collect())
+
+        Ok(res.into())
     }
 
     async fn range_with_values(

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -158,7 +158,10 @@ impl<S> ceramic_api::EventStore for StoreMetricsMiddleware<S>
 where
     S: ceramic_api::EventStore,
 {
-    async fn insert_many(&self, items: &[(EventId, Vec<u8>)]) -> anyhow::Result<Vec<bool>> {
+    async fn insert_many(
+        &self,
+        items: &[(EventId, Vec<u8>)],
+    ) -> anyhow::Result<Vec<ceramic_api::EventInsertResult>> {
         let new_keys = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "api_insert_many",
@@ -166,7 +169,7 @@ where
         )
         .await?;
 
-        let key_cnt = new_keys.iter().filter(|k| **k).count();
+        let key_cnt = new_keys.iter().filter(|k| k.success()).count();
 
         self.metrics.record(&InsertEvent {
             cnt: key_cnt as u64,


### PR DESCRIPTION
Previously, an API insert batch with a single event with invalid ordering could fail the entire set. It's still possible to "over fail" if something goes wrong somewhere (talking to the database or one of the events fails to parse), however both of those seem acceptable as the events are all parsed before being given to us so that should never happen. I'd like to change the signature to take an ceramic_event type in a follow up, but this is some progress in that direction. It builds on #390. 