### PR TITLE
fix: make sure the store directory exists and create it if needed

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -295,7 +295,7 @@ impl Daemon {
                         e
                     );
                     eprintln!("{}", message);
-                    return Err(anyhow!(message));
+                    anyhow::bail!(message);
                 }
             },
         }


### PR DESCRIPTION
If you ran `ceramic-one daemon` the process could fail to start with an unhelpful message `Error: Application error encountered: (code: 14) unable to open database file`. Now, we create the directory (and all parents) before starting if necessary.

Fixes [AES-196](https://linear.app/3boxlabs/issue/AES-196/ceramic-daemon-doesnt-create-store-directory-and-fails-to-start).