### PR TITLE
refactor: use test-log::test for all testing log needs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1045,10 +1045,10 @@ dependencies = [
  "serde",
  "serde_ipld_dagcbor",
  "swagger",
+ "test-log",
  "tikv-jemalloc-ctl",
  "tokio",
  "tracing",
- "tracing-test",
 ]
 
 [[package]]
@@ -1165,10 +1165,10 @@ dependencies = [
  "serde_ipld_dagjson",
  "serde_json",
  "swagger",
+ "test-log",
  "thiserror",
  "tokio",
  "tracing",
- "tracing-test",
 ]
 
 [[package]]
@@ -1385,7 +1385,6 @@ dependencies = [
  "tmpdir",
  "tokio",
  "tracing-subscriber",
- "tracing-test",
  "uuid 1.8.0",
 ]
 
@@ -8942,29 +8941,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-test"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
-dependencies = [
- "lazy_static",
- "tracing-core",
- "tracing-subscriber",
- "tracing-test-macro",
-]
-
-[[package]]
-name = "tracing-test-macro"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
-dependencies = [
- "lazy_static",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -35,5 +35,5 @@ tikv-jemalloc-ctl.workspace = true
 
 [dev-dependencies]
 expect-test.workspace = true
-tracing-test.workspace = true
+test-log.workspace = true
 mockall.workspace = true

--- a/api/src/server/event.rs
+++ b/api/src/server/event.rs
@@ -129,7 +129,7 @@ mod tests {
     use async_trait::async_trait;
     use expect_test::{expect, Expect};
     use mockall::{mock, predicate};
-    use tracing_test::traced_test;
+    use test_log::test;
 
     async fn test_event_id_from_car(
         event_data: &str,
@@ -146,8 +146,7 @@ mod tests {
         expected_event_id.assert_debug_eq(&event_id);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_signed_init_event() {
         let expected = expect![[r#"
             Ok(
@@ -175,8 +174,7 @@ mod tests {
         test_event_id_from_car(SIGNED_INIT_EVENT_CAR, expected, MockEventStoreTest::new()).await
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_unsigned_init_event() {
         let expected = expect![[r#"
             Ok(
@@ -210,8 +208,7 @@ mod tests {
         .await
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_data_event() {
         let expected = expect![[r#"
             Ok(
@@ -240,8 +237,7 @@ mod tests {
         test_event_id_from_car(DATA_EVENT_CAR, expected, mock_event_store).await
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_data_event_unsigned_init() {
         let expected = expect![[r#"
             Ok(
@@ -270,8 +266,7 @@ mod tests {
         test_event_id_from_car(DATA_EVENT_CAR_UNSIGNED_INIT, expected, mock_event_store).await
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_time_event() {
         let expected = expect![[r#"
             Ok(
@@ -300,8 +295,7 @@ mod tests {
         test_event_id_from_car(TIME_EVENT_CAR, expected, mock_event_store).await
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn event_id_from_car_data_event_missing() {
         let mut mock_store = MockEventStoreTest::new();
         mock_store

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -21,7 +21,7 @@ use expect_test::expect;
 use mockall::{mock, predicate};
 use multibase::Base;
 use recon::Key;
-use tracing_test::traced_test;
+use test_log::test;
 
 struct Context;
 
@@ -201,8 +201,7 @@ async fn create_event() {
         .unwrap();
     assert!(matches!(resp, EventsPostResponse::Success));
 }
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn register_interest_sort_value() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -250,8 +249,7 @@ async fn register_interest_sort_value() {
     assert_eq!(resp, InterestsPostResponse::Success);
 }
 
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn register_interest_sort_value_bad_request() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -272,8 +270,7 @@ async fn register_interest_sort_value_bad_request() {
     assert!(matches!(resp, InterestsPostResponse::BadRequest(_)));
 }
 
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn register_interest_sort_value_controller() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -323,8 +320,7 @@ async fn register_interest_sort_value_controller() {
     assert_eq!(resp, InterestsSortKeySortValuePostResponse::Success);
 }
 
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn register_interest_value_controller_stream() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -375,7 +371,7 @@ async fn register_interest_value_controller_stream() {
     assert_eq!(resp, InterestsSortKeySortValuePostResponse::Success);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn get_interests() {
     let peer_id = PeerId::from_str("1AaNXU5G2SJQSzCCP23V2TEDierSRBBGLA7aSCYScUTke9").unwrap();
     let network = Network::InMemory;
@@ -443,8 +439,7 @@ async fn get_interests() {
         )
     "#]].assert_debug_eq(&resp);
 }
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn get_events_for_interest_range() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -507,8 +502,7 @@ async fn get_events_for_interest_range() {
     );
 }
 
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn test_events_event_id_get_by_event_id_success() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;
@@ -546,8 +540,7 @@ async fn test_events_event_id_get_by_event_id_success() {
     assert_eq!(event.data, event_data_base64);
 }
 
-#[tokio::test]
-#[traced_test]
+#[test(tokio::test)]
 async fn test_events_event_id_get_by_cid_success() {
     let peer_id = PeerId::random();
     let network = Network::InMemory;

--- a/kubo-rpc/Cargo.toml
+++ b/kubo-rpc/Cargo.toml
@@ -41,7 +41,7 @@ go-parse-duration = "0.1.1"
 
 [dev-dependencies]
 expect-test.workspace = true
-tracing-test.workspace = true
+test-log.workspace = true
 mockall.workspace = true
 async-stream.workspace = true
 ipld-dagpb.workspace = true

--- a/kubo-rpc/src/http.rs
+++ b/kubo-rpc/src/http.rs
@@ -360,12 +360,11 @@ mod tests {
 
     use bytes::Bytes;
     use ceramic_metadata::Version;
+    use expect_test::expect;
     use ipld_core::codec::Codec;
     use ipld_dagpb::DagPbCodec;
     use mockall::predicate;
-    use tracing_test::traced_test;
-
-    use expect_test::expect;
+    use test_log::test;
 
     // Empty Context
     struct Context;
@@ -425,8 +424,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_get() {
         let cid =
             Cid::from_str("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap();
@@ -449,8 +447,7 @@ mod tests {
         .assert_debug_eq(&DebugResponse::from(resp));
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_get_offline() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -479,8 +476,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&DebugResponse::from(resp));
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_get_offline_not_found() {
         let cid =
             Cid::from_str("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap();
@@ -511,8 +507,7 @@ mod tests {
         .assert_debug_eq(&DebugResponse::from(resp));
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_get_timeout_success() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -549,8 +544,7 @@ mod tests {
         .assert_debug_eq(&DebugResponse::from(resp));
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_get_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -572,8 +566,7 @@ mod tests {
         .assert_debug_eq(&DebugResponse::from(resp));
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_stat() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -605,8 +598,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn block_stat_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -628,8 +620,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_get_json() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -670,8 +661,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&DebugResponse::from(resp));
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_get_cbor() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -706,8 +696,7 @@ mod tests {
         .assert_debug_eq(&DebugResponse::from(resp));
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_get_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -729,8 +718,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_resolve() {
         // Test data uses getting started guide for IPFS:
         // ipfs://QmQPeNsJPyVWPFDVHb77w8G42Fvo15z4bG2X8D2GhfbSXc // cspell:disable-line
@@ -765,8 +753,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_resolve_remaining() {
         let path = "bafyreih6aqnl3v2d6jlidqqnw6skf2ntrtswvra65xz73ymrqspdy2jfai/chainId"; // cspell:disable-line
 
@@ -799,8 +786,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn dag_resolve_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -821,8 +807,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn id_local() {
         let info = PeerInfo {
             peer_id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv"
@@ -891,8 +876,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn id_remote() {
         let info = PeerInfo {
             peer_id: "12D3KooWQuKj4A11GNZ4MmcAmJzCNGZjArjyRTgkLhSutqeqVypv"
@@ -965,8 +949,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn id_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -988,8 +971,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn pin_add() {
         // Test data from:
         // https://ipld.io/specs/codecs/dag-pb/fixtures/cross-codec/#dagpb_data_some
@@ -1027,8 +1009,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn pin_add_bad_request() {
         let cid =
             Cid::from_str("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap();
@@ -1083,8 +1064,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn pin_rm() {
         let cid =
             Cid::from_str("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap();
@@ -1108,8 +1088,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn pin_rm_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -1129,8 +1108,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn swarm_peers() {
         let mut mock_ipfs = MockIpfsDepTest::new();
         mock_ipfs.expect_clone().once().return_once(|| {
@@ -1173,8 +1151,7 @@ mod tests {
         .assert_debug_eq(&resp);
     }
 
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn swarm_connect() {
         let mut mock_ipfs = MockIpfsDepTest::new();
         mock_ipfs.expect_clone().once().return_once(|| {
@@ -1205,8 +1182,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn swarm_connect_bad_request() {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
@@ -1226,8 +1202,7 @@ mod tests {
         "#]]
         .assert_debug_eq(&resp);
     }
-    #[tokio::test]
-    #[traced_test]
+    #[test(tokio::test)]
     async fn version() {
         let mut mock_ipfs = MockIpfsDepTest::new();
         mock_ipfs.expect_clone().once().return_once(|| {

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -481,6 +481,7 @@ mod test {
     use ceramic_store::EventInsertable;
     use multihash_codetable::{Code, MultihashDigest};
     use recon::ReconItem;
+    use test_log::test;
 
     use crate::tests::{build_event, check_deliverable, random_block, TestEventInfo};
 
@@ -556,9 +557,8 @@ mod test {
         assert_eq!(0, deliverable.len());
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn test_all_deliverable_one_stream() {
-        let _ = ceramic_metrics::init_local_tracing();
         let TestEventInfo {
             event_id: one_id,
             car: one_car,
@@ -591,9 +591,8 @@ mod test {
         assert_stream_map_elems(&prev_map, 0);
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn test_some_deliverable_one_stream() {
-        let _ = ceramic_metrics::init_local_tracing();
         let TestEventInfo {
             event_id: one_id,
             car: one_car,
@@ -629,11 +628,10 @@ mod test {
         assert_stream_map_elems(&prev_map, 8);
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     // expected to be per stream but all events are combined for the history required version currently so
     // this needs to work as well
     async fn test_all_deliverable_multiple_streams() {
-        let _ = ceramic_metrics::init_local_tracing();
         let TestEventInfo {
             event_id: one_id,
             car: one_car,
@@ -703,9 +701,8 @@ mod test {
         assert_eq!(expected_b, split_b);
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn test_undelivered_batch_empty() {
-        let _ = ceramic_metrics::init_local_tracing();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
         let (new, found) = OrderingState::new()
             .add_undelivered_batch(&pool, 0, 10)
@@ -715,9 +712,8 @@ mod test {
         assert_eq!(0, found);
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn test_undelivered_batch_offset() {
-        let _ = ceramic_metrics::init_local_tracing();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
         let insertable = build_insertable_undelivered().await;
 
@@ -738,10 +734,8 @@ mod test {
         assert_eq!(0, found);
     }
 
-    #[tokio::test]
+    #[test(tokio::test)]
     async fn test_undelivered_batch_all() {
-        let _ = ceramic_metrics::init_local_tracing();
-
         let pool = SqlitePool::connect_in_memory().await.unwrap();
         let mut undelivered = Vec::with_capacity(10);
         for _ in 0..10 {

--- a/service/src/tests/event.rs
+++ b/service/src/tests/event.rs
@@ -13,10 +13,8 @@ use super::*;
 macro_rules! test_with_sqlite {
     ($test_name: ident, $test_fn: expr $(, $sql_stmts:expr)?) => {
         paste::paste! {
-            #[tokio::test]
+            #[test_log::test(tokio::test)]
             async fn [<$test_name _sqlite>]() {
-                let _  =ceramic_metrics::init_local_tracing();
-
                 let conn = ceramic_store::SqlitePool::connect_in_memory().await.unwrap();
                 let store = $crate::CeramicEventService::new(conn).await.unwrap();
                 $(
@@ -400,7 +398,6 @@ async fn test_store_block<S>(store: S)
 where
     S: iroh_bitswap::Store,
 {
-    let _ = ceramic_metrics::init_local_tracing();
     let data: Bytes = hex::decode("0a050001020304").unwrap().into();
     let cid: CidGeneric<64> =
         Cid::from_str("bafybeibazl2z4vqp2tmwcfag6wirmtpnomxknqcgrauj7m2yisrz3qjbom").unwrap(); // cspell:disable-line

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -1,6 +1,7 @@
 use ceramic_api::EventStore;
 use ceramic_core::EventId;
 use recon::ReconItem;
+use test_log::test;
 
 use crate::{
     tests::{check_deliverable, get_events},
@@ -8,7 +9,6 @@ use crate::{
 };
 
 async fn setup_service() -> CeramicEventService {
-    let _ = ceramic_metrics::init_local_tracing();
     let conn = ceramic_store::SqlitePool::connect_in_memory()
         .await
         .unwrap();
@@ -35,7 +35,7 @@ async fn add_and_assert_new_local_event(store: &CeramicEventService, item: Recon
     assert_eq!(1, new);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_init_event_delivered() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -44,7 +44,7 @@ async fn test_init_event_delivered() {
     check_deliverable(&store.pool, &init.0.cid().unwrap(), true).await;
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_missing_prev_error_history_required() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -71,7 +71,7 @@ async fn test_missing_prev_error_history_required() {
     };
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_prev_exists_history_required() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -93,7 +93,7 @@ async fn test_prev_exists_history_required() {
     assert_eq!(expected, delivered);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_prev_in_same_write_history_required() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -120,7 +120,7 @@ async fn test_prev_in_same_write_history_required() {
     assert_eq!(expected, delivered);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_missing_prev_pending_recon() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -166,7 +166,7 @@ async fn test_missing_prev_pending_recon() {
     assert_eq!(expected, delivered);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn missing_prev_pending_recon_should_deliver_without_stream_update() {
     let store = setup_service().await;
     let events = get_events().await;
@@ -192,7 +192,7 @@ async fn missing_prev_pending_recon_should_deliver_without_stream_update() {
     assert_eq!(expected, delivered);
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn multiple_streams_missing_prev_recon_should_deliver_without_stream_update() {
     let store = setup_service().await;
     let stream_1 = get_events().await;

--- a/store/Cargo.toml
+++ b/store/Cargo.toml
@@ -41,7 +41,6 @@ test-log.workspace = true
 tmpdir.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
-tracing-test.workspace = true
 uuid.workspace = true
 
 


### PR DESCRIPTION
Prior to this change we had three different ways of enabling logs/tracing inside of tests. Using tracing-test, using test-log, and a manual setup using init_local_tracing. All of these methods had the same goal, to be able to debug tests using tracing::debug etc macros. All accomplished the goal slightly differently leading to confusion when working with across multiple tests.

With this change all tests now use the test-log::test method. Here is a quick summary of how this method, and now therefore all tests, behave:

* By default no tracing logs are output
* Use env var `RUST_LOG`, i.e. `RUST_LOG=debug`, to enable logging in tests. Note only failing tests will print their logs, as this is the default `cargo test` behavior.
* Use `cargo test -- --show-output` to print logs from passing tests. This is because by default `cargo test` suppresses all logs from passing tests.
* Use `cargo test -- --nocapture` to print logs from passing or failing tests as they are printed without any buffering.