### PR TITLE
refactor: allow skipping ordering all events on start up and skip tracking during migration

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -288,7 +288,7 @@ impl DBOpts {
         let sql_pool =
             ceramic_store::SqlitePool::connect(path, ceramic_store::Migrations::Apply).await?;
         let interest_store = Arc::new(CeramicInterestService::new(sql_pool.clone()));
-        let event_store = Arc::new(CeramicEventService::new(sql_pool).await?);
+        let event_store = Arc::new(CeramicEventService::new(sql_pool, true).await?);
         info!(path, "connected to sqlite db");
 
         Ok(Databases::Sqlite(SqliteBackend {

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1385,7 +1385,7 @@ mod tests {
                 rpc_server_addr,
                 keypair.into(),
                 None::<(DummyRecon<Interest>, DummyRecon<EventId>)>,
-                Arc::new(CeramicEventService::new(sql_pool).await?),
+                Arc::new(CeramicEventService::new(sql_pool, true).await?),
                 metrics,
             )
             .await?;

--- a/service/src/event/migration.rs
+++ b/service/src/event/migration.rs
@@ -147,7 +147,7 @@ impl<'a> Migrator<'a> {
             .map(|(id, body)| recon::ReconItem::new(id, body))
             .collect::<Vec<_>>();
         self.service
-            .insert_events_from_carfiles_recon(&items)
+            .insert_events_from_carfiles_ipfs(&items)
             .await?;
         self.event_count += self.batch.len();
         self.batch.truncate(0);

--- a/service/src/event/migration.rs
+++ b/service/src/event/migration.rs
@@ -10,9 +10,10 @@ use serde::Deserialize;
 use thiserror::Error;
 use tracing::{debug, error, info, instrument, Level};
 
-use crate::CeramicEventService;
-
-use super::service::{Block, BoxedBlock};
+use crate::{
+    event::{Block, BoxedBlock, DeliverableRequirement},
+    CeramicEventService,
+};
 
 pub struct Migrator<'a> {
     service: &'a CeramicEventService,
@@ -147,7 +148,7 @@ impl<'a> Migrator<'a> {
             .map(|(id, body)| recon::ReconItem::new(id, body))
             .collect::<Vec<_>>();
         self.service
-            .insert_events_from_carfiles_ipfs(&items)
+            .insert_events(&items, DeliverableRequirement::Lazy)
             .await?;
         self.event_count += self.batch.len();
         self.batch.truncate(0);

--- a/service/src/event/mod.rs
+++ b/service/src/event/mod.rs
@@ -4,4 +4,4 @@ mod ordering_task;
 mod service;
 mod store;
 
-pub use service::{Block, BoxedBlock, CeramicEventService};
+pub use service::{Block, BoxedBlock, CeramicEventService, DeliverableRequirement};

--- a/service/src/tests/event.rs
+++ b/service/src/tests/event.rs
@@ -17,7 +17,7 @@ macro_rules! test_with_sqlite {
             async fn [<$test_name _sqlite>]() {
 
                 let conn = ceramic_store::SqlitePool::connect_in_memory().await.unwrap();
-                let store = $crate::CeramicEventService::new(conn).await.unwrap();
+                let store = $crate::CeramicEventService::new(conn, true).await.unwrap();
                 $(
                     for stmt in $sql_stmts {
                         store.pool.run_statement(stmt).await.unwrap();

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -56,7 +56,7 @@ async fn test_migration(cars: Vec<Vec<u8>>) {
     let conn = ceramic_store::SqlitePool::connect_in_memory()
         .await
         .unwrap();
-    let service = CeramicEventService::new(conn).await.unwrap();
+    let service = CeramicEventService::new(conn, false).await.unwrap();
     service
         .migrate_from_ipfs(Network::Local(42), blocks)
         .await

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -17,9 +17,7 @@ async fn setup_service() -> CeramicEventService {
         .await
         .unwrap();
 
-    CeramicEventService::new_without_undelivered(conn)
-        .await
-        .unwrap()
+    CeramicEventService::new(conn, false).await.unwrap()
 }
 
 async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -8,6 +8,7 @@ use recon::ReconItem;
 use test_log::test;
 
 use crate::{
+    event::DeliverableRequirement,
     tests::{check_deliverable, get_events},
     CeramicEventService,
 };
@@ -22,17 +23,13 @@ async fn setup_service() -> CeramicEventService {
 
 async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
     tracing::trace!("inserted event: {}", item.key.cid().unwrap());
-    let new = store
-        .insert_events_from_carfiles_recon(&[item])
-        .await
-        .unwrap();
-    let new = new.keys.into_iter().filter(|k| *k).count();
-    assert_eq!(1, new);
+    let new = recon::Store::insert(store, &item).await.unwrap();
+    assert!(new);
 }
 
 async fn add_and_assert_new_local_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
     let new = store
-        .insert_events_from_carfiles_local_api(&[item])
+        .insert_events(&[item], DeliverableRequirement::Immediate)
         .await
         .unwrap();
     let new = new.store_result.count_new_keys();
@@ -55,7 +52,10 @@ async fn test_missing_prev_history_required_not_inserted() {
     let data = &events[1];
 
     let new = store
-        .insert_events_from_carfiles_local_api(&[ReconItem::new(&data.0, &data.1)])
+        .insert_events(
+            &[ReconItem::new(&data.0, &data.1)],
+            DeliverableRequirement::Immediate,
+        )
         .await
         .unwrap();
     assert!(new.store_result.inserted.is_empty());
@@ -91,10 +91,13 @@ async fn test_prev_in_same_write_history_required() {
     let init: &(EventId, Vec<u8>) = &events[0];
     let data = &events[1];
     let new = store
-        .insert_events_from_carfiles_local_api(&[
-            ReconItem::new(&data.0, &data.1),
-            ReconItem::new(&init.0, &init.1),
-        ])
+        .insert_events(
+            &[
+                ReconItem::new(&data.0, &data.1),
+                ReconItem::new(&init.0, &init.1),
+            ],
+            DeliverableRequirement::Immediate,
+        )
         .await
         .unwrap();
     let new = new.store_result.count_new_keys();


### PR DESCRIPTION
You can skip ordering all the events in database on startup with a flag now (for use in the migration code). We also defer ordering all time events outside of the current batch until server startup. This reduces the memory pressure as we have to track everything while migrating it, and then duplicate quite a bit until it's found, which we can instead do successfully at the next start up. We still try to order the current batch as best we can so if an init and time event are in the same batch of 1000, they will be updated.