### PR TITLE
feat: change default ports used for swarm and rpc endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ check-deps:
 
 .PHONY: run
 run:
-	RUST_LOG=ERROR,ceramic_kubo_rpc=DEBUG,ceramic_one=DEBUG $(CARGO) run --all-features --locked --release --bin ceramic-one -- daemon -b 127.0.0.1:5001
+	RUST_LOG=ERROR,ceramic_kubo_rpc=DEBUG,ceramic_one=DEBUG $(CARGO) run --all-features --locked --release --bin ceramic-one -- daemon -b 127.0.0.1:5101
 
 .PHONY: publish-docker
 publish-docker:

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Migration
 * Move the sqlite3 database to the new rust-ceramic node.
 * Start the new rust-ceramic server and point the compose DB node to it.
     ```zsh
-    ./ceramic-one daemon --bind-address '127.0.0.1:5001'
+    ./ceramic-one daemon --bind-address '127.0.0.1:5101'
     ```
 * Once the traffic is cut over to the new node and we know there are not new block being crated on the old node.
 Re-run the migration to pick up any new block that were crated after the first migration

--- a/kubo-rpc/src/http.rs
+++ b/kubo-rpc/src/http.rs
@@ -1124,7 +1124,7 @@ mod tests {
                     (
                         PeerId::from_str("12D3KooWBSyp3QZQBFakvXT2uqT2L5ZmTNnpYNXgyVZq5YB3P7DU")
                             .unwrap(),
-                        vec![Multiaddr::from_str("/ip4/95.211.198.178/udp/4001/quic").unwrap()],
+                        vec![Multiaddr::from_str("/ip4/95.211.198.178/udp/4101/quic").unwrap()],
                     ),
                 ]))
             });
@@ -1138,7 +1138,7 @@ mod tests {
                 SwarmPeersPost200Response {
                     peers: [
                         SwarmPeersPost200ResponsePeersInner {
-                            addr: "/ip4/95.211.198.178/udp/4001/quic",
+                            addr: "/ip4/95.211.198.178/udp/4101/quic",
                             peer: "12D3KooWBSyp3QZQBFakvXT2uqT2L5ZmTNnpYNXgyVZq5YB3P7DU",
                         },
                         SwarmPeersPost200ResponsePeersInner {
@@ -1170,7 +1170,7 @@ mod tests {
             m
         });
         let server = Server::new(mock_ipfs);
-        let resp = server.swarm_connect_post(&vec!["/ip4/1.1.1.1/tcp/4001/p2p/12D3KooWFtPWZ1uHShnbvmxYJGmygUfTVmcb6iSQfiAm4XnmsQ8t".to_string()], &Context).await.unwrap();
+        let resp = server.swarm_connect_post(&vec!["/ip4/1.1.1.1/tcp/4101/p2p/12D3KooWFtPWZ1uHShnbvmxYJGmygUfTVmcb6iSQfiAm4XnmsQ8t".to_string()], &Context).await.unwrap();
 
         expect![[r#"
             Success(
@@ -1188,7 +1188,7 @@ mod tests {
         let mock_ipfs = MockIpfsDepTest::new();
         let server = Server::new(mock_ipfs);
         let resp = server
-            .swarm_connect_post(&vec!["/ip4/1.1.1.1/tcp/4001".to_string()], &Context)
+            .swarm_connect_post(&vec!["/ip4/1.1.1.1/tcp/4101".to_string()], &Context)
             .await
             .unwrap();
 

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -487,7 +487,14 @@ impl Daemon {
             )
             .await?
             .build(bitswap_block_store, ipfs_metrics)
-            .await?;
+            .await
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to start libp2p server using addresses: {}. {}",
+                    opts.swarm_addresses.join(", "),
+                    e
+                )
+            })?;
 
         // Start metrics server
         debug!(
@@ -495,7 +502,13 @@ impl Daemon {
             "starting prometheus metrics server"
         );
         let (tx_metrics_server_shutdown, metrics_server_handle) =
-            metrics::start(&opts.metrics_bind_address.parse()?);
+            metrics::start(&opts.metrics_bind_address.parse()?).map_err(|e| {
+                anyhow!(
+                    "Failed to start metrics server using address: {}. {}",
+                    opts.metrics_bind_address,
+                    e
+                )
+            })?;
 
         // Build HTTP server
         let ceramic_server = ceramic_api::Server::new(
@@ -539,7 +552,8 @@ impl Daemon {
 
         // The server task blocks until we are ready to start shutdown
         debug!("starting api server");
-        hyper::server::Server::bind(&opts.bind_address.parse()?)
+        hyper::server::Server::try_bind(&opts.bind_address.parse()?)
+            .map_err(|e| anyhow!("Failed to bind address: {}. {}", opts.bind_address, e))?
             .serve(service)
             .with_graceful_shutdown(async {
                 rx.await.ok();

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -54,7 +54,7 @@ struct DaemonOpts {
     #[arg(
         short,
         long,
-        default_value = "127.0.0.1:5001",
+        default_value = "127.0.0.1:5101",
         env = "CERAMIC_ONE_BIND_ADDRESS"
     )]
     bind_address: String,
@@ -62,7 +62,7 @@ struct DaemonOpts {
     /// Listen address of the p2p swarm.
     #[arg(
         long,
-        default_values_t = vec!["/ip4/0.0.0.0/tcp/4001".to_string(), "/ip4/0.0.0.0/udp/4001/quic-v1".to_string()],
+        default_values_t = vec!["/ip4/0.0.0.0/tcp/4101".to_string(), "/ip4/0.0.0.0/udp/4101/quic-v1".to_string()],
         use_value_delimiter = true,
         value_delimiter = ',',
         env = "CERAMIC_ONE_SWARM_ADDRESSES"
@@ -221,8 +221,8 @@ impl Network {
                 "/dns4/go-ipfs-ceramic-public-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmWiY3CbNawZjWnHXx3p3DXsg21pZYTj4CRY1iwMkhP8r3".to_string(), // cspell:disable-line
                 "/dns4/go-ipfs-ceramic-private-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmQotCKxiMWt935TyCBFTN23jaivxwrZ3uD58wNxeg5npi".to_string(), // cspell:disable-line
                 "/dns4/go-ipfs-ceramic-private-cas-clay-external.3boxlabs.com/tcp/4011/ws/p2p/QmbeBTzSccH8xYottaYeyVX8QsKyox1ExfRx7T1iBqRyCd".to_string(), // cspell:disable-line
-                "/dns/rust-ceramic-v4-tnet-0.3box.io/tcp/4001/p2p/12D3KooWNYomhBwgoCZ5sbhkCfEmmHV8m3bvESm6PL1bjDU7H3ja/p2p/12D3KooWNYomhBwgoCZ5sbhkCfEmmHV8m3bvESm6PL1bjDU7H3ja".to_string(),// cspell:disable-line
-                "/dns/rust-ceramic-v4-tnet-1.3box.io/tcp/4001/p2p/12D3KooWPYNbc6VBfPuJQ84sNb4xNXysD383ZXZuLYbG8xTmHmfj/p2p/12D3KooWPYNbc6VBfPuJQ84sNb4xNXysD383ZXZuLYbG8xTmHmfj".to_string(), // cspell:disable-line
+                "/dns/rust-ceramic-v4-tnet-0.3box.io/tcp/4101/p2p/12D3KooWNYomhBwgoCZ5sbhkCfEmmHV8m3bvESm6PL1bjDU7H3ja/p2p/12D3KooWNYomhBwgoCZ5sbhkCfEmmHV8m3bvESm6PL1bjDU7H3ja".to_string(),// cspell:disable-line
+                "/dns/rust-ceramic-v4-tnet-1.3box.io/tcp/4101/p2p/12D3KooWPYNbc6VBfPuJQ84sNb4xNXysD383ZXZuLYbG8xTmHmfj/p2p/12D3KooWPYNbc6VBfPuJQ84sNb4xNXysD383ZXZuLYbG8xTmHmfj".to_string(), // cspell:disable-line
             ],
             Network::DevUnstable => vec![
                 "/dns4/go-ipfs-ceramic-public-qa-external.3boxlabs.com/tcp/4011/ws/p2p/QmPP3RdaSWDkhcxZReGo591FWanLw9ucvgmUZhtSLt9t6D".to_string(),  // cspell:disable-line

--- a/one/src/main.rs
+++ b/one/src/main.rs
@@ -10,5 +10,9 @@ pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    ceramic_one::run().await
+    ceramic_one::run().await.map_err(|e| {
+        // this should use stderr if we error before tracing is hooked up
+        tracing::error!("Error running command: {:#}", e);
+        e
+    })
 }


### PR DESCRIPTION
As we no longer provide a compatible IPFS server, we are changing the default ports we use from 4001 (swarm) and 5001 (rpc) to 4101 (swarm) and 5101 (rpc). This will avoid any conflicts with people running a vanilla IPFS server on their machine. I also added some better logging around errors binding addresses so you'll get something like the following, instead of something like: `Address already in use (os error 48)`.

```
❯ RUST_BACKTRACE=1 RUST_LOG=info,ceramic_store=debug ./target/debug/ceramic-one daemon --network local --local-network-id 0 --store-dir ./local-data
Connected to sqlite database: ./local-data/db.sqlite3
  2024-07-01T19:58:09.317175Z  INFO ceramic_one: service__name: "ceramic-one", version: "0.25.0", build: "git:6acf4a09-modified", instance_id: "omniscient-volleyball", exe_hash: "uAAUAdebugg"
    at one/src/lib.rs:365

  2024-07-01T19:58:09.319031Z  INFO ceramic_p2p::node: identity loaded: 12D3KooWEQcETREP3t7P5RNCn9dbaWapeThSCFGVia4ryWEC2Nnc
    at p2p/src/node.rs:1158

  2024-07-01T19:58:09.325505Z  INFO libp2p_swarm: local_peer_id: 12D3KooWEQcETREP3t7P5RNCn9dbaWapeThSCFGVia4ryWEC2Nnc
    at /Users/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libp2p-swarm-0.44.2/src/lib.rs:367

  2024-07-01T19:58:09.325657Z  INFO ceramic_p2p::node: iroh-p2p peerid: 12D3KooWEQcETREP3t7P5RNCn9dbaWapeThSCFGVia4ryWEC2Nnc
    at p2p/src/node.rs:168

  2024-07-01T19:58:09.327095Z ERROR ceramic_one: Daemon run error: Failed to listen on swarm address: /ip4/0.0.0.0/udp/4101/quic-v1.
    at one/src/lib.rs:315

Error: Failed to listen on swarm address: /ip4/0.0.0.0/udp/4101/quic-v1.
```

