### PR TITLE
feat: add query parameter to return event data on feed endpoint

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-29T11:20:12.699785-06:00[America/Denver]
+- Build date: 2024-07-30T10:27:12.329754-06:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-30T10:27:24.718269-06:00[America/Denver]
+- Build date: 2024-07-30T18:32:38.681994-06:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-30T10:27:12.329754-06:00[America/Denver]
+- Build date: 2024-07-30T10:27:24.718269-06:00[America/Denver]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -421,13 +421,28 @@ paths:
         schema:
           type: string
         style: form
-      - description: "the maximum number of events to return, default is 10000."
+      - description: "The maximum number of events to return, default is 100. The\
+          \ max with data is 10000."
         explode: true
         in: query
         name: limit
         required: false
         schema:
           type: integer
+        style: form
+      - description: |
+          Whether to include the event data (carfile) in the response. In the future, only the payload or other options may be supported:
+            * `none` - Empty, only the event ID is returned
+            * `full` - The entire envelope carfile (including the envelope and payload)
+        explode: true
+        in: query
+        name: includeData
+        required: false
+        schema:
+          enum:
+          - none
+          - full
+          type: string
         style: form
       responses:
         "200":

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -433,7 +433,7 @@ paths:
       - description: |
           Whether to include the event data (carfile) in the response. In the future, only the payload or other options may be supported:
             * `none` - Empty, only the event ID is returned
-            * `full` - The entire envelope carfile (including the envelope and payload)
+            * `full` - The entire event carfile (including the envelope and payload)
         explode: true
         in: query
         name: includeData

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -554,7 +554,6 @@ components:
           description: Multibase encoding of event data.
           type: string
       required:
-      - data
       - id
       title: A Ceramic Event
       type: object

--- a/api-server/docs/Event.md
+++ b/api-server/docs/Event.md
@@ -4,7 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** | Multibase encoding of event root CID bytes. | 
-**data** | **String** | Multibase encoding of event data. | 
+**data** | **String** | Multibase encoding of event data. | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -341,7 +341,8 @@ Optional parameters are passed through a map[string]interface{}.
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **resume_at** | **String**| token that designates the point to resume from, that is find keys added after this point | 
- **limit** | **i32**| the maximum number of events to return, default is 10000. | 
+ **limit** | **i32**| The maximum number of events to return, default is 100. The max with data is 10000. | 
+ **include_data** | **String**| Whether to include the event data (carfile) in the response. In the future, only the payload or other options may be supported:   * `none` - Empty, only the event ID is returned   * `full` - The entire envelope carfile (including the envelope and payload)  | 
 
 ### Return type
 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -342,7 +342,7 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **resume_at** | **String**| token that designates the point to resume from, that is find keys added after this point | 
  **limit** | **i32**| The maximum number of events to return, default is 100. The max with data is 10000. | 
- **include_data** | **String**| Whether to include the event data (carfile) in the response. In the future, only the payload or other options may be supported:   * `none` - Empty, only the event ID is returned   * `full` - The entire envelope carfile (including the envelope and payload)  | 
+ **include_data** | **String**| Whether to include the event data (carfile) in the response. In the future, only the payload or other options may be supported:   * `none` - Empty, only the event ID is returned   * `full` - The entire event carfile (including the envelope and payload)  | 
 
 ### Return type
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -226,8 +226,11 @@ fn main() {
             );
         }
         Some("FeedEventsGet") => {
-            let result = rt
-                .block_on(client.feed_events_get(Some("resume_at_example".to_string()), Some(56)));
+            let result = rt.block_on(client.feed_events_get(
+                Some("resume_at_example".to_string()),
+                Some(56),
+                Some("include_data_example".to_string()),
+            ));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -269,12 +269,14 @@ where
         &self,
         resume_at: Option<String>,
         limit: Option<i32>,
+        include_data: Option<String>,
         context: &C,
     ) -> Result<FeedEventsGetResponse, ApiError> {
         info!(
-            "feed_events_get({:?}, {:?}) - X-Span-ID: {:?}",
+            "feed_events_get({:?}, {:?}, {:?}) - X-Span-ID: {:?}",
             resume_at,
             limit,
+            include_data,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -1501,6 +1501,7 @@ where
         &self,
         param_resume_at: Option<String>,
         param_limit: Option<i32>,
+        param_include_data: Option<String>,
         context: &C,
     ) -> Result<FeedEventsGetResponse, ApiError> {
         let mut client_service = self.client_service.clone();
@@ -1514,6 +1515,9 @@ where
             }
             if let Some(param_limit) = param_limit {
                 query_string.append_pair("limit", &param_limit.to_string());
+            }
+            if let Some(param_include_data) = param_include_data {
+                query_string.append_pair("includeData", &param_include_data);
             }
             query_string.finish()
         };

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -316,6 +316,7 @@ pub trait Api<C: Send + Sync> {
         &self,
         resume_at: Option<String>,
         limit: Option<i32>,
+        include_data: Option<String>,
         context: &C,
     ) -> Result<FeedEventsGetResponse, ApiError>;
 
@@ -456,6 +457,7 @@ pub trait ApiNoContext<C: Send + Sync> {
         &self,
         resume_at: Option<String>,
         limit: Option<i32>,
+        include_data: Option<String>,
     ) -> Result<FeedEventsGetResponse, ApiError>;
 
     /// cors
@@ -641,9 +643,12 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         &self,
         resume_at: Option<String>,
         limit: Option<i32>,
+        include_data: Option<String>,
     ) -> Result<FeedEventsGetResponse, ApiError> {
         let context = self.context().clone();
-        self.api().feed_events_get(resume_at, limit, &context).await
+        self.api()
+            .feed_events_get(resume_at, limit, include_data, &context)
+            .await
     }
 
     /// cors

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -288,13 +288,14 @@ pub struct Event {
 
     /// Multibase encoding of event data.
     #[serde(rename = "data")]
-    pub data: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
 }
 
 impl Event {
     #[allow(clippy::new_without_default)]
-    pub fn new(id: String, data: String) -> Event {
-        Event { id, data }
+    pub fn new(id: String) -> Event {
+        Event { id, data: None }
     }
 }
 
@@ -306,8 +307,9 @@ impl std::string::ToString for Event {
         let params: Vec<Option<String>> = vec![
             Some("id".to_string()),
             Some(self.id.to_string()),
-            Some("data".to_string()),
-            Some(self.data.to_string()),
+            self.data
+                .as_ref()
+                .map(|data| ["data".to_string(), data.to_string()].join(",")),
         ];
 
         params.into_iter().flatten().collect::<Vec<_>>().join(",")
@@ -375,11 +377,7 @@ impl std::str::FromStr for Event {
                 .into_iter()
                 .next()
                 .ok_or_else(|| "id missing in Event".to_string())?,
-            data: intermediate_rep
-                .data
-                .into_iter()
-                .next()
-                .ok_or_else(|| "data missing in Event".to_string())?,
+            data: intermediate_rep.data.into_iter().next(),
         })
     }
 }

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -1063,9 +1063,28 @@ where
                         }
                         None => None,
                     };
+                    let param_include_data = query_params
+                        .iter()
+                        .filter(|e| e.0 == "includeData")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_include_data = match param_include_data {
+                        Some(param_include_data) => {
+                            let param_include_data =
+                                <String as std::str::FromStr>::from_str(&param_include_data);
+                            match param_include_data {
+                            Ok(param_include_data) => Some(param_include_data),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter includeData - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter includeData")),
+                        }
+                        }
+                        None => None,
+                    };
 
                     let result = api_impl
-                        .feed_events_get(param_resume_at, param_limit, &context)
+                        .feed_events_get(param_resume_at, param_limit, param_include_data, &context)
                         .await;
                     let mut response = Response::new(Body::empty());
                     response.headers_mut().insert(

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -405,7 +405,7 @@ paths:
             Whether to include the event data (carfile) in the response.
             In the future, only the payload or other options may be supported:
               * `none` - Empty, only the event ID is returned
-              * `full` - The entire envelope carfile (including the envelope and payload)
+              * `full` - The entire event carfile (including the envelope and payload)
       responses:
         "200":
           description: success

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -391,10 +391,21 @@ paths:
           required: false
         - name: limit
           in: query
-          description: the maximum number of events to return, default is 10000.
+          description: The maximum number of events to return, default is 100. The max with data is 10000.
           required: false
           schema:
             type: integer
+        - name: includeData
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [none, full]
+          description: >
+            Whether to include the event data (carfile) in the response.
+            In the future, only the payload or other options may be supported:
+              * `none` - Empty, only the event ID is returned
+              * `full` - The entire envelope carfile (including the envelope and payload)
       responses:
         "200":
           description: success

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -505,7 +505,6 @@ components:
       type: object
       required:
         - id
-        - data
       properties:
         id:
           type: string

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -3,7 +3,9 @@ mod server;
 
 pub use resume_token::ResumeToken;
 
-pub use server::{EventInsertResult, EventStore, InterestStore, Server};
+pub use server::{
+    EventDataResult, EventInsertResult, EventStore, IncludeEventData, InterestStore, Server,
+};
 
 #[cfg(test)]
 mod tests;

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -2,11 +2,8 @@
 
 use std::{ops::Range, str::FromStr, sync::Arc};
 
-use crate::server::decode_multibase_data;
-use crate::server::BuildResponse;
-use crate::server::Server;
-use crate::EventInsertResult;
-use crate::{EventStore, InterestStore};
+use crate::server::{decode_multibase_data, BuildResponse, Server};
+use crate::{EventDataResult, EventInsertResult, EventStore, IncludeEventData, InterestStore};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -125,7 +122,8 @@ mock! {
             &self,
             highwater: i64,
             limit: i64,
-        ) -> Result<(i64, Vec<Cid>)>;
+            include_data: IncludeEventData,
+        ) -> Result<(i64, Vec<EventDataResult>)>;
         async fn highwater_mark(
             &self,
         ) -> Result<i64>;

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -520,7 +520,7 @@ async fn get_events_for_interest_range() {
     r: Success(EventsGet { events: [Event { id: "fce0105ff012616e0f0c1e987ef0f772afbe2c7f05c50102bc800", data: "" }], resume_offset: 1, is_complete: false })
             */
     let mock_interest = MockAccessInterestStoreTest::new();
-    let expected = BuildResponse::event(cid, vec![]);
+    let expected = BuildResponse::event(cid, None);
     let mut mock_event_store = MockEventStoreTest::new();
     mock_event_store
         .expect_range_with_values()
@@ -589,7 +589,7 @@ async fn test_events_event_id_get_by_event_id_success() {
         event.id,
         multibase::encode(multibase::Base::Base32Lower, event_cid.to_bytes())
     );
-    assert_eq!(event.data, event_data_base64);
+    assert_eq!(event.data.unwrap(), event_data_base64);
 }
 
 #[test(tokio::test)]
@@ -619,5 +619,5 @@ async fn test_events_event_id_get_by_cid_success() {
         event.id,
         multibase::encode(multibase::Base::Base32Lower, event_cid.to_bytes())
     );
-    assert_eq!(event.data, event_data_base64);
+    assert_eq!(event.data.unwrap(), event_data_base64);
 }

--- a/service/src/event/store.rs
+++ b/service/src/event/store.rs
@@ -179,7 +179,7 @@ impl ceramic_api::EventStore for CeramicEventService {
                     CeramicOneEvent::new_events_since_value(&self.pool, highwater, limit).await?;
                 let res = cids
                     .into_iter()
-                    .map(|cid| ceramic_api::EventDataResult::new(cid, vec![]))
+                    .map(|cid| ceramic_api::EventDataResult::new(cid, None))
                     .collect();
                 (hw, res)
             }
@@ -191,7 +191,7 @@ impl ceramic_api::EventStore for CeramicEventService {
                 for (cid, value) in data {
                     res.push(ceramic_api::EventDataResult::new(
                         cid,
-                        value.encode_car().await?,
+                        Some(value.encode_car().await?),
                     ));
                 }
                 (hw, res)

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -212,11 +212,13 @@ where
         &self,
         highwater: i64,
         limit: i64,
-    ) -> anyhow::Result<(i64, Vec<Cid>)> {
+        include_data: ceramic_api::IncludeEventData,
+    ) -> anyhow::Result<(i64, Vec<ceramic_api::EventDataResult>)> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "api_events_since_highwater_mark",
-            self.store.events_since_highwater_mark(highwater, limit),
+            self.store
+                .events_since_highwater_mark(highwater, limit, include_data),
         )
         .await
     }

--- a/store/src/sql/entities/mod.rs
+++ b/store/src/sql/entities/mod.rs
@@ -11,4 +11,4 @@ pub use event_block::{EventBlockRaw, ReconEventBlockRaw};
 pub use hash::{BlockHash, ReconHash};
 pub use version::VersionRow;
 
-pub use utils::{CountRow, DeliveredEventRow, OrderKey};
+pub use utils::{CountRow, OrderKey};

--- a/store/src/sql/entities/utils.rs
+++ b/store/src/sql/entities/utils.rs
@@ -1,7 +1,4 @@
 use ceramic_core::EventId;
-use cid::Cid;
-
-use crate::{Error, Result};
 
 #[derive(Debug, sqlx::FromRow)]
 /// The query returns a column 'res' that is an int8
@@ -20,24 +17,5 @@ impl TryFrom<OrderKey> for EventId {
 
     fn try_from(value: OrderKey) -> std::prelude::v1::Result<Self, Self::Error> {
         EventId::try_from(value.order_key)
-    }
-}
-
-#[derive(sqlx::FromRow)]
-pub struct DeliveredEventRow {
-    pub cid: Vec<u8>,
-    pub new_highwater_mark: i64,
-}
-
-impl DeliveredEventRow {
-    /// assumes rows are sorted by `delivered` ascending
-    pub fn parse_query_results(current: i64, rows: Vec<Self>) -> Result<(i64, Vec<Cid>)> {
-        let max: i64 = rows.last().map_or(current, |r| r.new_highwater_mark + 1);
-        let rows = rows
-            .into_iter()
-            .map(|row| Cid::try_from(row.cid).map_err(Error::new_app))
-            .collect::<Result<Vec<Cid>>>()?;
-
-        Ok((max, rows))
     }
 }

--- a/store/src/sql/query.rs
+++ b/store/src/sql/query.rs
@@ -93,9 +93,9 @@ impl EventQuery {
                 FROM ceramic_one_event e
                 WHERE
                     EXISTS (SELECT 1 FROM ceramic_one_event_block where event_cid = e.cid)
-                    AND e.delivered IS NULL  and e.rowid > $2
+                    AND e.delivered IS NULL and e.rowid > $1
                 LIMIT
-                    $1
+                    $2
             ) key
             JOIN
                 ceramic_one_event_block eb ON key.event_cid = eb.event_cid
@@ -103,8 +103,32 @@ impl EventQuery {
                 ORDER BY key.order_key, eb.idx;"#
     }
 
-    /// Requires binding 2 parameters. Fetches the new rows as `DeliveredEvent` objects
-    pub fn new_delivered_events() -> &'static str {
+    /// Requires binding 2 parameters.
+    ///     $1 delivered highwater mark (i64)
+    ///     $2 limit (i64)
+    ///
+    /// Returns the event blocks that can be used to reconstruct the event carfile
+    ///
+    /// IMPORTANT: The results should be sorted by the delivered value before being given to clients
+    pub fn new_delivered_events_with_data() -> &'static str {
+        r#"SELECT
+                key.order_key, key.event_cid, eb.codec, eb.root, eb.idx, b.multihash, b.bytes, key.new_highwater_mark
+            FROM (
+                SELECT
+                    e.cid as event_cid, e.order_key, COALESCE(e.delivered, 0) as "new_highwater_mark"
+                FROM ceramic_one_event e
+                WHERE e.delivered >= $1 -- we return delivered+1 so we must match it next search
+                ORDER BY e.delivered
+                LIMIT
+                    $2
+            ) key
+            JOIN
+                ceramic_one_event_block eb ON key.event_cid = eb.event_cid
+            JOIN ceramic_one_block b on b.multihash = eb.block_multihash
+                ORDER BY key.order_key, eb.idx;"#
+    }
+
+    pub fn new_delivered_events_id_only() -> &'static str {
         r#"SELECT 
                 cid, COALESCE(delivered, 0) as "new_highwater_mark"
             FROM ceramic_one_event


### PR DESCRIPTION
There is now an enum parameter called `includeData` that can be `none` or `full`. I originally had a boolean, so it's not the best name and open to suggestions. I also changed the data field to return null instead of an empty string to avoid crashing multibase decoding (need to verify js-ceramic is okay with this but it doesn't use the value currently).

Example usage: `curl -v --location 'http://127.0.0.1:5001/ceramic/feed/events?includeData=full&limit=1` and `curl -v --location 'http://127.0.0.1:5001/ceramic/feed/events?limit=1`

```json
{
  "events": [
    {
      "id": "bafyreia2ihx26sxlukdpnjzkpkyi4flmyxrwq4ritcbwxlxxyf2qltiyhq",
      "data": "mOqJlcm9vdHOB2CpYJQABcRIgGkHvr0rroob2pyp6sI4VbMXjaHIomINrrvfBdQXNGDxndmVyc2lvbgHLAQFxEiAaQe+vSuuihvanKnqwjhVsxeNociiYg2uu98F1Bc0YPKJkZGF0YaJhYQFhYgJmaGVhZGVypGNzZXBlbW9kZWxlbW9kZWxYJc4BAhIg0yo2H8npd2cKQSdTnW/+biSFW79zdPyVWE4sJu0icYNmdW5pcXVlTJsqdYUc+GBaeYDfgmtjb250cm9sbGVyc4F4OGRpZDprZXk6ejZNa29GVXBwY0tFVllUUzhvVmlkcmphOTRVb0pUYXROaG5oeEpSS0Y3TllQU2NT"
    }
  ],
  "resumeToken": "2"
}

{
  "events": [
    {
      "id": "bafyreia2ihx26sxlukdpnjzkpkyi4flmyxrwq4ritcbwxlxxyf2qltiyhq"
    }
  ],
  "resumeToken": "2"
}


```

I made some refactors simultaneously. First I modified the store to return an unvalidated event, which requires parsing the bytes to an event and then back to bytes, so a bit unnecessary but it (again) verifies it's valid and makes getting the CID easy. Could change the queries instead to read from disk but cbor should be fast to parse. I also moved the related queries for delivered/undelivered together and made sure the resume/limit params are in the same order. The API trait response for feed is now a struct and there were a handful of updates to tests to test the new option.