### PR TITLE
chore: homebrew support

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -27,13 +27,13 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
             arch: x86_64
-            ext: pkg
+            ext: bin
             protoc-arch: osx-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest
             config-file: fpm/osx.fpm
             arch: aarch64
-            ext: pkg
+            ext: bin
             protoc-arch: osx-aarch_64
         #- target: x86_64-pc-windows-msvc
         #  os: windows-latest

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -1,0 +1,44 @@
+name: Update Homebrew Formula
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+
+jobs:
+  update-homebrew-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Latest Release
+        id: release
+        run: |
+          # Download files from the latest release and calculate their SHA256 checksums
+          gh release view --json tagName,assets > release.json
+          echo "X86_URL=$(jq -r '.assets[] | select(.name | contains("x86_64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
+          echo "ARM_URL=$(jq -r '.assets[] | select(.name | contains("aarch64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
+          gh release download -p '*apple-darwin*'
+          echo "X86_SHA256=$(sha256sum ceramic-one_x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "ARM_SHA256=$(sha256sum ceramic-one_aarch64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "VERSION=$(jq -r '.tagName' release.json)" >> $GITHUB_OUTPUT
+      - name: Checkout Homebrew Tap
+        uses: actions/checkout@v2
+        with:
+          repository: ceramicnetwork/homebrew-tap
+          path: homebrew-tap
+      - name: Update Homebrew Formula
+        run: |
+          sed -i.bak -E "s|(url \".*_x86_64-apple-darwin.*\")|url \"${steps.release.outputs.X86_URL}\"|" homebrew-tap/Formula/ceramic-one.rb
+          sed -i '' '/CPU.intel?/,/sha256/ s/sha256 "[^"]*"/sha256 "${steps.release.outputs.X86_SHA}"/' homebrew-tap/Formula/ceramic-one.rb
+          sed -i.bak -E "s|(url \".*_aarch64-apple-darwin.*\")|url \"${steps.release.outputs.ARM_URL}\"|" homebrew-tap/Formula/ceramic-one.rb
+          sed -i '' '/CPU.arm?/,/sha256/ s/sha256 "[^"]*"/sha256 "${steps.release.outputs.ARM_SHA}"/' homebrew-tap/Formula/ceramic-one.rb
+      - name: Commit and Push changes
+        run: |
+          cd homebrew-tap
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add Formula/rust-ceramic.rb
+          git diff
+          git commit -m "Update rust-ceramic formula to ${{ steps.release.outputs.VERSION }}"
+#          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -47,21 +47,10 @@ cp ./target/release/ceramic-one /usr/local/bin/ceramic-one
 
 ### MacOS - Local System
 
-Install a Github release (Darwin armv64)
-
-1. Download the binary:
+Install from [Homebrew](https://brew.sh/)
 
 ```bash
-curl -LO https://github.com/ceramicnetwork/rust-ceramic/releases/download/latest/ceramic-one_aarch64-apple-darwin.tar.gz
-tar zxvf ceramic-one_aarch64-apple-darwin.tar.gz
-```
-
-2. Open Finder and double-click the `ceramic-one.pkg` file to start the installation
-
-3. After the installation is complete, copy the binary:
-
-```bash
-sudo cp /Applications/ceramic-one /usr/local/bin/
+brew install ceramicnetwork/tap/ceramic-one
 ```
 
 ### Docker

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -82,8 +82,14 @@ echo "Building artifacts for "$TARGET
 
 cargo build --release --locked --target $TARGET
 
-echo "Building package for "$TARGET
-fpm --fpm-options-file $CONFIG_FILE -C $BIN_DIR -v $PKG_VERSION -p $OUT_PATH ceramic-one=$INSTALL_DIR/ceramic-one
 
-echo "Compressing package for "$TARGET
-tar -cvzf ceramic-one_$TARGET.tar.gz -C $ARTIFACTS_DIR $OUT_FILE
+if [ "$EXT" = "bin" ]; then
+    echo "Compressing package for $TARGET"
+    tar -cvzf $ARTIFACTS_DIR/ceramic-one_$TARGET.tar.gz $BIN_DIR/ceramic-one
+else
+    echo "Building package for $TARGET"
+    fpm --fpm-options-file $CONFIG_FILE -C $BIN_DIR -v $PKG_VERSION -p $OUT_PATH ceramic-one=$INSTALL_DIR/ceramic-one
+
+    echo "Compressing package for $TARGET"
+    tar -cvzf ceramic-one_$TARGET.tar.gz -C $ARTIFACTS_DIR $OUT_FILE
+fi


### PR DESCRIPTION
This PR adds support for easier installation of Ceramic on Macos through homebrew. When a new release is made, the [homebrew-tap](https://github.com/ceramicnetwork/homebrew-tap) repo is updated to point to the new version.

Not sure what the best way to test the CI workflow without breaking anything. Ideally this isn't merged until we've validated it works.