### PR TITLE
fix: use default (google) dns servers if system resolv.conf is invalid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "criterion2",
  "futures",
  "futures-util",
+ "hickory-resolver",
  "iroh-bitswap",
  "iroh-rpc-client",
  "iroh-rpc-types",

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -21,6 +21,9 @@ ceramic-store.workspace = true
 cid.workspace = true
 futures-util.workspace = true
 futures.workspace = true
+# temporary to address lack of error for invalid resolv.conf (missing nameservers)
+# and libp2p not exposing enough types to actually build a dns resolver
+hickory-resolver = { version = "0.24.1", default-features = false, features = ["system-config"] }
 iroh-bitswap.workspace = true
 iroh-rpc-client.workspace = true
 iroh-rpc-types.workspace = true

--- a/store/src/sql/access/event.rs
+++ b/store/src/sql/access/event.rs
@@ -145,7 +145,7 @@ impl CeramicOneEvent {
         // Fetch add happens with an open transaction (on one writer for the db) so we're guaranteed to get a unique value
         sqlx::query(EventQuery::mark_ready_to_deliver())
             .bind(Self::next_deliverable())
-            .bind(&key.to_bytes())
+            .bind(key.to_bytes())
             .execute(&mut **conn.inner())
             .await?;
 


### PR DESCRIPTION
If the system dns conf is missing nameservers, dns queries will never be resolved. Currently, hickory-dns doesn't error in this case so we handle it manually until the fix is released. This happens on osx if wifi is disabled when you start c1 and is never able to resolve itself without this change, even after connectivity returns. However, if the interface is active when the process starts and then wifi is disabled, it will resolve itself and we will use whatever was defined in resolv.conf.