### PR TITLE
chore: version v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.30.0] - 2024-07-29
+
+### 🚀 Features
+
+- Log bind address at startup (#446)
+- Expose current ceramic network via api (#441)
+- Track version history in database (#409)
+
+### 🐛 Bug Fixes
+
+- Disable libp2p tcp port reuse (#440)
+- Use default (google) dns servers if system resolv.conf is invalid (#447)
+
 ## [0.29.0] - 2024-07-22
 
 ### 🚀 Features
@@ -21,6 +34,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Add CODEOWNERS file (#443)
+- Version v0.29.0 (#445)
 
 ## [0.28.1] - 2024-07-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1112,7 +1112,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1173,7 +1173,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "built",
  "project-root",
@@ -1209,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1230,7 +1230,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-service"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1352,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-store"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -3668,7 +3668,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-car"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -3684,7 +3684,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3702,7 +3702,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "bytes 1.6.0",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.29.0
-- Build date: 2024-07-25T17:06:40.519231-06:00[America/Denver]
+- API version: 0.30.0
+- Build date: 2024-07-29T15:13:05.556088160Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.29.0
+  version: 0.30.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.29.0";
+pub const API_VERSION: &str = "0.30.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.29.0
+  version: 0.30.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.29.0
-- Build date: 2024-07-22T20:00:55.293650347Z[Etc/UTC]
+- API version: 0.30.0
+- Build date: 2024-07-29T15:13:07.774305723Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.29.0
+  version: 0.30.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -20,7 +20,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.29.0";
+pub const API_VERSION: &str = "0.30.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.29.0
+  version: 0.30.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.30.0] - 2024-07-29

### 🚀 Features

- Log bind address at startup (#446)
- Expose current ceramic network via api (#441)
- Track version history in database (#409)

### 🐛 Bug Fixes

- Disable libp2p tcp port reuse (#440)
- Use default (google) dns servers if system resolv.conf is invalid (#447)