### PR TITLE
feat: expose current ceramic network via api

### DIFF
--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -13,6 +13,7 @@ docs/FeedResumeTokenGet200Response.md
 docs/Interest.md
 docs/InterestsGet.md
 docs/InterestsGetInterestsInner.md
+docs/NetworkInfo.md
 docs/Version.md
 docs/default_api.md
 examples/ca.pem

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.29.0
-- Build date: 2024-07-22T20:00:53.129668076Z[Etc/UTC]
+- Build date: 2024-07-25T17:06:13.915918-06:00[America/Denver]
 
 
 
@@ -80,6 +80,8 @@ cargo run --example client InterestsSortKeySortValueOptions
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
 cargo run --example client LivenessOptions
+cargo run --example client NetworkGet
+cargo run --example client NetworkOptions
 cargo run --example client VersionGet
 cargo run --example client VersionOptions
 cargo run --example client VersionPost
@@ -136,6 +138,8 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /liveness | cors
+[****](docs/default_api.md#) | **GET** /network | Get info about the Ceramic network the node is connected to
+[****](docs/default_api.md#) | **OPTIONS** /network | cors
 [****](docs/default_api.md#) | **GET** /version | Get the version of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /version | cors
 [****](docs/default_api.md#) | **POST** /version | Get the version of the Ceramic node
@@ -153,6 +157,7 @@ Method | HTTP request | Description
  - [Interest](docs/Interest.md)
  - [InterestsGet](docs/InterestsGet.md)
  - [InterestsGetInterestsInner](docs/InterestsGetInterestsInner.md)
+ - [NetworkInfo](docs/NetworkInfo.md)
  - [Version](docs/Version.md)
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.29.0
-- Build date: 2024-07-25T17:06:13.915918-06:00[America/Denver]
+- Build date: 2024-07-25T17:06:40.519231-06:00[America/Denver]
 
 
 
@@ -62,6 +62,8 @@ cargo run --example server
 To run a client, follow one of the following simple steps:
 
 ```
+cargo run --example client ConfigNetworkGet
+cargo run --example client ConfigNetworkOptions
 cargo run --example client DebugHeapGet
 cargo run --example client DebugHeapOptions
 cargo run --example client EventsEventIdGet
@@ -80,8 +82,6 @@ cargo run --example client InterestsSortKeySortValueOptions
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
 cargo run --example client LivenessOptions
-cargo run --example client NetworkGet
-cargo run --example client NetworkOptions
 cargo run --example client VersionGet
 cargo run --example client VersionOptions
 cargo run --example client VersionPost
@@ -118,6 +118,8 @@ All URIs are relative to */ceramic*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[****](docs/default_api.md#) | **GET** /config/network | Get info about the Ceramic network the node is connected to
+[****](docs/default_api.md#) | **OPTIONS** /config/network | cors
 [****](docs/default_api.md#) | **GET** /debug/heap | Get the heap statistics of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /debug/heap | cors
 [****](docs/default_api.md#) | **GET** /events/{event_id} | Get event data
@@ -138,8 +140,6 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /liveness | cors
-[****](docs/default_api.md#) | **GET** /network | Get info about the Ceramic network the node is connected to
-[****](docs/default_api.md#) | **OPTIONS** /network | cors
 [****](docs/default_api.md#) | **GET** /version | Get the version of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /version | cors
 [****](docs/default_api.md#) | **POST** /version | Get the version of the Ceramic node

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -269,6 +269,21 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Register interest for a sort key
+  /network:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NetworkInfo'
+          description: success
+      summary: Get info about the Ceramic network the node is connected to
+    options:
+      responses:
+        "200":
+          description: cors
+      summary: cors
   /experimental/interests:
     get:
       responses:
@@ -644,6 +659,18 @@ components:
       - sep
       - sepValue
       title: A recon interest
+      type: object
+    NetworkInfo:
+      description: Ceramic network information
+      example:
+        name: name
+      properties:
+        name:
+          description: Name of the Ceramic network
+          type: string
+      required:
+      - name
+      title: Information about the Ceramic network
       type: object
     _feed_resumeToken_get_200_response:
       example:

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -269,7 +269,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
           description: Internal server error
       summary: Register interest for a sort key
-  /network:
+  /config/network:
     get:
       responses:
         "200":

--- a/api-server/docs/NetworkInfo.md
+++ b/api-server/docs/NetworkInfo.md
@@ -1,0 +1,10 @@
+# NetworkInfo
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**name** | **String** | Name of the Ceramic network | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -4,6 +4,8 @@ All URIs are relative to */ceramic*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+****](default_api.md#) | **GET** /config/network | Get info about the Ceramic network the node is connected to
+****](default_api.md#) | **OPTIONS** /config/network | cors
 ****](default_api.md#) | **GET** /debug/heap | Get the heap statistics of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /debug/heap | cors
 ****](default_api.md#) | **GET** /events/{event_id} | Get event data
@@ -24,12 +26,54 @@ Method | HTTP request | Description
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /liveness | cors
-****](default_api.md#) | **GET** /network | Get info about the Ceramic network the node is connected to
-****](default_api.md#) | **OPTIONS** /network | cors
 ****](default_api.md#) | **GET** /version | Get the version of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /version | cors
 ****](default_api.md#) | **POST** /version | Get the version of the Ceramic node
 
+
+# ****
+> models::NetworkInfo ()
+Get info about the Ceramic network the node is connected to
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**models::NetworkInfo**](NetworkInfo.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
 > swagger::ByteArray ()
@@ -500,50 +544,6 @@ This endpoint does not need any parameter.
 ### Return type
 
  (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: application/json
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# ****
-> ()
-cors
-
-### Required Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
- (empty response body)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
- - **Content-Type**: Not defined
- - **Accept**: Not defined
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
-
-# ****
-> models::NetworkInfo ()
-Get info about the Ceramic network the node is connected to
-
-### Required Parameters
-This endpoint does not need any parameter.
-
-### Return type
-
-[**models::NetworkInfo**](NetworkInfo.md)
 
 ### Authorization
 

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -24,6 +24,8 @@ Method | HTTP request | Description
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /liveness | cors
+****](default_api.md#) | **GET** /network | Get info about the Ceramic network the node is connected to
+****](default_api.md#) | **OPTIONS** /network | cors
 ****](default_api.md#) | **GET** /version | Get the version of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /version | cors
 ****](default_api.md#) | **POST** /version | Get the version of the Ceramic node
@@ -498,6 +500,50 @@ This endpoint does not need any parameter.
 ### Return type
 
  (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> ()
+cors
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::NetworkInfo ()
+Get info about the Ceramic network the node is connected to
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**models::NetworkInfo**](NetworkInfo.md)
 
 ### Authorization
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -10,7 +10,8 @@ use ceramic_api_server::{
     FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
     InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
+    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -58,6 +59,8 @@ fn main() {
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
                     "LivenessOptions",
+                    "NetworkGet",
+                    "NetworkOptions",
                     "VersionGet",
                     "VersionOptions",
                     "VersionPost",
@@ -290,6 +293,22 @@ fn main() {
         }
         Some("LivenessOptions") => {
             let result = rt.block_on(client.liveness_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("NetworkGet") => {
+            let result = rt.block_on(client.network_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("NetworkOptions") => {
+            let result = rt.block_on(client.network_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -2,16 +2,15 @@
 
 #[allow(unused_imports)]
 use ceramic_api_server::{
-    models, Api, ApiNoContext, Client, ContextWrapperExt, DebugHeapGetResponse,
-    DebugHeapOptionsResponse, EventsEventIdGetResponse, EventsEventIdOptionsResponse,
-    EventsOptionsResponse, EventsPostResponse, ExperimentalEventsSepSepValueGetResponse,
-    ExperimentalEventsSepSepValueOptionsResponse, ExperimentalInterestsGetResponse,
-    ExperimentalInterestsOptionsResponse, FeedEventsGetResponse, FeedEventsOptionsResponse,
-    FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
-    InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    models, Api, ApiNoContext, Client, ConfigNetworkGetResponse, ConfigNetworkOptionsResponse,
+    ContextWrapperExt, DebugHeapGetResponse, DebugHeapOptionsResponse, EventsEventIdGetResponse,
+    EventsEventIdOptionsResponse, EventsOptionsResponse, EventsPostResponse,
+    ExperimentalEventsSepSepValueGetResponse, ExperimentalEventsSepSepValueOptionsResponse,
+    ExperimentalInterestsGetResponse, ExperimentalInterestsOptionsResponse, FeedEventsGetResponse,
+    FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
+    InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
-    VersionPostResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -41,6 +40,8 @@ fn main() {
             Arg::with_name("operation")
                 .help("Sets the operation to run")
                 .possible_values(&[
+                    "ConfigNetworkGet",
+                    "ConfigNetworkOptions",
                     "DebugHeapGet",
                     "DebugHeapOptions",
                     "EventsEventIdGet",
@@ -59,8 +60,6 @@ fn main() {
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
                     "LivenessOptions",
-                    "NetworkGet",
-                    "NetworkOptions",
                     "VersionGet",
                     "VersionOptions",
                     "VersionPost",
@@ -119,6 +118,22 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().unwrap();
 
     match matches.value_of("operation") {
+        Some("ConfigNetworkGet") => {
+            let result = rt.block_on(client.config_network_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("ConfigNetworkOptions") => {
+            let result = rt.block_on(client.config_network_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
         Some("DebugHeapGet") => {
             let result = rt.block_on(client.debug_heap_get());
             info!(
@@ -293,22 +308,6 @@ fn main() {
         }
         Some("LivenessOptions") => {
             let result = rt.block_on(client.liveness_options());
-            info!(
-                "{:?} (X-Span-ID: {:?})",
-                result,
-                (client.context() as &dyn Has<XSpanIdString>).get().clone()
-            );
-        }
-        Some("NetworkGet") => {
-            let result = rt.block_on(client.network_get());
-            info!(
-                "{:?} (X-Span-ID: {:?})",
-                result,
-                (client.context() as &dyn Has<XSpanIdString>).get().clone()
-            );
-        }
-        Some("NetworkOptions") => {
-            let result = rt.block_on(client.network_options());
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -101,15 +101,15 @@ impl<C> Server<C> {
 
 use ceramic_api_server::server::MakeService;
 use ceramic_api_server::{
-    Api, DebugHeapGetResponse, DebugHeapOptionsResponse, EventsEventIdGetResponse,
-    EventsEventIdOptionsResponse, EventsOptionsResponse, EventsPostResponse,
-    ExperimentalEventsSepSepValueGetResponse, ExperimentalEventsSepSepValueOptionsResponse,
-    ExperimentalInterestsGetResponse, ExperimentalInterestsOptionsResponse, FeedEventsGetResponse,
-    FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
-    InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    Api, ConfigNetworkGetResponse, ConfigNetworkOptionsResponse, DebugHeapGetResponse,
+    DebugHeapOptionsResponse, EventsEventIdGetResponse, EventsEventIdOptionsResponse,
+    EventsOptionsResponse, EventsPostResponse, ExperimentalEventsSepSepValueGetResponse,
+    ExperimentalEventsSepSepValueOptionsResponse, ExperimentalInterestsGetResponse,
+    ExperimentalInterestsOptionsResponse, FeedEventsGetResponse, FeedEventsOptionsResponse,
+    FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
+    InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
-    VersionPostResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -119,6 +119,27 @@ impl<C> Api<C> for Server<C>
 where
     C: Has<XSpanIdString> + Send + Sync,
 {
+    /// Get info about the Ceramic network the node is connected to
+    async fn config_network_get(&self, context: &C) -> Result<ConfigNetworkGetResponse, ApiError> {
+        info!(
+            "config_network_get() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn config_network_options(
+        &self,
+        context: &C,
+    ) -> Result<ConfigNetworkOptionsResponse, ApiError> {
+        info!(
+            "config_network_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
     /// Get the heap statistics of the Ceramic node
     async fn debug_heap_get(&self, context: &C) -> Result<DebugHeapGetResponse, ApiError> {
         info!(
@@ -364,21 +385,6 @@ where
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
         info!(
             "liveness_options() - X-Span-ID: {:?}",
-            context.get().0.clone()
-        );
-        Err(ApiError("Generic failure".into()))
-    }
-
-    /// Get info about the Ceramic network the node is connected to
-    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError> {
-        info!("network_get() - X-Span-ID: {:?}", context.get().0.clone());
-        Err(ApiError("Generic failure".into()))
-    }
-
-    /// cors
-    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError> {
-        info!(
-            "network_options() - X-Span-ID: {:?}",
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -108,7 +108,8 @@ use ceramic_api_server::{
     FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
     InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
+    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -363,6 +364,21 @@ where
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
         info!(
             "liveness_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError> {
+        info!("network_get() - X-Span-ID: {:?}", context.get().0.clone());
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError> {
+        info!(
+            "network_options() - X-Span-ID: {:?}",
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -49,7 +49,8 @@ use crate::{
     FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
     InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
+    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -2222,6 +2223,154 @@ where
 
         match response.status().as_u16() {
             200 => Ok(LivenessOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/network", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::NetworkInfo>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(NetworkGetResponse::Success(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/network", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(NetworkOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -42,15 +42,15 @@ const FRAGMENT_ENCODE_SET: &AsciiSet = &percent_encoding::CONTROLS
 const ID_ENCODE_SET: &AsciiSet = &FRAGMENT_ENCODE_SET.add(b'|');
 
 use crate::{
-    Api, DebugHeapGetResponse, DebugHeapOptionsResponse, EventsEventIdGetResponse,
-    EventsEventIdOptionsResponse, EventsOptionsResponse, EventsPostResponse,
-    ExperimentalEventsSepSepValueGetResponse, ExperimentalEventsSepSepValueOptionsResponse,
-    ExperimentalInterestsGetResponse, ExperimentalInterestsOptionsResponse, FeedEventsGetResponse,
-    FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
-    InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
+    Api, ConfigNetworkGetResponse, ConfigNetworkOptionsResponse, DebugHeapGetResponse,
+    DebugHeapOptionsResponse, EventsEventIdGetResponse, EventsEventIdOptionsResponse,
+    EventsOptionsResponse, EventsPostResponse, ExperimentalEventsSepSepValueGetResponse,
+    ExperimentalEventsSepSepValueOptionsResponse, ExperimentalInterestsGetResponse,
+    ExperimentalInterestsOptionsResponse, FeedEventsGetResponse, FeedEventsOptionsResponse,
+    FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
+    InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    NetworkGetResponse, NetworkOptionsResponse, VersionGetResponse, VersionOptionsResponse,
-    VersionPostResponse,
+    VersionGetResponse, VersionOptionsResponse, VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -394,6 +394,157 @@ where
             Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
             Poll::Ready(Ok(o)) => Poll::Ready(Ok(o)),
             Poll::Pending => Poll::Pending,
+        }
+    }
+
+    async fn config_network_get(&self, context: &C) -> Result<ConfigNetworkGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/config/network", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::NetworkInfo>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(ConfigNetworkGetResponse::Success(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn config_network_options(
+        &self,
+        context: &C,
+    ) -> Result<ConfigNetworkOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/config/network", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(ConfigNetworkOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
         }
     }
 
@@ -2223,154 +2374,6 @@ where
 
         match response.status().as_u16() {
             200 => Ok(LivenessOptionsResponse::Cors),
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body().take(100).into_raw().await;
-                Err(ApiError(format!(
-                    "Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError> {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!("{}/ceramic/network", self.base_path);
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("GET")
-            .uri(uri)
-            .body(Body::empty())
-        {
-            Ok(req) => req,
-            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(
-            HeaderName::from_static("x-span-id"),
-            match header {
-                Ok(h) => h,
-                Err(e) => {
-                    return Err(ApiError(format!(
-                        "Unable to create X-Span ID header value: {}",
-                        e
-                    )))
-                }
-            },
-        );
-
-        let response = client_service
-            .call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e)))
-            .await?;
-
-        match response.status().as_u16() {
-            200 => {
-                let body = response.into_body();
-                let body = body
-                    .into_raw()
-                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
-                    .await?;
-                let body = str::from_utf8(&body)
-                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
-                let body = serde_json::from_str::<models::NetworkInfo>(body).map_err(|e| {
-                    ApiError(format!("Response body did not match the schema: {}", e))
-                })?;
-                Ok(NetworkGetResponse::Success(body))
-            }
-            code => {
-                let headers = response.headers().clone();
-                let body = response.into_body().take(100).into_raw().await;
-                Err(ApiError(format!(
-                    "Unexpected response code {}:\n{:?}\n\n{}",
-                    code,
-                    headers,
-                    match body {
-                        Ok(body) => match String::from_utf8(body) {
-                            Ok(body) => body,
-                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
-                        },
-                        Err(e) => format!("<Failed to read body: {}>", e),
-                    }
-                )))
-            }
-        }
-    }
-
-    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError> {
-        let mut client_service = self.client_service.clone();
-        let mut uri = format!("{}/ceramic/network", self.base_path);
-
-        // Query parameters
-        let query_string = {
-            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
-            query_string.finish()
-        };
-        if !query_string.is_empty() {
-            uri += "?";
-            uri += &query_string;
-        }
-
-        let uri = match Uri::from_str(&uri) {
-            Ok(uri) => uri,
-            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
-        };
-
-        let mut request = match Request::builder()
-            .method("OPTIONS")
-            .uri(uri)
-            .body(Body::empty())
-        {
-            Ok(req) => req,
-            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
-        };
-
-        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
-        request.headers_mut().insert(
-            HeaderName::from_static("x-span-id"),
-            match header {
-                Ok(h) => h,
-                Err(e) => {
-                    return Err(ApiError(format!(
-                        "Unable to create X-Span ID header value: {}",
-                        e
-                    )))
-                }
-            },
-        );
-
-        let response = client_service
-            .call((request, context.clone()))
-            .map_err(|e| ApiError(format!("No response received: {}", e)))
-            .await?;
-
-        match response.status().as_u16() {
-            200 => Ok(NetworkOptionsResponse::Cors),
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -193,6 +193,18 @@ pub enum LivenessOptionsResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum NetworkGetResponse {
+    /// success
+    Success(models::NetworkInfo),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum NetworkOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum VersionGetResponse {
     /// success
@@ -347,6 +359,12 @@ pub trait Api<C: Send + Sync> {
     /// cors
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError>;
 
+    /// Get info about the Ceramic network the node is connected to
+    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError>;
+
+    /// cors
+    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError>;
+
     /// Get the version of the Ceramic node
     async fn version_get(&self, context: &C) -> Result<VersionGetResponse, ApiError>;
 
@@ -469,6 +487,12 @@ pub trait ApiNoContext<C: Send + Sync> {
 
     /// cors
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError>;
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn network_get(&self) -> Result<NetworkGetResponse, ApiError>;
+
+    /// cors
+    async fn network_options(&self) -> Result<NetworkOptionsResponse, ApiError>;
 
     /// Get the version of the Ceramic node
     async fn version_get(&self) -> Result<VersionGetResponse, ApiError>;
@@ -677,6 +701,18 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError> {
         let context = self.context().clone();
         self.api().liveness_options(&context).await
+    }
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn network_get(&self) -> Result<NetworkGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().network_get(&context).await
+    }
+
+    /// cors
+    async fn network_options(&self) -> Result<NetworkOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().network_options(&context).await
     }
 
     /// Get the version of the Ceramic node

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -23,6 +23,18 @@ pub const BASE_PATH: &str = "/ceramic";
 pub const API_VERSION: &str = "0.29.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum ConfigNetworkGetResponse {
+    /// success
+    Success(models::NetworkInfo),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum ConfigNetworkOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum DebugHeapGetResponse {
     /// success
@@ -193,18 +205,6 @@ pub enum LivenessOptionsResponse {
 }
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum NetworkGetResponse {
-    /// success
-    Success(models::NetworkInfo),
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub enum NetworkOptionsResponse {
-    /// cors
-    Cors,
-}
-
-#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 pub enum VersionGetResponse {
     /// success
@@ -238,6 +238,15 @@ pub trait Api<C: Send + Sync> {
     ) -> Poll<Result<(), Box<dyn Error + Send + Sync + 'static>>> {
         Poll::Ready(Ok(()))
     }
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn config_network_get(&self, context: &C) -> Result<ConfigNetworkGetResponse, ApiError>;
+
+    /// cors
+    async fn config_network_options(
+        &self,
+        context: &C,
+    ) -> Result<ConfigNetworkOptionsResponse, ApiError>;
 
     /// Get the heap statistics of the Ceramic node
     async fn debug_heap_get(&self, context: &C) -> Result<DebugHeapGetResponse, ApiError>;
@@ -359,12 +368,6 @@ pub trait Api<C: Send + Sync> {
     /// cors
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError>;
 
-    /// Get info about the Ceramic network the node is connected to
-    async fn network_get(&self, context: &C) -> Result<NetworkGetResponse, ApiError>;
-
-    /// cors
-    async fn network_options(&self, context: &C) -> Result<NetworkOptionsResponse, ApiError>;
-
     /// Get the version of the Ceramic node
     async fn version_get(&self, context: &C) -> Result<VersionGetResponse, ApiError>;
 
@@ -385,6 +388,12 @@ pub trait ApiNoContext<C: Send + Sync> {
     ) -> Poll<Result<(), Box<dyn Error + Send + Sync + 'static>>>;
 
     fn context(&self) -> &C;
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn config_network_get(&self) -> Result<ConfigNetworkGetResponse, ApiError>;
+
+    /// cors
+    async fn config_network_options(&self) -> Result<ConfigNetworkOptionsResponse, ApiError>;
 
     /// Get the heap statistics of the Ceramic node
     async fn debug_heap_get(&self) -> Result<DebugHeapGetResponse, ApiError>;
@@ -488,12 +497,6 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// cors
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError>;
 
-    /// Get info about the Ceramic network the node is connected to
-    async fn network_get(&self) -> Result<NetworkGetResponse, ApiError>;
-
-    /// cors
-    async fn network_options(&self) -> Result<NetworkOptionsResponse, ApiError>;
-
     /// Get the version of the Ceramic node
     async fn version_get(&self) -> Result<VersionGetResponse, ApiError>;
 
@@ -527,6 +530,18 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
 
     fn context(&self) -> &C {
         ContextWrapper::context(self)
+    }
+
+    /// Get info about the Ceramic network the node is connected to
+    async fn config_network_get(&self) -> Result<ConfigNetworkGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().config_network_get(&context).await
+    }
+
+    /// cors
+    async fn config_network_options(&self) -> Result<ConfigNetworkOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().config_network_options(&context).await
     }
 
     /// Get the heap statistics of the Ceramic node
@@ -701,18 +716,6 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError> {
         let context = self.context().clone();
         self.api().liveness_options(&context).await
-    }
-
-    /// Get info about the Ceramic network the node is connected to
-    async fn network_get(&self) -> Result<NetworkGetResponse, ApiError> {
-        let context = self.context().clone();
-        self.api().network_get(&context).await
-    }
-
-    /// cors
-    async fn network_options(&self) -> Result<NetworkOptionsResponse, ApiError> {
-        let context = self.context().clone();
-        self.api().network_options(&context).await
     }
 
     /// Get the version of the Ceramic node

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -1480,6 +1480,139 @@ impl std::convert::TryFrom<hyper::header::HeaderValue>
     }
 }
 
+/// Ceramic network information
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct NetworkInfo {
+    /// Name of the Ceramic network
+    #[serde(rename = "name")]
+    pub name: String,
+}
+
+impl NetworkInfo {
+    #[allow(clippy::new_without_default)]
+    pub fn new(name: String) -> NetworkInfo {
+        NetworkInfo { name }
+    }
+}
+
+/// Converts the NetworkInfo value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::string::ToString for NetworkInfo {
+    fn to_string(&self) -> String {
+        let params: Vec<Option<String>> =
+            vec![Some("name".to_string()), Some(self.name.to_string())];
+
+        params.into_iter().flatten().collect::<Vec<_>>().join(",")
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a NetworkInfo value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for NetworkInfo {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub name: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing NetworkInfo".to_string(),
+                    )
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "name" => intermediate_rep.name.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing NetworkInfo".to_string(),
+                        )
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(NetworkInfo {
+            name: intermediate_rep
+                .name
+                .into_iter()
+                .next()
+                .ok_or_else(|| "name missing in NetworkInfo".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<NetworkInfo> and hyper::header::HeaderValue
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<header::IntoHeaderValue<NetworkInfo>> for hyper::header::HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<NetworkInfo>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match hyper::header::HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Invalid header value for NetworkInfo - value: {} is invalid {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
+#[cfg(any(feature = "client", feature = "server"))]
+impl std::convert::TryFrom<hyper::header::HeaderValue> for header::IntoHeaderValue<NetworkInfo> {
+    type Error = String;
+
+    fn try_from(hdr_value: hyper::header::HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <NetworkInfo as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        "Unable to convert header value '{}' into NetworkInfo - {}",
+                        value, err
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                "Unable to convert header: {:?} to string: {}",
+                hdr_value, e
+            )),
+        }
+    }
+}
+
 /// Version of the Ceramic node in semver format, e.g. 2.1.0
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -254,7 +254,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-  "/network":
+  "/config/network":
     options:
       summary: cors
       responses:

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -254,6 +254,21 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  "/network":
+    options:
+      summary: cors
+      responses:
+        "200":
+          description: cors
+    get:
+      summary: Get info about the Ceramic network the node is connected to
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NetworkInfo"
   /experimental/interests:
     options:
       summary: cors
@@ -583,3 +598,13 @@ components:
         streamId:
           type: string
           description: Multibase encoded stream ID.
+    NetworkInfo:
+      title: Information about the Ceramic network
+      description: Ceramic network information
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the Ceramic network

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -31,7 +31,7 @@ use ceramic_api_server::{
 };
 use ceramic_api_server::{
     Api, ExperimentalEventsSepSepValueGetResponse, ExperimentalInterestsGetResponse,
-    FeedEventsGetResponse, FeedResumeTokenGetResponse, InterestsPostResponse,
+    FeedEventsGetResponse, FeedResumeTokenGetResponse, InterestsPostResponse, NetworkGetResponse,
 };
 use ceramic_core::{Cid, EventId, Interest, Network, PeerId, StreamId};
 use futures::TryFutureExt;
@@ -869,6 +869,21 @@ where
         self.get_events_event_id(event_id)
             .await
             .or_else(|err| Ok(EventsEventIdGetResponse::InternalServerError(err)))
+    }
+
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
+    async fn network_get(&self, _context: &C) -> Result<NetworkGetResponse, ApiError> {
+        Ok(NetworkGetResponse::Success(models::NetworkInfo {
+            name: self.network.name(),
+        }))
+    }
+
+    /// cors
+    async fn network_options(
+        &self,
+        _context: &C,
+    ) -> Result<ceramic_api_server::NetworkOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::NetworkOptionsResponse::Cors)
     }
 
     /// cors

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -30,8 +30,9 @@ use ceramic_api_server::{
     VersionPostResponse,
 };
 use ceramic_api_server::{
-    Api, ExperimentalEventsSepSepValueGetResponse, ExperimentalInterestsGetResponse,
-    FeedEventsGetResponse, FeedResumeTokenGetResponse, InterestsPostResponse, NetworkGetResponse,
+    Api, ConfigNetworkGetResponse, ExperimentalEventsSepSepValueGetResponse,
+    ExperimentalInterestsGetResponse, FeedEventsGetResponse, FeedResumeTokenGetResponse,
+    InterestsPostResponse,
 };
 use ceramic_core::{Cid, EventId, Interest, Network, PeerId, StreamId};
 use futures::TryFutureExt;
@@ -872,18 +873,18 @@ where
     }
 
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
-    async fn network_get(&self, _context: &C) -> Result<NetworkGetResponse, ApiError> {
-        Ok(NetworkGetResponse::Success(models::NetworkInfo {
+    async fn config_network_get(&self, _context: &C) -> Result<ConfigNetworkGetResponse, ApiError> {
+        Ok(ConfigNetworkGetResponse::Success(models::NetworkInfo {
             name: self.network.name(),
         }))
     }
 
     /// cors
-    async fn network_options(
+    async fn config_network_options(
         &self,
         _context: &C,
-    ) -> Result<ceramic_api_server::NetworkOptionsResponse, ApiError> {
-        Ok(ceramic_api_server::NetworkOptionsResponse::Cors)
+    ) -> Result<ceramic_api_server::ConfigNetworkOptionsResponse, ApiError> {
+        Ok(ceramic_api_server::ConfigNetworkOptionsResponse::Cors)
     }
 
     /// cors

--- a/core/src/network.rs
+++ b/core/src/network.rs
@@ -30,11 +30,11 @@ impl Network {
     /// Get the network as a unique name.
     pub fn name(&self) -> String {
         match self {
-            Network::Mainnet => "/ceramic".to_owned(),
-            Network::TestnetClay => "/ceramic/testnet-clay".to_owned(),
-            Network::DevUnstable => "/ceramic/dev-unstable".to_owned(),
-            Network::Local(i) => format!("/ceramic/local-{}", i),
-            Network::InMemory => "/ceramic/inmemory".to_owned(),
+            Network::Mainnet => "mainnet".to_owned(),
+            Network::TestnetClay => "testnet-clay".to_owned(),
+            Network::DevUnstable => "dev-unstable".to_owned(),
+            Network::Local(i) => format!("local-{}", i),
+            Network::InMemory => "inmemory".to_owned(),
         }
     }
 }

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -216,6 +216,7 @@ enum Network {
     /// Local network with unique id
     Local,
     /// Singleton network in memory
+    #[clap(alias = "inmemory")]
     InMemory,
 }
 


### PR DESCRIPTION
This adds a new endpoint to support retrieving the current network the server is connected to. I changing the name formatting to remove `/ceramic/` and return the values that match more closely to what we previously used in js-ceramic. It is possibly a subtly breaking change if people were relying on this string representation to match the pubsub topics, but I can't find any uses in the repo, http client or keramik so went ahead and changed it. Open to implementing `Display` or another function instead if others deem that worthwhile.

I also added `inmemory` as an alias of `in-memory` for the network cli flag so either can be passed in. It's not advertised in help/completion but it will work if passed in.

```bash
# GET /ceramic/network
❯ curl http://127.0.0.1:5101/ceramic/config/network
{"name":"local-0"}
```