### PR TITLE
feat: Log bind address at startup

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -572,7 +572,7 @@ impl Daemon {
         let signals_handle = tokio::spawn(handle_signals(signals, tx));
 
         // The server task blocks until we are ready to start shutdown
-        debug!("starting api server");
+        info!("starting api server at address {}", opts.bind_address);
         hyper::server::Server::try_bind(&opts.bind_address.parse()?)
             .map_err(|e| anyhow!("Failed to bind address: {}. {}", opts.bind_address, e))?
             .serve(service)


### PR DESCRIPTION
With this change at startup there's a message like
```
  2024-07-24T21:40:00.705970Z  INFO ceramic_one: starting api server at address 127.0.0.1:5101
    at one/src/lib.rs:575
```

It does make me wonder though if we should separate `bind_address` into separate args for the port to use and the network interface to bind to.  It's kind of weird to print `127.0.0.1:5101` when presumably we also accept connections that don't just come from localhost.  Really it's the port that's going to be the most interesting part for most people