### PR TITLE
feat: support cors via cli flag

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.28.1
-- Build date: 2024-07-14T19:10:51.794436387Z[Etc/UTC]
+- Build date: 2024-07-15T07:42:36.368308-07:00[America/Los_Angeles]
 
 
 
@@ -63,14 +63,25 @@ To run a client, follow one of the following simple steps:
 
 ```
 cargo run --example client DebugHeapGet
+cargo run --example client DebugHeapOptions
 cargo run --example client EventsEventIdGet
+cargo run --example client EventsEventIdOptions
+cargo run --example client EventsOptions
 cargo run --example client ExperimentalEventsSepSepValueGet
+cargo run --example client ExperimentalEventsSepSepValueOptions
 cargo run --example client ExperimentalInterestsGet
+cargo run --example client ExperimentalInterestsOptions
 cargo run --example client FeedEventsGet
+cargo run --example client FeedEventsOptions
 cargo run --example client FeedResumeTokenGet
+cargo run --example client FeedResumeTokenOptions
+cargo run --example client InterestsOptions
+cargo run --example client InterestsSortKeySortValueOptions
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
+cargo run --example client LivenessOptions
 cargo run --example client VersionGet
+cargo run --example client VersionOptions
 cargo run --example client VersionPost
 ```
 
@@ -106,16 +117,27 @@ All URIs are relative to */ceramic*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [****](docs/default_api.md#) | **GET** /debug/heap | Get the heap statistics of the Ceramic node
+[****](docs/default_api.md#) | **OPTIONS** /debug/heap | cors
 [****](docs/default_api.md#) | **GET** /events/{event_id} | Get event data
+[****](docs/default_api.md#) | **OPTIONS** /events/{event_id} | cors
+[****](docs/default_api.md#) | **OPTIONS** /events | cors
 [****](docs/default_api.md#) | **POST** /events | Creates a new event
 [****](docs/default_api.md#) | **GET** /experimental/events/{sep}/{sepValue} | Get events matching the interest stored on the node
+[****](docs/default_api.md#) | **OPTIONS** /experimental/events/{sep}/{sepValue} | cors
 [****](docs/default_api.md#) | **GET** /experimental/interests | Get the interests stored on the node
+[****](docs/default_api.md#) | **OPTIONS** /experimental/interests | cors
 [****](docs/default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
+[****](docs/default_api.md#) | **OPTIONS** /feed/events | cors
 [****](docs/default_api.md#) | **GET** /feed/resumeToken | Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
+[****](docs/default_api.md#) | **OPTIONS** /feed/resumeToken | cors
+[****](docs/default_api.md#) | **OPTIONS** /interests | cors
 [****](docs/default_api.md#) | **POST** /interests | Register interest for a sort key
+[****](docs/default_api.md#) | **OPTIONS** /interests/{sort_key}/{sort_value} | cors
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
+[****](docs/default_api.md#) | **OPTIONS** /liveness | cors
 [****](docs/default_api.md#) | **GET** /version | Get the version of the Ceramic node
+[****](docs/default_api.md#) | **OPTIONS** /version | cors
 [****](docs/default_api.md#) | **POST** /version | Get the version of the Ceramic node
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -22,6 +22,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Test the liveness of the Ceramic node
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /debug/heap:
     get:
       responses:
@@ -45,6 +50,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get the heap statistics of the Ceramic node
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /version:
     get:
       responses:
@@ -61,6 +71,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get the version of the Ceramic node
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
     post:
       responses:
         "200":
@@ -77,6 +92,11 @@ paths:
           description: Internal server error
       summary: Get the version of the Ceramic node
   /events:
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
     post:
       requestBody:
         $ref: '#/components/requestBodies/EventData'
@@ -134,7 +154,46 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get event data
+    options:
+      parameters:
+      - description: Name of the field in the Events header that holds the separator
+          value e.g. 'model'
+        explode: false
+        in: path
+        name: event_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /interests/{sort_key}/{sort_value}:
+    options:
+      parameters:
+      - description: Name of the field in the Events header that holds the separator
+          value e.g. 'model'
+        explode: false
+        in: path
+        name: sort_key
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The value of the field in the Events header indicated by the
+          separator key e.g. multibase encoded model ID
+        explode: false
+        in: path
+        name: sort_value
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          description: cors
+      summary: cors
     post:
       parameters:
       - description: name of the sort_key
@@ -186,6 +245,11 @@ paths:
           description: Internal server error
       summary: Register interest for a sort key
   /interests:
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
     post:
       requestBody:
         $ref: '#/components/requestBodies/Interest'
@@ -227,6 +291,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get the interests stored on the node
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /experimental/events/{sep}/{sepValue}:
     get:
       parameters:
@@ -301,6 +370,30 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get events matching the interest stored on the node
+    options:
+      parameters:
+      - description: Name of the field in the Events header that holds the separator
+          value e.g. 'model'
+        explode: false
+        in: path
+        name: sep
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: The value of the field in the Events header indicated by the
+          separator key e.g. multibase encoded model ID
+        explode: false
+        in: path
+        name: sepValue
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /feed/events:
     get:
       parameters:
@@ -341,6 +434,11 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Get all new event keys since resume token
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /feed/resumeToken:
     get:
       responses:
@@ -364,6 +462,11 @@ paths:
           description: Internal server error
       summary: Get the current (maximum) highwater mark/continuation token of the
         feed. Allows starting `feed/events` from 'now'.
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
 components:
   requestBodies:
     EventData:

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -5,16 +5,27 @@ All URIs are relative to */ceramic*
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 ****](default_api.md#) | **GET** /debug/heap | Get the heap statistics of the Ceramic node
+****](default_api.md#) | **OPTIONS** /debug/heap | cors
 ****](default_api.md#) | **GET** /events/{event_id} | Get event data
+****](default_api.md#) | **OPTIONS** /events/{event_id} | cors
+****](default_api.md#) | **OPTIONS** /events | cors
 ****](default_api.md#) | **POST** /events | Creates a new event
 ****](default_api.md#) | **GET** /experimental/events/{sep}/{sepValue} | Get events matching the interest stored on the node
+****](default_api.md#) | **OPTIONS** /experimental/events/{sep}/{sepValue} | cors
 ****](default_api.md#) | **GET** /experimental/interests | Get the interests stored on the node
+****](default_api.md#) | **OPTIONS** /experimental/interests | cors
 ****](default_api.md#) | **GET** /feed/events | Get all new event keys since resume token
+****](default_api.md#) | **OPTIONS** /feed/events | cors
 ****](default_api.md#) | **GET** /feed/resumeToken | Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
+****](default_api.md#) | **OPTIONS** /feed/resumeToken | cors
+****](default_api.md#) | **OPTIONS** /interests | cors
 ****](default_api.md#) | **POST** /interests | Register interest for a sort key
+****](default_api.md#) | **OPTIONS** /interests/{sort_key}/{sort_value} | cors
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
+****](default_api.md#) | **OPTIONS** /liveness | cors
 ****](default_api.md#) | **GET** /version | Get the version of the Ceramic node
+****](default_api.md#) | **OPTIONS** /version | cors
 ****](default_api.md#) | **POST** /version | Get the version of the Ceramic node
 
 
@@ -41,6 +52,28 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
 > models::Event (event_id)
 Get event data
 
@@ -62,6 +95,53 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json, text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (event_id)
+cors
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **event_id** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -130,6 +210,32 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
+> (sep, sep_value)
+cors
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **sep** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
+  **sep_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
 > models::InterestsGet ()
 Get the interests stored on the node
 
@@ -148,6 +254,28 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -185,6 +313,28 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
 > models::FeedResumeTokenGet200Response ()
 Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
 
@@ -203,6 +353,50 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -228,6 +422,32 @@ No authorization required
 
  - **Content-Type**: application/json
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (sort_key, sort_value)
+cors
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **sort_key** | **String**| Name of the field in the Events header that holds the separator value e.g. 'model' | 
+  **sort_value** | **String**| The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -291,6 +511,28 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
 > models::Version ()
 Get the version of the Ceramic node
 
@@ -309,6 +551,28 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -3,10 +3,14 @@
 #[allow(unused_imports)]
 use ceramic_api_server::{
     models, Api, ApiNoContext, Client, ContextWrapperExt, DebugHeapGetResponse,
-    EventsEventIdGetResponse, EventsPostResponse, ExperimentalEventsSepSepValueGetResponse,
-    ExperimentalInterestsGetResponse, FeedEventsGetResponse, FeedResumeTokenGetResponse,
-    InterestsPostResponse, InterestsSortKeySortValuePostResponse, LivenessGetResponse,
-    VersionGetResponse, VersionPostResponse,
+    DebugHeapOptionsResponse, EventsEventIdGetResponse, EventsEventIdOptionsResponse,
+    EventsOptionsResponse, EventsPostResponse, ExperimentalEventsSepSepValueGetResponse,
+    ExperimentalEventsSepSepValueOptionsResponse, ExperimentalInterestsGetResponse,
+    ExperimentalInterestsOptionsResponse, FeedEventsGetResponse, FeedEventsOptionsResponse,
+    FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
+    InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -37,14 +41,25 @@ fn main() {
                 .help("Sets the operation to run")
                 .possible_values(&[
                     "DebugHeapGet",
+                    "DebugHeapOptions",
                     "EventsEventIdGet",
+                    "EventsEventIdOptions",
+                    "EventsOptions",
                     "ExperimentalEventsSepSepValueGet",
+                    "ExperimentalEventsSepSepValueOptions",
                     "ExperimentalInterestsGet",
+                    "ExperimentalInterestsOptions",
                     "FeedEventsGet",
+                    "FeedEventsOptions",
                     "FeedResumeTokenGet",
+                    "FeedResumeTokenOptions",
+                    "InterestsOptions",
+                    "InterestsSortKeySortValueOptions",
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
+                    "LivenessOptions",
                     "VersionGet",
+                    "VersionOptions",
                     "VersionPost",
                 ])
                 .required(true)
@@ -109,8 +124,33 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        Some("DebugHeapOptions") => {
+            let result = rt.block_on(client.debug_heap_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("EventsEventIdGet") => {
             let result = rt.block_on(client.events_event_id_get("event_id_example".to_string()));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("EventsEventIdOptions") => {
+            let result =
+                rt.block_on(client.events_event_id_options("event_id_example".to_string()));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("EventsOptions") => {
+            let result = rt.block_on(client.events_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,
@@ -140,8 +180,27 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        Some("ExperimentalEventsSepSepValueOptions") => {
+            let result = rt.block_on(client.experimental_events_sep_sep_value_options(
+                "sep_example".to_string(),
+                "sep_value_example".to_string(),
+            ));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("ExperimentalInterestsGet") => {
             let result = rt.block_on(client.experimental_interests_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("ExperimentalInterestsOptions") => {
+            let result = rt.block_on(client.experimental_interests_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,
@@ -157,8 +216,32 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        Some("FeedEventsOptions") => {
+            let result = rt.block_on(client.feed_events_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("FeedResumeTokenGet") => {
             let result = rt.block_on(client.feed_resume_token_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("FeedResumeTokenOptions") => {
+            let result = rt.block_on(client.feed_resume_token_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("InterestsOptions") => {
+            let result = rt.block_on(client.interests_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,
@@ -173,6 +256,17 @@ fn main() {
             info!("{:?} (X-Span-ID: {:?})", result, (client.context() as &dyn Has<XSpanIdString>).get().clone());
         },
         */
+        Some("InterestsSortKeySortValueOptions") => {
+            let result = rt.block_on(client.interests_sort_key_sort_value_options(
+                "sort_key_example".to_string(),
+                "sort_value_example".to_string(),
+            ));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("InterestsSortKeySortValuePost") => {
             let result = rt.block_on(client.interests_sort_key_sort_value_post(
                 "sort_key_example".to_string(),
@@ -194,8 +288,24 @@ fn main() {
                 (client.context() as &dyn Has<XSpanIdString>).get().clone()
             );
         }
+        Some("LivenessOptions") => {
+            let result = rt.block_on(client.liveness_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("VersionGet") => {
             let result = rt.block_on(client.version_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("VersionOptions") => {
+            let result = rt.block_on(client.version_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -101,11 +101,14 @@ impl<C> Server<C> {
 
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
-    Api, DebugHeapGetResponse, EventsEventIdGetResponse, EventsPostResponse,
-    ExperimentalEventsSepSepValueGetResponse, ExperimentalInterestsGetResponse,
-    FeedEventsGetResponse, FeedResumeTokenGetResponse, InterestsPostResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionGetResponse,
-    VersionPostResponse,
+    Api, DebugHeapGetResponse, DebugHeapOptionsResponse, EventsEventIdGetResponse,
+    EventsEventIdOptionsResponse, EventsOptionsResponse, EventsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, ExperimentalEventsSepSepValueOptionsResponse,
+    ExperimentalInterestsGetResponse, ExperimentalInterestsOptionsResponse, FeedEventsGetResponse,
+    FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
+    InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -124,6 +127,15 @@ where
         Err(ApiError("Generic failure".into()))
     }
 
+    /// cors
+    async fn debug_heap_options(&self, context: &C) -> Result<DebugHeapOptionsResponse, ApiError> {
+        info!(
+            "debug_heap_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
     /// Get event data
     async fn events_event_id_get(
         &self,
@@ -133,6 +145,29 @@ where
         info!(
             "events_event_id_get(\"{}\") - X-Span-ID: {:?}",
             event_id,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn events_event_id_options(
+        &self,
+        event_id: String,
+        context: &C,
+    ) -> Result<EventsEventIdOptionsResponse, ApiError> {
+        info!(
+            "events_event_id_options(\"{}\") - X-Span-ID: {:?}",
+            event_id,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn events_options(&self, context: &C) -> Result<EventsOptionsResponse, ApiError> {
+        info!(
+            "events_options() - X-Span-ID: {:?}",
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))
@@ -167,6 +202,22 @@ where
         Err(ApiError("Generic failure".into()))
     }
 
+    /// cors
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        sep: String,
+        sep_value: String,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepSepValueOptionsResponse, ApiError> {
+        info!(
+            "experimental_events_sep_sep_value_options(\"{}\", \"{}\") - X-Span-ID: {:?}",
+            sep,
+            sep_value,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
@@ -174,6 +225,18 @@ where
     ) -> Result<ExperimentalInterestsGetResponse, ApiError> {
         info!(
             "experimental_interests_get() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn experimental_interests_options(
+        &self,
+        context: &C,
+    ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
+        info!(
+            "experimental_interests_options() - X-Span-ID: {:?}",
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))
@@ -195,6 +258,18 @@ where
         Err(ApiError("Generic failure".into()))
     }
 
+    /// cors
+    async fn feed_events_options(
+        &self,
+        context: &C,
+    ) -> Result<FeedEventsOptionsResponse, ApiError> {
+        info!(
+            "feed_events_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
     /// Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
     async fn feed_resume_token_get(
         &self,
@@ -202,6 +277,27 @@ where
     ) -> Result<FeedResumeTokenGetResponse, ApiError> {
         info!(
             "feed_resume_token_get() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn feed_resume_token_options(
+        &self,
+        context: &C,
+    ) -> Result<FeedResumeTokenOptionsResponse, ApiError> {
+        info!(
+            "feed_resume_token_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn interests_options(&self, context: &C) -> Result<InterestsOptionsResponse, ApiError> {
+        info!(
+            "interests_options() - X-Span-ID: {:?}",
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))
@@ -216,6 +312,22 @@ where
         info!(
             "interests_post({:?}) - X-Span-ID: {:?}",
             interest,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        context: &C,
+    ) -> Result<InterestsSortKeySortValueOptionsResponse, ApiError> {
+        info!(
+            "interests_sort_key_sort_value_options(\"{}\", \"{}\") - X-Span-ID: {:?}",
+            sort_key,
+            sort_value,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))
@@ -247,9 +359,27 @@ where
         Err(ApiError("Generic failure".into()))
     }
 
+    /// cors
+    async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
+        info!(
+            "liveness_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
     /// Get the version of the Ceramic node
     async fn version_get(&self, context: &C) -> Result<VersionGetResponse, ApiError> {
         info!("version_get() - X-Span-ID: {:?}", context.get().0.clone());
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn version_options(&self, context: &C) -> Result<VersionOptionsResponse, ApiError> {
+        info!(
+            "version_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
         Err(ApiError("Generic failure".into()))
     }
 

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -42,11 +42,14 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
 const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
-    Api, DebugHeapGetResponse, EventsEventIdGetResponse, EventsPostResponse,
-    ExperimentalEventsSepSepValueGetResponse, ExperimentalInterestsGetResponse,
-    FeedEventsGetResponse, FeedResumeTokenGetResponse, InterestsPostResponse,
-    InterestsSortKeySortValuePostResponse, LivenessGetResponse, VersionGetResponse,
-    VersionPostResponse,
+    Api, DebugHeapGetResponse, DebugHeapOptionsResponse, EventsEventIdGetResponse,
+    EventsEventIdOptionsResponse, EventsOptionsResponse, EventsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, ExperimentalEventsSepSepValueOptionsResponse,
+    ExperimentalInterestsGetResponse, ExperimentalInterestsOptionsResponse, FeedEventsGetResponse,
+    FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
+    InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -496,6 +499,74 @@ where
         }
     }
 
+    async fn debug_heap_options(&self, context: &C) -> Result<DebugHeapOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/debug/heap", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(DebugHeapOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
     async fn events_event_id_get(
         &self,
         param_event_id: String,
@@ -603,6 +674,150 @@ where
                 })?;
                 Ok(EventsEventIdGetResponse::InternalServerError(body))
             }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn events_event_id_options(
+        &self,
+        param_event_id: String,
+        context: &C,
+    ) -> Result<EventsEventIdOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/ceramic/events/{event_id}",
+            self.base_path,
+            event_id = utf8_percent_encode(&param_event_id.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(EventsEventIdOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn events_options(&self, context: &C) -> Result<EventsOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/events", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(EventsOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -871,6 +1086,84 @@ where
         }
     }
 
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        param_sep: String,
+        param_sep_value: String,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepSepValueOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/ceramic/experimental/events/{sep}/{sep_value}",
+            self.base_path,
+            sep = utf8_percent_encode(&param_sep.to_string(), ID_ENCODE_SET),
+            sep_value = utf8_percent_encode(&param_sep_value.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(ExperimentalEventsSepSepValueOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
     async fn experimental_interests_get(
         &self,
         context: &C,
@@ -962,6 +1255,77 @@ where
                 })?;
                 Ok(ExperimentalInterestsGetResponse::InternalServerError(body))
             }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn experimental_interests_options(
+        &self,
+        context: &C,
+    ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/experimental/interests", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(ExperimentalInterestsOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -1099,6 +1463,77 @@ where
         }
     }
 
+    async fn feed_events_options(
+        &self,
+        context: &C,
+    ) -> Result<FeedEventsOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/feed/events", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(FeedEventsOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
     async fn feed_resume_token_get(
         &self,
         context: &C,
@@ -1191,6 +1626,145 @@ where
                 })?;
                 Ok(FeedResumeTokenGetResponse::InternalServerError(body))
             }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn feed_resume_token_options(
+        &self,
+        context: &C,
+    ) -> Result<FeedResumeTokenOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/feed/resumeToken", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(FeedResumeTokenOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn interests_options(&self, context: &C) -> Result<InterestsOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/interests", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(InterestsOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -1306,6 +1880,84 @@ where
                 })?;
                 Ok(InterestsPostResponse::InternalServerError(body))
             }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        param_sort_key: String,
+        param_sort_value: String,
+        context: &C,
+    ) -> Result<InterestsSortKeySortValueOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!(
+            "{}/ceramic/interests/{sort_key}/{sort_value}",
+            self.base_path,
+            sort_key = utf8_percent_encode(&param_sort_key.to_string(), ID_ENCODE_SET),
+            sort_value = utf8_percent_encode(&param_sort_value.to_string(), ID_ENCODE_SET)
+        );
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(InterestsSortKeySortValueOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;
@@ -1521,6 +2173,74 @@ where
         }
     }
 
+    async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/liveness", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(LivenessOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
     async fn version_get(&self, context: &C) -> Result<VersionGetResponse, ApiError> {
         let mut client_service = self.client_service.clone();
         let mut uri = format!("{}/ceramic/version", self.base_path);
@@ -1595,6 +2315,74 @@ where
                 })?;
                 Ok(VersionGetResponse::InternalServerError(body))
             }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn version_options(&self, context: &C) -> Result<VersionOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/version", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(VersionOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -34,6 +34,12 @@ pub enum DebugHeapGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum DebugHeapOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum EventsEventIdGetResponse {
     /// success
@@ -44,6 +50,18 @@ pub enum EventsEventIdGetResponse {
     EventNotFound(String),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum EventsEventIdOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum EventsOptionsResponse {
+    /// cors
+    Cors,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -69,6 +87,12 @@ pub enum ExperimentalEventsSepSepValueGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum ExperimentalEventsSepSepValueOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum ExperimentalInterestsGetResponse {
     /// success
@@ -77,6 +101,12 @@ pub enum ExperimentalInterestsGetResponse {
     BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum ExperimentalInterestsOptionsResponse {
+    /// cors
+    Cors,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -91,6 +121,12 @@ pub enum FeedEventsGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum FeedEventsOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum FeedResumeTokenGetResponse {
     /// success
@@ -102,6 +138,18 @@ pub enum FeedResumeTokenGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum FeedResumeTokenOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum InterestsOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum InterestsPostResponse {
     /// success
@@ -110,6 +158,12 @@ pub enum InterestsPostResponse {
     BadRequest(models::BadRequestResponse),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum InterestsSortKeySortValueOptionsResponse {
+    /// cors
+    Cors,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -133,12 +187,24 @@ pub enum LivenessGetResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum LivenessOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum VersionGetResponse {
     /// success
     Success(models::Version),
     /// Internal server error
     InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum VersionOptionsResponse {
+    /// cors
+    Cors,
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -164,12 +230,25 @@ pub trait Api<C: Send + Sync> {
     /// Get the heap statistics of the Ceramic node
     async fn debug_heap_get(&self, context: &C) -> Result<DebugHeapGetResponse, ApiError>;
 
+    /// cors
+    async fn debug_heap_options(&self, context: &C) -> Result<DebugHeapOptionsResponse, ApiError>;
+
     /// Get event data
     async fn events_event_id_get(
         &self,
         event_id: String,
         context: &C,
     ) -> Result<EventsEventIdGetResponse, ApiError>;
+
+    /// cors
+    async fn events_event_id_options(
+        &self,
+        event_id: String,
+        context: &C,
+    ) -> Result<EventsEventIdOptionsResponse, ApiError>;
+
+    /// cors
+    async fn events_options(&self, context: &C) -> Result<EventsOptionsResponse, ApiError>;
 
     /// Creates a new event
     async fn events_post(
@@ -190,11 +269,25 @@ pub trait Api<C: Send + Sync> {
         context: &C,
     ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError>;
 
+    /// cors
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        sep: String,
+        sep_value: String,
+        context: &C,
+    ) -> Result<ExperimentalEventsSepSepValueOptionsResponse, ApiError>;
+
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
         context: &C,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError>;
+
+    /// cors
+    async fn experimental_interests_options(
+        &self,
+        context: &C,
+    ) -> Result<ExperimentalInterestsOptionsResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -204,11 +297,24 @@ pub trait Api<C: Send + Sync> {
         context: &C,
     ) -> Result<FeedEventsGetResponse, ApiError>;
 
+    /// cors
+    async fn feed_events_options(&self, context: &C)
+        -> Result<FeedEventsOptionsResponse, ApiError>;
+
     /// Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
     async fn feed_resume_token_get(
         &self,
         context: &C,
     ) -> Result<FeedResumeTokenGetResponse, ApiError>;
+
+    /// cors
+    async fn feed_resume_token_options(
+        &self,
+        context: &C,
+    ) -> Result<FeedResumeTokenOptionsResponse, ApiError>;
+
+    /// cors
+    async fn interests_options(&self, context: &C) -> Result<InterestsOptionsResponse, ApiError>;
 
     /// Register interest for a sort key
     async fn interests_post(
@@ -216,6 +322,14 @@ pub trait Api<C: Send + Sync> {
         interest: models::Interest,
         context: &C,
     ) -> Result<InterestsPostResponse, ApiError>;
+
+    /// cors
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        sort_key: String,
+        sort_value: String,
+        context: &C,
+    ) -> Result<InterestsSortKeySortValueOptionsResponse, ApiError>;
 
     /// Register interest for a sort key
     async fn interests_sort_key_sort_value_post(
@@ -230,8 +344,14 @@ pub trait Api<C: Send + Sync> {
     /// Test the liveness of the Ceramic node
     async fn liveness_get(&self, context: &C) -> Result<LivenessGetResponse, ApiError>;
 
+    /// cors
+    async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError>;
+
     /// Get the version of the Ceramic node
     async fn version_get(&self, context: &C) -> Result<VersionGetResponse, ApiError>;
+
+    /// cors
+    async fn version_options(&self, context: &C) -> Result<VersionOptionsResponse, ApiError>;
 
     /// Get the version of the Ceramic node
     async fn version_post(&self, context: &C) -> Result<VersionPostResponse, ApiError>;
@@ -251,11 +371,23 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Get the heap statistics of the Ceramic node
     async fn debug_heap_get(&self) -> Result<DebugHeapGetResponse, ApiError>;
 
+    /// cors
+    async fn debug_heap_options(&self) -> Result<DebugHeapOptionsResponse, ApiError>;
+
     /// Get event data
     async fn events_event_id_get(
         &self,
         event_id: String,
     ) -> Result<EventsEventIdGetResponse, ApiError>;
+
+    /// cors
+    async fn events_event_id_options(
+        &self,
+        event_id: String,
+    ) -> Result<EventsEventIdOptionsResponse, ApiError>;
+
+    /// cors
+    async fn events_options(&self) -> Result<EventsOptionsResponse, ApiError>;
 
     /// Creates a new event
     async fn events_post(
@@ -274,10 +406,22 @@ pub trait ApiNoContext<C: Send + Sync> {
         limit: Option<i32>,
     ) -> Result<ExperimentalEventsSepSepValueGetResponse, ApiError>;
 
+    /// cors
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        sep: String,
+        sep_value: String,
+    ) -> Result<ExperimentalEventsSepSepValueOptionsResponse, ApiError>;
+
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError>;
+
+    /// cors
+    async fn experimental_interests_options(
+        &self,
+    ) -> Result<ExperimentalInterestsOptionsResponse, ApiError>;
 
     /// Get all new event keys since resume token
     async fn feed_events_get(
@@ -286,14 +430,30 @@ pub trait ApiNoContext<C: Send + Sync> {
         limit: Option<i32>,
     ) -> Result<FeedEventsGetResponse, ApiError>;
 
+    /// cors
+    async fn feed_events_options(&self) -> Result<FeedEventsOptionsResponse, ApiError>;
+
     /// Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
     async fn feed_resume_token_get(&self) -> Result<FeedResumeTokenGetResponse, ApiError>;
+
+    /// cors
+    async fn feed_resume_token_options(&self) -> Result<FeedResumeTokenOptionsResponse, ApiError>;
+
+    /// cors
+    async fn interests_options(&self) -> Result<InterestsOptionsResponse, ApiError>;
 
     /// Register interest for a sort key
     async fn interests_post(
         &self,
         interest: models::Interest,
     ) -> Result<InterestsPostResponse, ApiError>;
+
+    /// cors
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        sort_key: String,
+        sort_value: String,
+    ) -> Result<InterestsSortKeySortValueOptionsResponse, ApiError>;
 
     /// Register interest for a sort key
     async fn interests_sort_key_sort_value_post(
@@ -307,8 +467,14 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Test the liveness of the Ceramic node
     async fn liveness_get(&self) -> Result<LivenessGetResponse, ApiError>;
 
+    /// cors
+    async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError>;
+
     /// Get the version of the Ceramic node
     async fn version_get(&self) -> Result<VersionGetResponse, ApiError>;
+
+    /// cors
+    async fn version_options(&self) -> Result<VersionOptionsResponse, ApiError>;
 
     /// Get the version of the Ceramic node
     async fn version_post(&self) -> Result<VersionPostResponse, ApiError>;
@@ -345,6 +511,12 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().debug_heap_get(&context).await
     }
 
+    /// cors
+    async fn debug_heap_options(&self) -> Result<DebugHeapOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().debug_heap_options(&context).await
+    }
+
     /// Get event data
     async fn events_event_id_get(
         &self,
@@ -352,6 +524,21 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     ) -> Result<EventsEventIdGetResponse, ApiError> {
         let context = self.context().clone();
         self.api().events_event_id_get(event_id, &context).await
+    }
+
+    /// cors
+    async fn events_event_id_options(
+        &self,
+        event_id: String,
+    ) -> Result<EventsEventIdOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().events_event_id_options(event_id, &context).await
+    }
+
+    /// cors
+    async fn events_options(&self) -> Result<EventsOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().events_options(&context).await
     }
 
     /// Creates a new event
@@ -381,12 +568,32 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
             .await
     }
 
+    /// cors
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        sep: String,
+        sep_value: String,
+    ) -> Result<ExperimentalEventsSepSepValueOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api()
+            .experimental_events_sep_sep_value_options(sep, sep_value, &context)
+            .await
+    }
+
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError> {
         let context = self.context().clone();
         self.api().experimental_interests_get(&context).await
+    }
+
+    /// cors
+    async fn experimental_interests_options(
+        &self,
+    ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().experimental_interests_options(&context).await
     }
 
     /// Get all new event keys since resume token
@@ -399,10 +606,28 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().feed_events_get(resume_at, limit, &context).await
     }
 
+    /// cors
+    async fn feed_events_options(&self) -> Result<FeedEventsOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().feed_events_options(&context).await
+    }
+
     /// Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
     async fn feed_resume_token_get(&self) -> Result<FeedResumeTokenGetResponse, ApiError> {
         let context = self.context().clone();
         self.api().feed_resume_token_get(&context).await
+    }
+
+    /// cors
+    async fn feed_resume_token_options(&self) -> Result<FeedResumeTokenOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().feed_resume_token_options(&context).await
+    }
+
+    /// cors
+    async fn interests_options(&self) -> Result<InterestsOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().interests_options(&context).await
     }
 
     /// Register interest for a sort key
@@ -412,6 +637,18 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     ) -> Result<InterestsPostResponse, ApiError> {
         let context = self.context().clone();
         self.api().interests_post(interest, &context).await
+    }
+
+    /// cors
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        sort_key: String,
+        sort_value: String,
+    ) -> Result<InterestsSortKeySortValueOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api()
+            .interests_sort_key_sort_value_options(sort_key, sort_value, &context)
+            .await
     }
 
     /// Register interest for a sort key
@@ -436,10 +673,22 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
         self.api().liveness_get(&context).await
     }
 
+    /// cors
+    async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().liveness_options(&context).await
+    }
+
     /// Get the version of the Ceramic node
     async fn version_get(&self) -> Result<VersionGetResponse, ApiError> {
         let context = self.context().clone();
         self.api().version_get(&context).await
+    }
+
+    /// cors
+    async fn version_options(&self) -> Result<VersionOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().version_options(&context).await
     }
 
     /// Get the version of the Ceramic node

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -16,6 +16,11 @@ servers:
 
 paths:
   /liveness:
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Test the liveness of the Ceramic node
       responses:
@@ -28,6 +33,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /debug/heap:
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get the heap statistics of the Ceramic node
       responses:
@@ -51,6 +61,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /version:
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get the version of the Ceramic node
       responses:
@@ -82,6 +97,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /events:
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     post:
       summary: Creates a new event
       requestBody:
@@ -102,6 +122,18 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /events/{event_id}:
+    options:
+      summary: cors
+      parameters:
+        - name: event_id
+          in: path
+          required: true
+          description: Name of the field in the Events header that holds the separator value e.g. 'model'
+          schema:
+            type: string
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get event data
       parameters:
@@ -137,6 +169,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   "/interests/{sort_key}/{sort_value}":
+    options:
+      summary: cors
+      parameters:
+        - name: sort_key
+          in: path
+          description: Name of the field in the Events header that holds the separator value e.g. 'model'
+          schema:
+            type: string
+          required: true
+        - name: sort_value
+          in: path
+          description: The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: cors
     post:
       summary: Register interest for a sort key
       parameters:
@@ -180,6 +230,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   "/interests":
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     post:
       summary: Register interest for a sort key
       requestBody:
@@ -200,6 +255,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   /experimental/interests:
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get the interests stored on the node
       responses:
@@ -222,6 +282,24 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   "/experimental/events/{sep}/{sepValue}":
+    options:
+      summary: cors
+      parameters:
+        - name: sep
+          in: path
+          description: Name of the field in the Events header that holds the separator value e.g. 'model'
+          schema:
+            type: string
+          required: true
+        - name: sepValue
+          in: path
+          description: The value of the field in the Events header indicated by the separator key e.g. multibase encoded model ID
+          schema:
+            type: string
+          required: true
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get events matching the interest stored on the node
       parameters:
@@ -282,6 +360,11 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
   "/feed/events":
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get all new event keys since resume token
       parameters:
@@ -317,6 +400,11 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
   "/feed/resumeToken":
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
     get:
       summary: Get the current (maximum) highwater mark/continuation token of the feed. Allows starting `feed/events` from 'now'.
       responses:

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -885,8 +885,7 @@ where
         _event_id: String,
         _context: &C,
     ) -> Result<ceramic_api_server::EventsEventIdOptionsResponse, ApiError> {
-        Ok(
-            ceramic_api_server::EventsEventIdOptionsResponse::Cors)
+        Ok(ceramic_api_server::EventsEventIdOptionsResponse::Cors)
     }
 
     /// cors
@@ -904,8 +903,7 @@ where
         _sep_value: String,
         _context: &C,
     ) -> Result<ceramic_api_server::ExperimentalEventsSepSepValueOptionsResponse, ApiError> {
-        Ok(
-            ceramic_api_server::ExperimentalEventsSepSepValueOptionsResponse::Cors)
+        Ok(ceramic_api_server::ExperimentalEventsSepSepValueOptionsResponse::Cors)
     }
 
     /// cors
@@ -913,8 +911,7 @@ where
         &self,
         _context: &C,
     ) -> Result<ceramic_api_server::ExperimentalInterestsOptionsResponse, ApiError> {
-        Ok(
-            ceramic_api_server::ExperimentalInterestsOptionsResponse::Cors)
+        Ok(ceramic_api_server::ExperimentalInterestsOptionsResponse::Cors)
     }
 
     /// cors
@@ -930,8 +927,7 @@ where
         &self,
         _context: &C,
     ) -> Result<ceramic_api_server::FeedResumeTokenOptionsResponse, ApiError> {
-        Ok(
-            ceramic_api_server::FeedResumeTokenOptionsResponse::Cors)
+        Ok(ceramic_api_server::FeedResumeTokenOptionsResponse::Cors)
     }
 
     /// cors
@@ -949,8 +945,7 @@ where
         _sort_value: String,
         _context: &C,
     ) -> Result<ceramic_api_server::InterestsSortKeySortValueOptionsResponse, ApiError> {
-        Ok(
-            ceramic_api_server::InterestsSortKeySortValueOptionsResponse::Cors)
+        Ok(ceramic_api_server::InterestsSortKeySortValueOptionsResponse::Cors)
     }
 
     /// Test the liveness of the Ceramic node

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -870,4 +870,104 @@ where
             .await
             .or_else(|err| Ok(EventsEventIdGetResponse::InternalServerError(err)))
     }
+
+    /// cors
+    async fn debug_heap_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::DebugHeapOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::DebugHeapOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn events_event_id_options(
+        &self,
+        _event_id: String,
+        _context: &C,
+    ) -> Result<ceramic_api_server::EventsEventIdOptionsResponse, ApiError> {
+        Ok(
+            ceramic_api_server::EventsEventIdOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn events_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::EventsOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::EventsOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn experimental_events_sep_sep_value_options(
+        &self,
+        _sep: String,
+        _sep_value: String,
+        _context: &C,
+    ) -> Result<ceramic_api_server::ExperimentalEventsSepSepValueOptionsResponse, ApiError> {
+        Ok(
+            ceramic_api_server::ExperimentalEventsSepSepValueOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn experimental_interests_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::ExperimentalInterestsOptionsResponse, ApiError> {
+        Ok(
+            ceramic_api_server::ExperimentalInterestsOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn feed_events_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::FeedEventsOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::FeedEventsOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn feed_resume_token_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::FeedResumeTokenOptionsResponse, ApiError> {
+        Ok(
+            ceramic_api_server::FeedResumeTokenOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn interests_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::InterestsOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::InterestsOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn interests_sort_key_sort_value_options(
+        &self,
+        _sort_key: String,
+        _sort_value: String,
+        _context: &C,
+    ) -> Result<ceramic_api_server::InterestsSortKeySortValueOptionsResponse, ApiError> {
+        Ok(
+            ceramic_api_server::InterestsSortKeySortValueOptionsResponse::Cors)
+    }
+
+    /// Test the liveness of the Ceramic node
+
+    /// cors
+    async fn liveness_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::LivenessOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::LivenessOptionsResponse::Cors)
+    }
+
+    /// cors
+    async fn version_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::VersionOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::VersionOptionsResponse::Cors)
+    }
 }

--- a/one/src/http.rs
+++ b/one/src/http.rs
@@ -137,7 +137,7 @@ pub struct CorsService<T> {
     default_allow_origin: HeaderValue,
     allow_methods: HeaderValue,
     allow_headers: HeaderValue,
-    allowed_origins: HashSet<Vec<u8>>,
+    allowed_origins: Arc<HashSet<Vec<u8>>>,
     inner: T,
 }
 
@@ -147,7 +147,7 @@ impl<T> CorsService<T> {
         default_allow_origin: HeaderValue,
         allow_methods: HeaderValue,
         allow_headers: HeaderValue,
-        allowed_origins: HashSet<Vec<u8>>,
+        allowed_origins: Arc<HashSet<Vec<u8>>>,
     ) -> Self {
         Self {
             default_allow_origin,
@@ -207,7 +207,7 @@ where
 
 pub struct MakeCorsService<T> {
     inner: T,
-    origins: HashSet<Vec<u8>>,
+    origins: Arc<HashSet<Vec<u8>>>,
     default_allow_origin: HeaderValue,
     allow_methods: HeaderValue,
     allow_headers: HeaderValue,
@@ -217,10 +217,12 @@ impl<T> MakeCorsService<T> {
     /// Currently only the first value is used
     pub fn new(inner: T, origins: Vec<String>) -> Self {
         let default_allow_origin = origins.first().map(|o| o.as_bytes()).unwrap_or(b"*");
-        let origins = origins
-            .iter()
-            .map(|o| o.as_bytes().to_vec())
-            .collect::<HashSet<Vec<u8>>>();
+        let origins = Arc::new(
+            origins
+                .iter()
+                .map(|o| o.as_bytes().to_vec())
+                .collect::<HashSet<Vec<u8>>>(),
+        );
         Self {
             inner,
             origins,

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -147,6 +147,16 @@ struct DaemonOpts {
         env = "CERAMIC_ONE_IDLE_CONNS_TIMEOUT_MS"
     )]
     idle_conns_timeout_ms: u64,
+
+    /// Allowed CORS origins. Should include the transport e.g. https:// or http://.
+    #[arg(
+            long,
+            default_values_t = vec!["*".to_string()],
+            use_value_delimiter = true,
+            value_delimiter = ',',
+            env = "CERAMIC_ONE_CORS_ALLOW_ORIGINS"
+        )]
+    cors_allow_origins: Vec<String>,
 }
 
 #[derive(Args, Debug)]
@@ -519,6 +529,9 @@ impl Daemon {
             );
         let kubo_rpc_service =
             http::MakeMetricsService::new(kubo_rpc_service, http_metrics.clone());
+        let kubo_rpc_service =
+            http::MakeCorsService::new(kubo_rpc_service, opts.cors_allow_origins.clone());
+        let ceramic_service = http::MakeCorsService::new(ceramic_service, opts.cors_allow_origins);
         let ceramic_service = http::MakeMetricsService::new(ceramic_service, http_metrics);
 
         // Compose both services


### PR DESCRIPTION
Adds a cli flag `--cors-allow-origins` that defaults to `*` and supports a list. For example, running with `--cors-allow-origins "3box.io,localhost,https://ceramic.network"` and then going to https://ceramic.network and running `fetch('http://127.0.0.1:5101/ceramic/liveness')` it will resolve. Without the origin, you'll see an error. We currently require you to specify the transport as we only http at the moment and you may want an https front end.

This feels a bit clunky. The service trait gets a lot nicer in hyper 1.0 (or if using something like axum). It might be worth considering moving updating the open API generator to support 1.0, or move away from it if we're going to need more standard web server features.

```
❯ curl -v http://127.0.0.1:5101/ceramic/liveness
*   Trying 127.0.0.1:5101...
* Connected to 127.0.0.1 (127.0.0.1) port 5101
> GET /ceramic/liveness HTTP/1.1
> Host: 127.0.0.1:5101
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< x-span-id: 7e7b20c8-e293-4a74-9a33-54845f7a718b
< access-control-allow-origin: *
< access-control-allow-methods: POST, GET, OPTIONS, DELETE, PUT
< access-control-allow-headers: *
< content-length: 0
< date: Tue, 09 Jul 2024 22:31:35 GMT
<
* Connection #0 to host 127.0.0.1 left intact

❯ curl -v http://127.0.0.1:5101/ceramic/liveness
*   Trying 127.0.0.1:5101...
* Connected to 127.0.0.1 (127.0.0.1) port 5101
> GET /ceramic/liveness HTTP/1.1
> Host: 127.0.0.1:5101
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< x-span-id: 013e1748-9933-4956-916f-f3246a1f2257
< access-control-allow-origin: 3box.io
< access-control-allow-methods: POST, GET, OPTIONS, DELETE, PUT
< access-control-allow-headers: *
< content-length: 0
< date: Tue, 09 Jul 2024 22:33:34 GMT
<
* Connection #0 to host 127.0.0.1 left intact
```