### PR TITLE
feat: workflow update deb repo

### DIFF
--- a/.github/workflows/update-deb-repo.yml
+++ b/.github/workflows/update-deb-repo.yml
@@ -1,0 +1,39 @@
+name: Update Deb Repo
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  update-deb-repo:
+    name: Update Deb Repo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout Deb Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ceramicnetwork/repo
+          token: ${{ secrets.GH_TOKEN_PAT }}
+      - name: Get Latest Release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view --json tagName,assets > release.json
+          echo "VERSION=$(jq -r '.tagName' release.json)" >> $GITHUB_OUTPUT
+          gh release download -p ceramic-one_x86_64-unknown-linux-gnu.tar.gz
+          tar xvf ceramic-one_x86_64-unknown-linux-gnu.tar.gz
+      - name: Update Deb Repo
+        working-directory: repo
+        run: |
+          reprepro --basedir . includedeb stable ../ceramic-one.deb
+      - name: Commit and Push changes
+        working-directory: repo
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git diff
+          git add .
+          git commit -m "chore: update ceramic-one deb to ${{ steps.release.outputs.VERSION }}"
+          git push

--- a/.github/workflows/update-deb-repo.yml
+++ b/.github/workflows/update-deb-repo.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout Deb Repo
-        uses: actions/checkout@v4
-        with:
-          repository: ceramicnetwork/repo
-          token: ${{ secrets.GH_TOKEN_PAT }}
       - name: Get Latest Release
         id: release
         env:
@@ -24,10 +19,28 @@ jobs:
           echo "VERSION=$(jq -r '.tagName' release.json)" >> $GITHUB_OUTPUT
           gh release download -p ceramic-one_x86_64-unknown-linux-gnu.tar.gz
           tar xvf ceramic-one_x86_64-unknown-linux-gnu.tar.gz
+
+
+      - name: Set up GPG
+        run: |
+          mkdir -p /tmp/gnupg
+          echo "${{ secrets.REPO_GPG_PRIVATE_KEY }}" | gpg --homedir /tmp/gnupg --import
+          echo "allow-loopback-pinentry" >> /tmp/gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> /tmp/gnupg/gpg.conf
+      - name: Install Dependencies
+        run: sudo apt-get update && sudo apt-get install -y reprepro
+
+      - name: Checkout Deb Repo
+        uses: actions/checkout@v4
+        with:
+          repository: ceramicnetwork/repo
+          token: ${{ secrets.GH_TOKEN_PAT }}
       - name: Update Deb Repo
         working-directory: repo
+        env:
+          GPG_PASSPHRASE: ${{ secrets.REPO_GPG_PASSPHRASE }}
         run: |
-          reprepro --basedir . includedeb stable ../ceramic-one.deb
+          GNUPGHOME=/tmp/gnupg reprepro --basedir . includedeb stable ../ceramic-one.deb
       - name: Commit and Push changes
         working-directory: repo
         run: |

--- a/.github/workflows/update-deb-repo.yml
+++ b/.github/workflows/update-deb-repo.yml
@@ -1,6 +1,7 @@
 name: Update Deb Repo
 
 on:
+  workflow_dispatch:
   release:
     types: [released]
 

--- a/.github/workflows/update-deb-repo.yml
+++ b/.github/workflows/update-deb-repo.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Checkout Deb Repo
         uses: actions/checkout@v4
         with:
-          repository: ceramicnetwork/repo
+          repository: ceramicnetwork/debian-repo
           token: ${{ secrets.GH_TOKEN_PAT }}
       - name: Update Deb Repo
         working-directory: repo


### PR DESCRIPTION
Wanted to simplify the node update process so that they no longer needed Ansible.

A new repo for the debian package was created https://github.com/ceramicnetwork/repo

This workflow publishes rust-ceramic releases to that debian repo.

(need to merge to make sure the gpg stuff works)