### PR TITLE
fix: disable libp2p tcp port reuse

### DIFF
--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -22,7 +22,9 @@ where
     let builder = SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_tcp(
-            tcp::Config::default().port_reuse(true),
+            // we've encountered errors when restarting the binary failing to bind with port_reuse(true)
+            // so we use the default which has it disabled and use transient ports for outgoing connections
+            tcp::Config::default(),
             noise::Config::new,
             yamux::Config::default,
         )?


### PR DESCRIPTION
This was causing errors opening outgoing connections on restarts (easily noticeable running from js-ceramic and stopping/restarting the daemon repeatedly). It doesn't seem to add any benefits for our basic use so we'll default to opening outgoing connections using transient ports, which is the default behavior.

```
2024-07-16T17:46:12.102446Z DEBUG libp2p_tcp: dialing address, address: 34.27.246.129:4101
    at /Users/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libp2p-tcp-0.41.0/src/lib.rs:475
    in libp2p_swarm::Transport::dial with address=/dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs

  2024-07-16T17:46:12.102747Z TRACE libp2p_tcp: Binding dial socket to listen socket address, address: 0.0.0.0:4101
    at /Users/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libp2p-tcp-0.41.0/src/lib.rs:482
    in libp2p_swarm::Transport::dial with address=/dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs

  2024-07-16T17:46:12.103477Z  WARN ceramic_p2p::behaviour::ceramic_peer_manager: dial failed, redial ceramic peer, multiaddr: /dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs
    at p2p/src/behaviour/ceramic_peer_manager.rs:126
    in libp2p_swarm::Swarm::poll
    in ceramic_p2p::node::run

  2024-07-16T17:46:12.103640Z DEBUG libp2p_swarm: Connection attempt to peer failed with Transport([("/dns4/bootstrap-tnet-rust-ceramic-2.3box.io/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs", Other(Custom { kind: Other, error: Other(Right(Transport(Left(Left(Left(Os { code: 48, kind: AddrInUse, message: "Address already in use" })))))) }))])., peer: 12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs
    at /Users/david/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libp2p-swarm-0.44.2/src/lib.rs:843
    in libp2p_swarm::Swarm::poll
    in ceramic_p2p::node::run
````