### PR TITLE
feat: add debug to all event types

### DIFF
--- a/event/Cargo.toml
+++ b/event/Cargo.toml
@@ -17,6 +17,7 @@ cid.workspace = true
 ipld-core.workspace = true
 iroh-car.workspace = true
 multihash-codetable.workspace = true
+multibase.workspace = true
 serde.workspace = true
 serde_ipld_dagcbor.workspace = true
 serde_json.workspace = true

--- a/event/src/bytes.rs
+++ b/event/src/bytes.rs
@@ -1,13 +1,23 @@
 //! Thin wrapper on a Vec<u8> that correctly serializes and deserializes as bytes as opposed to a
 //! sequence of u8 integers.
+use std::fmt::Debug;
+
 use serde::{
     de::{self, Visitor},
     Deserialize, Serialize,
 };
 
 /// Sequence of byte values.
-#[derive(Clone, PartialEq, Eq, Default, Debug)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct Bytes(Vec<u8>);
+
+impl Debug for Bytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Bytes")
+            .field(&multibase::encode(multibase::Base::Base64Url, &self.0))
+            .finish()
+    }
+}
 
 impl Bytes {
     /// Return a reference to the bytes

--- a/event/src/bytes.rs
+++ b/event/src/bytes.rs
@@ -14,7 +14,7 @@ pub struct Bytes(Vec<u8>);
 impl Debug for Bytes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Bytes")
-            .field(&multibase::encode(multibase::Base::Base64Url, &self.0))
+            .field(&multibase::encode(multibase::Base::Base16Lower, &self.0))
             .finish()
     }
 }

--- a/event/src/unvalidated/event.rs
+++ b/event/src/unvalidated/event.rs
@@ -5,13 +5,14 @@ use cid::Cid;
 use ipld_core::ipld::Ipld;
 use iroh_car::{CarHeader, CarReader, CarWriter};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 use tokio::io::AsyncRead;
 use tracing::debug;
 
 use super::{cid_from_dag_cbor, init, signed};
 
 /// Materialized Ceramic Event where internal structure is accessible.
+#[derive(Debug)]
 pub enum Event<D> {
     /// Time event in a stream
     // NOTE: TimeEvent has several CIDs so it's a relatively large struct (~312 bytes according to
@@ -292,12 +293,23 @@ impl TimeEvent {
     }
 }
 /// Raw Time Event as it is encoded in the protocol.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct RawTimeEvent {
     id: Cid,
     prev: Cid,
     proof: Cid,
     path: String,
+}
+
+impl Debug for RawTimeEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RawTimeEvent")
+            .field("id", &self.id.to_string())
+            .field("prev", &self.prev.to_string())
+            .field("proof", &self.proof.to_string())
+            .field("path", &self.path)
+            .finish()
+    }
 }
 
 impl RawTimeEvent {
@@ -332,13 +344,24 @@ impl RawTimeEvent {
     }
 }
 /// Proof data
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Proof {
     chain_id: String,
     root: Cid,
     tx_hash: Cid,
     tx_type: String,
+}
+
+impl Debug for Proof {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Proof")
+            .field("chain_id", &self.chain_id)
+            .field("root", &self.root.to_string())
+            .field("tx_hash", &self.tx_hash.to_string())
+            .field("tx_type", &self.tx_type)
+            .finish()
+    }
 }
 
 impl Proof {

--- a/event/src/unvalidated/payload/data.rs
+++ b/event/src/unvalidated/payload/data.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use cid::Cid;
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +11,17 @@ pub struct Payload<D> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     header: Option<Header>,
     data: D,
+}
+
+impl<D: Debug> Debug for Payload<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Payload")
+            .field("id", &self.id.to_string())
+            .field("prev", &self.prev.to_string())
+            .field("header", &self.header)
+            .field("data", &self.data)
+            .finish()
+    }
 }
 
 impl<D> Payload<D> {
@@ -44,7 +57,7 @@ impl<D> Payload<D> {
 }
 
 /// Headers for a data event
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Header {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/event/src/unvalidated/payload/mod.rs
+++ b/event/src/unvalidated/payload/mod.rs
@@ -6,7 +6,7 @@ pub mod init;
 use serde::{Deserialize, Serialize};
 
 /// Payload of a signed event
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 // Note untagged variants a deserialized in order and the first one that succeeds is returned.
 // Therefore the order of the variants is important to be most specific to least specific
 #[serde(untagged)]

--- a/event/src/unvalidated/signed/mod.rs
+++ b/event/src/unvalidated/signed/mod.rs
@@ -1,6 +1,8 @@
 //! Unvalidated signed events.
 pub mod cacao;
 
+use std::fmt::Debug;
+
 use crate::bytes::Bytes;
 use crate::unvalidated::Payload;
 use base64::Engine;
@@ -23,6 +25,24 @@ pub struct Event<D> {
     payload: Payload<D>,
     payload_cid: Cid,
     capability: Option<(Cid, Capability)>,
+}
+
+impl<D: Debug> Debug for Event<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Event")
+            .field("envelope", &self.envelope)
+            .field("envelope_cid", &self.envelope_cid.to_string())
+            .field("payload", &self.payload)
+            .field("payload_cid", &self.payload_cid.to_string())
+            .field(
+                "capability",
+                &self
+                    .capability
+                    .as_ref()
+                    .map(|(cid, cap)| (cid.to_string(), cap)),
+            )
+            .finish()
+    }
 }
 
 impl<D: serde::Serialize> Event<D> {


### PR DESCRIPTION
Adds Debug implementation for Event type and ensures CIDs are printed as strings instead of deconstruction of the CID struct