### PR TITLE
fix: schedule post-deployment tests 15 min after deployment

### DIFF
--- a/ci-scripts/schedule_k8s_deploy.sh
+++ b/ci-scripts/schedule_k8s_deploy.sh
@@ -10,11 +10,11 @@ network=${1-dev}
 environment=ceramic-v4-${network}
 
 if [[ "$network" == "dev" || "$network" == "qa" ]]; then
-    ceramic_image_name="ceramicnetwork/js-ceramic:develop"
+    ceramic_image="ceramicnetwork/js-ceramic:develop"
 elif [[ "$network" == "tnet" ]]; then
-    ceramic_image_name="ceramicnetwork/js-ceramic:release-candidate"
+    ceramic_image="ceramicnetwork/js-ceramic:release-candidate"
 elif [[ "$network" == "prod" ]]; then
-    ceramic_image_name="ceramicnetwork/js-ceramic:latest"
+    ceramic_image="ceramicnetwork/js-ceramic:latest"
 else
     echo "Invalid network value: $network"
     exit 1
@@ -27,28 +27,28 @@ docker run --rm -i \
   -v ~/.aws:/root/.aws \
   -v "$PWD":/aws \
   amazon/aws-cli dynamodb put-item --table-name "ceramic-$network-ops" --item \
-  "{                                                                         \
-    \"id\":     {\"S\": \"$id\"},                                            \
-    \"job\":    {\"S\": \"$job_id\"},                                        \
-    \"ts\":     {\"N\": \"$now\"},                                           \
-    \"ttl\":    {\"N\": \"$ttl\"},                                           \
-    \"stage\":  {\"S\": \"queued\"},                                         \
-    \"type\":   {\"S\": \"workflow\"},                                       \
-    \"params\": {                                                            \
-      \"M\": {                                                               \
-        \"name\":     {\"S\": \"Deploy k8s $network CERAMIC ONE\"},          \
-        \"org\":      {\"S\": \"3box\"},                                     \
-        \"repo\":     {\"S\": \"ceramic-infra\"},                            \
-        \"ref\":      {\"S\": \"$branch\"},                                  \
-        \"workflow\": {\"S\": \"update_image.yml\"},                         \
-        \"labels\":   {\"L\": [{\"S\": \"deploy\"}]},                        \
-        \"inputs\":   {                                                      \
-          \"M\": {                                                           \
-            \"ceramic_one_image\": {\"S\": \"$image\"},                      \
-            \"ceramic_image\":     {\"S\": \"$ceramic_image\"},              \
-            \"environment\":       {\"S\": \"$environment\"}                 \
-          }                                                                  \
-        }                                                                    \
-      }                                                                      \
-    }                                                                        \
+  "{                                                                \
+    \"id\":     {\"S\": \"$id\"},                                   \
+    \"job\":    {\"S\": \"$job_id\"},                               \
+    \"ts\":     {\"N\": \"$now\"},                                  \
+    \"ttl\":    {\"N\": \"$ttl\"},                                  \
+    \"stage\":  {\"S\": \"queued\"},                                \
+    \"type\":   {\"S\": \"workflow\"},                              \
+    \"params\": {                                                   \
+      \"M\": {                                                      \
+        \"name\":     {\"S\": \"Deploy k8s $network CERAMIC ONE\"}, \
+        \"org\":      {\"S\": \"3box\"},                            \
+        \"repo\":     {\"S\": \"ceramic-infra\"},                   \
+        \"ref\":      {\"S\": \"$branch\"},                         \
+        \"workflow\": {\"S\": \"update_image.yml\"},                \
+        \"labels\":   {\"L\": [{\"S\": \"deploy\"}]},               \
+        \"inputs\":   {                                             \
+          \"M\": {                                                  \
+            \"ceramic_one_image\": {\"S\": \"$image\"},             \
+            \"ceramic_image\":     {\"S\": \"$ceramic_image\"},     \
+            \"environment\":       {\"S\": \"$environment\"}        \
+          }                                                         \
+        }                                                           \
+      }                                                             \
+    }                                                               \
   }"

--- a/ci-scripts/schedule_tests.sh
+++ b/ci-scripts/schedule_tests.sh
@@ -2,11 +2,11 @@
 
 id=$(uuidgen)
 job_id=$(uuidgen)
-# Schedule tests for 10 minutes in the future to allow the network to stabilize. This assumes that the deployment is
+# Schedule tests for 15 minutes in the future to allow the network to stabilize. This assumes that the deployment is
 # successful with the right image being deployed, which might not always be the case if the deployment fails for some
 # reason. In the future, this can be done better via the CD manager, which will check for the network being ready with
 # the right image before scheduling tests.
-now=$(date +%s%N -d "10 minutes")
+now=$(date +%s%N -d "15 minutes")
 ttl=$(date +%s -d "14 days")
 network=${1-dev}
 test_selector=${2-.}


### PR DESCRIPTION
Also fixes a typo in the deployment script where the `js-ceramic` image for the env was being set.