### PR TITLE
feat: add option for external swarm addresses

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -76,6 +76,16 @@ struct DaemonOpts {
     )]
     swarm_addresses: Vec<String>,
 
+    /// External address of the p2p swarm.
+    /// These addressed are advertised to remote peers in order to dial the local peer.
+    #[arg(
+        long,
+        use_value_delimiter = true,
+        value_delimiter = ',',
+        env = "CERAMIC_ONE_EXTERNAL_SWARM_ADDRESSES"
+    )]
+    external_swarm_addresses: Vec<String>,
+
     /// Extra addresses of peers that participate in the Ceramic network.
     /// A best-effort attempt will be made to maintain a connection to these addresses.
     #[arg(
@@ -417,6 +427,11 @@ impl Daemon {
                         .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?,
                 )
                 .collect(),
+            external_multiaddrs: opts
+                .external_swarm_addresses
+                .iter()
+                .map(|addr| addr.parse())
+                .collect::<Result<Vec<Multiaddr>, multiaddr::Error>>()?,
             listening_multiaddrs: opts
                 .swarm_addresses
                 .iter()

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -165,7 +165,6 @@ where
             metrics.clone(),
         )
         .await?;
-        info!("iroh-p2p peerid: {}", swarm.local_peer_id());
 
         for addr in &libp2p_config.external_multiaddrs {
             swarm.add_external_address(addr.clone());


### PR DESCRIPTION
External swarm addresses are useful when ceramic-one is run behind a NAT. This allows explicit configuration for how remote nodes should dial the local peer.