### PR TITLE
chore: release archive with linux binary

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -70,20 +70,17 @@ jobs:
       - name: Run package script
         run: |
           ./ci-scripts/package.sh -a ${{ matrix.arch }} -e ${{ matrix.ext }}
-      - name: Archive artifact
+      - name: Archive Binary
         uses: actions/upload-artifact@v3
-        if: ${{ matrix.ext == 'bin' }}
         with:
           name: ceramic-one_${{ matrix.target }}
           path: ceramic-one_${{ matrix.target }}.bin.tar.gz
-      - name: Archive artifact
+      - name: Archive Debian Package
         uses: actions/upload-artifact@v3
         if: ${{ matrix.ext == 'deb' }}
         with:
           name: ceramic-one_${{ matrix.target }}
-          path: |
-            ceramic-one_${{ matrix.target }}.bin.tar.gz
-            ceramic-one_${{ matrix.target }}.tar.gz
+          path: ceramic-one_${{ matrix.target }}.tar.gz
 
   release:
     needs: [build-binaries]

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -72,9 +72,17 @@ jobs:
           ./ci-scripts/package.sh -a ${{ matrix.arch }} -e ${{ matrix.ext }}
       - name: Archive artifact
         uses: actions/upload-artifact@v3
+        if: ${{ matrix.ext == 'bin' }}
+        with:
+          name: ceramic-one_${{ matrix.target }}
+          path: ceramic-one_${{ matrix.target }}.bin.tar.gz
+      - name: Archive artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.ext == 'deb' }}
         with:
           name: ceramic-one_${{ matrix.target }}
           path: |
+            ceramic-one_${{ matrix.target }}.bin.tar.gz
             ceramic-one_${{ matrix.target }}.tar.gz
 
   release:

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -21,8 +21,8 @@ jobs:
           echo "VERSION=$(jq -r '.tagName' release.json)" >> $GITHUB_OUTPUT
           echo "X86_URL=$(jq -r '.assets[] | select(.name | contains("x86_64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
           echo "ARM_URL=$(jq -r '.assets[] | select(.name | contains("aarch64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
-          echo "X86_SHA=$(sha256sum ceramic-one_x86_64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "ARM_SHA=$(sha256sum ceramic-one_aarch64-apple-darwin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "X86_SHA=$(sha256sum ceramic-one_x86_64-apple-darwin.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "ARM_SHA=$(sha256sum ceramic-one_aarch64-apple-darwin.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       - name: Checkout Homebrew Tap
         uses: actions/checkout@v4
         with:

--- a/README.md
+++ b/README.md
@@ -8,9 +8,17 @@ Current status is that the `ceramic-one` binary only mimics the Kubo RPC API and
 
 The following section covers several ways one can install Rust-Ceramic contingent on the recieving environment:
 
-### Linux - from Binary Distribution
+### MacOS
 
-Install a Github release (Debian-based distributions):
+Install from [Homebrew](https://brew.sh/):
+
+```bash
+brew install ceramicnetwork/tap/ceramic-one
+```
+
+### Linux - Debian-based distributions
+
+Install a the latest release using dpkg:
 
 ```bash
 # get deb.tar.gz
@@ -43,14 +51,6 @@ git clone https://github.com/ceramicnetwork/rust-ceramic
 cd rust-ceramic
 make build
 cp ./target/release/ceramic-one /usr/local/bin/ceramic-one
-```
-
-### MacOS - Local System
-
-Install from [Homebrew](https://brew.sh/)
-
-```bash
-brew install ceramicnetwork/tap/ceramic-one
 ```
 
 ### Docker

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -82,10 +82,10 @@ echo "Building artifacts for "$TARGET
 
 cargo build --release --locked --target $TARGET
 
-if [ "$EXT" = "bin" ]; then
-    echo "Compressing package for $TARGET"
-    tar -cvzf ceramic-one_$TARGET.tar.gz -C $BIN_DIR ceramic-one
-else
+echo "Compressing binary package for $TARGET"
+tar -cvzf ceramic-one_$TARGET.bin.tar.gz -C $BIN_DIR ceramic-one
+
+if [ "$EXT" != "bin" ]; then
     echo "Building package for $TARGET"
     fpm --fpm-options-file $CONFIG_FILE -C $BIN_DIR -v $PKG_VERSION -p $OUT_PATH ceramic-one=$INSTALL_DIR/ceramic-one
 


### PR DESCRIPTION
This PR updates the pre-release process to also package binaries for linux. This will be helpful when creating an AUR package for arch linux.

Note: macos archives will change extension from `.tar.gz` to `.bin.tar.gz`, so we will likely need to update the archive names to include `.bin` on the most recent pre-release to not break the workflow.

Also changed the order of the README install instructions to Macos before Linux because I didn't want the Macos instructions to get lost under the *from source* instructions for Linux.