### PR TITLE
fix: use event service rather than store to enforce deliverability/or…

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -19,6 +19,7 @@ futures.workspace = true
 hex.workspace = true
 ipld-core.workspace = true
 iroh-bitswap.workspace = true
+iroh-car.workspace = true
 multibase.workspace = true
 multihash-codetable.workspace = true
 multihash-derive.workspace = true

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -85,13 +85,10 @@ impl CeramicEventService {
         network: Network,
         blocks: impl Stream<Item = anyhow::Result<BoxedBlock>>,
     ) -> Result<()> {
-        let migrator = Migrator::new(network, blocks)
+        let migrator = Migrator::new(self, network, blocks)
             .await
             .map_err(Error::new_fatal)?;
-        migrator
-            .migrate(&self.pool)
-            .await
-            .map_err(Error::new_fatal)?;
+        migrator.migrate().await.map_err(Error::new_fatal)?;
         Ok(())
     }
 

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -286,7 +286,7 @@ async fn unsigned_time_event() {
     test_migration(cars).await;
 }
 #[test(tokio::test)]
-async fn sigined_init_time_event() {
+async fn signed_init_time_event() {
     let mut cars = Vec::new();
     for event in random_signed_init_time_event().await {
         cars.push(event.encode_car().await.unwrap());


### PR DESCRIPTION
The migration collects the blocks and builds a carfile that it hands off to the event service to order/insert/etc. This definitely does more work (we parse the cbor more and do more sorting) but I haven't measured to see how much of an impact it has. 