### PR TITLE
fix: address edge cases in from-ipfs time events

### DIFF
--- a/event/src/unvalidated/event.rs
+++ b/event/src/unvalidated/event.rs
@@ -364,7 +364,7 @@ impl Proof {
 }
 
 /// Proof edge
-pub type ProofEdge = Vec<Cid>;
+pub type ProofEdge = Vec<Ipld>;
 
 #[cfg(test)]
 mod tests {

--- a/event/src/unvalidated/payload/init.rs
+++ b/event/src/unvalidated/payload/init.rs
@@ -4,7 +4,7 @@ use iroh_car::{CarHeader, CarWriter};
 use serde::{Deserialize, Serialize};
 
 /// Payload of an init event
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Payload<D> {
     header: Header,
     data: Option<D>,
@@ -28,6 +28,11 @@ impl<D> Payload<D> {
 }
 
 impl<D: serde::Serialize> Payload<D> {
+    /// Compute CID of encoded event.
+    pub async fn encoded_cid(&self) -> Result<Cid, anyhow::Error> {
+        let event = serde_ipld_dagcbor::to_vec(self)?;
+        Ok(cid_from_dag_cbor(&event))
+    }
     /// Encode the unsigned init event into CAR bytes.
     pub async fn encode_car(&self) -> Result<Vec<u8>, anyhow::Error> {
         let event = serde_ipld_dagcbor::to_vec(self)?;


### PR DESCRIPTION
There were two edge cases not covered with the time event migration code:

1. The time event previous may be either a signed or unsigned event.
2. The witness nodes may contain null entries.

Additionally fixes a bug with initializing tracing for the migration CLI cmd and removes resulting dead code.