### PR TITLE
refactor: modify store API and rename some things 

### DIFF
--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -312,7 +312,7 @@ impl OrderingState {
                 // once we find the first event that's deliverable, we can go back through and find the rest
                 continue;
             } else {
-                let (exists, delivered) = CeramicOneEvent::delivered_by_cid(pool, &prev).await?;
+                let (exists, delivered) = CeramicOneEvent::deliverable_by_cid(pool, &prev).await?;
                 if delivered {
                     trace!(deliverable=?ev_cid, "Found delivered prev in database. Adding to ready list");
                     deliverable.push_back(ev_cid);

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -5,7 +5,7 @@ use ceramic_event::unvalidated;
 use ceramic_store::{CeramicOneEvent, EventInsertable, EventInsertableBody, SqlitePool};
 use cid::Cid;
 use ipld_core::ipld::Ipld;
-use recon::{InsertResult, ReconItem};
+use recon::ReconItem;
 use tracing::{trace, warn};
 
 use super::ordering_task::{
@@ -126,10 +126,10 @@ impl CeramicEventService {
     /// This is likely used in API contexts when a user is trying to insert events. Events discovered from
     /// peers can come in any order and we will discover the prev chain over time. Use
     /// `insert_events_from_carfiles_remote_history` for that case.
-    pub(crate) async fn insert_events_from_carfiles_local_history<'a>(
+    pub(crate) async fn insert_events_from_carfiles_local_api<'a>(
         &self,
         items: &[recon::ReconItem<'a, EventId>],
-    ) -> Result<recon::InsertResult> {
+    ) -> Result<InsertResult> {
         if items.is_empty() {
             return Ok(InsertResult::default());
         }
@@ -144,19 +144,31 @@ impl CeramicEventService {
     /// This is used in recon contexts when we are discovering events from peers in a recon but not ceramic order and
     /// don't have the complete order. To enforce that the history is local, e.g. in API contexts, use
     /// `insert_events_from_carfiles_local_history`.
-    pub(crate) async fn insert_events_from_carfiles_remote_history<'a>(
+    pub(crate) async fn insert_events_from_carfiles_recon<'a>(
         &self,
         items: &[recon::ReconItem<'a, EventId>],
     ) -> Result<recon::InsertResult> {
         if items.is_empty() {
-            return Ok(InsertResult::default());
+            return Ok(recon::InsertResult::default());
         }
 
         let ordering = InsertEventOrdering::discover_deliverable_remote_history(items).await?;
-        self.process_events(ordering).await
+        let res = self.process_events(ordering).await?;
+        // we need to put things back in the right order that the recon trait expects, even though we don't really care about the result
+        let mut keys = vec![false; items.len()];
+        for (i, item) in items.iter().enumerate() {
+            let new_key = res
+                .store_result
+                .inserted
+                .iter()
+                .find(|e| e.order_key == *item.key)
+                .map_or(false, |e| e.new_key); // TODO: should we error if it's not in this set
+            keys[i] = new_key;
+        }
+        Ok(recon::InsertResult::new(keys))
     }
 
-    async fn process_events(&self, ordering: InsertEventOrdering) -> Result<recon::InsertResult> {
+    async fn process_events(&self, ordering: InsertEventOrdering) -> Result<InsertResult> {
         let res = CeramicOneEvent::insert_many(&self.pool, &ordering.insert_now[..]).await?;
 
         for ev in ordering.background_task_deliverable {
@@ -194,7 +206,10 @@ impl CeramicEventService {
                 }
             }
         }
-        Ok(res)
+        Ok(InsertResult {
+            store_result: res,
+            missing_history: vec![],
+        })
     }
 }
 
@@ -373,4 +388,10 @@ impl InsertEventOrdering {
             Ok(())
         }
     }
+}
+
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct InsertResult {
+    pub(crate) store_result: ceramic_store::InsertResult,
+    pub(crate) missing_history: Vec<EventId>,
 }

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -285,7 +285,7 @@ impl InsertEventOrdering {
     }
 
     fn mark_event_deliverable_now(&mut self, mut ev: EventInsertable, init_cid: Cid) {
-        ev.deliverable(true);
+        ev.set_deliverable(true);
         self.notify_task_new
             .push(DeliveredEvent::new(ev.body.cid, init_cid));
         self.insert_now.push(ev);

--- a/service/src/tests/mod.rs
+++ b/service/src/tests/mod.rs
@@ -129,7 +129,7 @@ pub(crate) async fn check_deliverable(
     cid: &Cid,
     deliverable: bool,
 ) {
-    let (exists, delivered) = ceramic_store::CeramicOneEvent::delivered_by_cid(pool, cid)
+    let (exists, delivered) = ceramic_store::CeramicOneEvent::deliverable_by_cid(pool, cid)
         .await
         .unwrap();
     assert!(exists);

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -10,8 +10,8 @@ pub use error::Error;
 pub use metrics::{Metrics, StoreMetricsMiddleware};
 pub use sql::{
     entities::EventInsertable, entities::EventInsertableBody, CeramicOneBlock, CeramicOneEvent,
-    CeramicOneEventBlock, CeramicOneInterest, Migrations, SqlitePool, SqliteRootStore,
-    SqliteTransaction,
+    CeramicOneEventBlock, CeramicOneInterest, InsertResult, InsertedEvent, Migrations, SqlitePool,
+    SqliteRootStore, SqliteTransaction,
 };
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -13,7 +13,7 @@ use prometheus_client::{
     },
     registry::Registry,
 };
-use recon::{AssociativeHash, HashCount, InsertResult, ReconItem, Result as ReconResult};
+use recon::{AssociativeHash, HashCount, ReconItem, Result as ReconResult};
 use tokio::time::Instant;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -253,7 +253,7 @@ where
         Ok(new)
     }
 
-    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> ReconResult<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<'_, K>]) -> ReconResult<recon::InsertResult> {
         let res = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "insert_many",

--- a/store/src/sql/access/event.rs
+++ b/store/src/sql/access/event.rs
@@ -12,7 +12,7 @@ use recon::{AssociativeHash, HashCount, InsertResult, Key, Result as ReconResult
 use crate::{
     sql::{
         entities::{
-            rebuild_car, BlockRow, CountRow, DeliveredEvent, EventInsertable, OrderKey,
+            rebuild_car, BlockRow, CountRow, DeliveredEventRow, EventInsertable, OrderKey,
             ReconEventBlockRaw, ReconHash,
         },
         query::{EventQuery, ReconQuery, ReconType, SqlBackend},
@@ -220,13 +220,13 @@ impl CeramicOneEvent {
         delivered: i64,
         limit: i64,
     ) -> Result<(i64, Vec<Cid>)> {
-        let rows: Vec<DeliveredEvent> = sqlx::query_as(EventQuery::new_delivered_events())
+        let rows: Vec<DeliveredEventRow> = sqlx::query_as(EventQuery::new_delivered_events())
             .bind(delivered)
             .bind(limit)
             .fetch_all(pool.reader())
             .await?;
 
-        DeliveredEvent::parse_query_results(delivered, rows)
+        DeliveredEventRow::parse_query_results(delivered, rows)
     }
 
     /// Finds the event data by a given EventId i.e. "order key".

--- a/store/src/sql/access/mod.rs
+++ b/store/src/sql/access/mod.rs
@@ -4,6 +4,6 @@ mod event_block;
 mod interest;
 
 pub use block::CeramicOneBlock;
-pub use event::CeramicOneEvent;
+pub use event::{CeramicOneEvent, InsertResult, InsertedEvent};
 pub use event_block::CeramicOneEventBlock;
 pub use interest::CeramicOneInterest;

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -63,7 +63,7 @@ impl EventInsertable {
     }
 
     /// change the deliverable status of the event
-    pub fn deliverable(&mut self, deliverable: bool) {
+    pub fn set_deliverable(&mut self, deliverable: bool) {
         self.body.deliverable = deliverable;
     }
 }

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -62,7 +62,23 @@ impl EventInsertable {
         Ok(Self { order_key, body })
     }
 
-    /// change the deliverable status of the event
+    /// Get the CID of the event
+    pub fn cid(&self) -> Cid {
+        self.body.cid
+    }
+
+    /// Whether this event is deliverable currently
+    pub fn deliverable(&self) -> bool {
+        self.body.deliverable
+    }
+
+    /// Whether this event is deliverable currently
+    pub fn blocks(&self) -> &Vec<EventBlockRaw> {
+        &self.body.blocks
+    }
+
+    /// Mark the event as deliverable.
+    /// This will be used when inserting the event to make sure the field is updated accordingly.
     pub fn set_deliverable(&mut self, deliverable: bool) {
         self.body.deliverable = deliverable;
     }
@@ -82,10 +98,10 @@ pub struct EventInsertableBody {
 
 impl EventInsertableBody {
     /// Create a new EventInsertRaw struct. Deliverable is set to false by default.
-    pub fn new(cid: Cid, blocks: Vec<EventBlockRaw>) -> Self {
+    pub fn new(cid: Cid, blocks: Vec<EventBlockRaw>, deliverable: bool) -> Self {
         Self {
             cid,
-            deliverable: false,
+            deliverable,
             blocks,
         }
     }
@@ -136,6 +152,6 @@ impl EventInsertableBody {
             blocks.push(ebr);
             idx += 1;
         }
-        Ok(Self::new(event_cid, blocks))
+        Ok(Self::new(event_cid, blocks, false))
     }
 }

--- a/store/src/sql/entities/event_block.rs
+++ b/store/src/sql/entities/event_block.rs
@@ -134,4 +134,8 @@ impl EventBlockRaw {
             bytes,
         })
     }
+
+    pub fn cid(&self) -> Cid {
+        Cid::new_v1(self.codec as u64, self.multihash.clone().into_inner())
+    }
 }

--- a/store/src/sql/entities/hash.rs
+++ b/store/src/sql/entities/hash.rs
@@ -4,7 +4,7 @@ use sqlx::{sqlite::SqliteRow, Row as _};
 
 use crate::{Error, Result};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, sqlx::Type)]
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::Type)]
 pub struct BlockHash(Multihash<64>);
 
 impl BlockHash {

--- a/store/src/sql/entities/mod.rs
+++ b/store/src/sql/entities/mod.rs
@@ -9,4 +9,4 @@ pub use event::{rebuild_car, EventInsertable, EventInsertableBody};
 pub use event_block::{EventBlockRaw, ReconEventBlockRaw};
 pub use hash::{BlockHash, ReconHash};
 
-pub use utils::{CountRow, DeliveredEvent, OrderKey};
+pub use utils::{CountRow, DeliveredEventRow, OrderKey};

--- a/store/src/sql/entities/utils.rs
+++ b/store/src/sql/entities/utils.rs
@@ -24,12 +24,12 @@ impl TryFrom<OrderKey> for EventId {
 }
 
 #[derive(sqlx::FromRow)]
-pub struct DeliveredEvent {
+pub struct DeliveredEventRow {
     pub cid: Vec<u8>,
     pub new_highwater_mark: i64,
 }
 
-impl DeliveredEvent {
+impl DeliveredEventRow {
     /// assumes rows are sorted by `delivered` ascending
     pub fn parse_query_results(current: i64, rows: Vec<Self>) -> Result<(i64, Vec<Cid>)> {
         let max: i64 = rows.last().map_or(current, |r| r.new_highwater_mark + 1);

--- a/store/src/sql/mod.rs
+++ b/store/src/sql/mod.rs
@@ -6,7 +6,10 @@ mod sqlite;
 #[cfg(test)]
 mod test;
 
-pub use access::{CeramicOneBlock, CeramicOneEvent, CeramicOneEventBlock, CeramicOneInterest};
+pub use access::{
+    CeramicOneBlock, CeramicOneEvent, CeramicOneEventBlock, CeramicOneInterest, InsertResult,
+    InsertedEvent,
+};
 pub use root::SqliteRootStore;
 pub use sqlite::{SqlitePool, SqliteTransaction};
 

--- a/store/src/sql/query.rs
+++ b/store/src/sql/query.rs
@@ -121,7 +121,7 @@ impl EventQuery {
 
     /// Updates the delivered column in the event table so it can be set to the client
     pub fn mark_ready_to_deliver() -> &'static str {
-        "UPDATE ceramic_one_event SET delivered = $1 WHERE cid = $2;"
+        "UPDATE ceramic_one_event SET delivered = $1 WHERE cid = $2 and delivered is NULL;"
     }
 }
 
@@ -167,11 +167,13 @@ impl ReconQuery {
         "INSERT INTO ceramic_one_event (
             order_key, cid,
             ahash_0, ahash_1, ahash_2, ahash_3,
-            ahash_4, ahash_5, ahash_6, ahash_7
+            ahash_4, ahash_5, ahash_6, ahash_7,
+            delivered
         ) VALUES (
             $1, $2,
             $3, $4, $5, $6,
-            $7, $8, $9, $10
+            $7, $8, $9, $10,
+            $11
         );"
     }
 

--- a/store/src/sql/test.rs
+++ b/store/src/sql/test.rs
@@ -30,11 +30,7 @@ fn random_event(cid: &str) -> EventInsertable {
     let cid = order_key.cid().unwrap();
     EventInsertable {
         order_key,
-        body: EventInsertableBody {
-            cid,
-            deliverable: false,
-            blocks: vec![],
-        },
+        body: EventInsertableBody::new(cid, vec![], true),
     }
 }
 
@@ -48,8 +44,7 @@ async fn hash_range_query() {
         .await
         .unwrap();
 
-    let new = x.keys.into_iter().filter(|x| *x).count();
-    assert_eq!(new, 2);
+    assert_eq!(x.count_new_keys(), 2);
 
     let hash = CeramicOneEvent::hash_range(
         &pool,
@@ -70,8 +65,7 @@ async fn range_query() {
         .await
         .unwrap();
 
-    let new = x.keys.into_iter().filter(|x| *x).count();
-    assert_eq!(new, 2);
+    assert_eq!(x.count_new_keys(), 2);
 
     let ids = CeramicOneEvent::range(
         &pool,


### PR DESCRIPTION
Use deliverable instead of delivered language. Fixes the possibility of changing the delivered integer value after is has been set. Modifies the insert events response to include some more information. This is probably not strictly necessary, but it does make it easier to map things back after they have been reordered in the case of recon that only cares about original order.