### PR TITLE
feat: change default dir to current directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,6 @@ dependencies = [
  "expect-test",
  "futures",
  "git-version",
- "home",
  "hyper",
  "iroh-bitswap",
  "iroh-rpc-client",

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -26,7 +26,6 @@ cid.workspace = true
 clap.workspace = true
 futures.workspace = true
 git-version = "0.3"
-home = "0.5"
 hyper.workspace = true
 iroh-bitswap.workspace = true
 iroh-rpc-client.workspace = true

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -35,8 +35,13 @@ pub struct FromIpfsOpts {
     input_ipfs_path: PathBuf,
 
     /// Path to storage directory
-    #[clap(long, short, env = "CERAMIC_ONE_OUTPUT_STORE_PATH")]
-    output_store_path: Option<PathBuf>,
+    #[clap(
+        long,
+        short,
+        default_value = ".",
+        env = "CERAMIC_ONE_OUTPUT_STORE_PATH"
+    )]
+    output_store_path: PathBuf,
 
     /// Unique key used to find other Ceramic peers via the DHT
     #[arg(long, default_value = "testnet-clay", env = "CERAMIC_ONE_NETWORK")]


### PR DESCRIPTION
BREAKING CHANGE: Both the store and p2p key dirs now default to the current working directory instead of the home/.ceramic-one directory.

Generally this makes it less error prone when running multiple daemon on a single host as the naturally isolate from each other using their working directory. Running multiple daemons locally is a common task in order to experiment with the p2p nature of ceramic-one.

This is a breaking change. If you previously relied on the home directory default you must now explicitly pass in the home directory like so:

    ceramic-one daemon -s ~/.ceramic-one -p ~/.ceramic-one