### PR TITLE
chore: rust 1.80 lints

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-29T15:13:05.556088160Z[Etc/UTC]
+- Build date: 2024-07-29T11:20:12.699785-06:00[America/Denver]
 
 
 

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::duplicated_attributes)]
 #![allow(
     missing_docs,
     trivial_casts,

--- a/api-server/src/models.rs
+++ b/api-server/src/models.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::to_string_trait_impl)]
+#![allow(unexpected_cfgs)]
 #![allow(unused_qualifications)]
 
 use validator::Validate;

--- a/beetle/iroh-bitswap/src/server/decision.rs
+++ b/beetle/iroh-bitswap/src/server/decision.rs
@@ -29,21 +29,6 @@ use super::{
     task_merger::{TaskData, TaskMerger},
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TaskInfo {
-    peer: PeerId,
-    /// The cid of the block.
-    cid: Cid,
-    /// Tasks can be want-have ro want-block.
-    is_want_block: bool,
-    /// Wether to immediately send a response if the block is not found.
-    send_dont_have: bool,
-    /// The size of the block corresponding to the task.
-    block_size: usize,
-    /// Wether the block was found.
-    have_block: bool,
-}
-
 // Used to accept / deny requests for a CID coming from a PeerID
 // It should return true if the request should be fullfilled.
 pub trait PeerBlockRequestFilter:
@@ -67,6 +52,7 @@ pub struct Config {
     /// for a block that is not in the blockstore. Either
     /// - Send a DONT_HAVE message
     /// - Simply don't respond
+    /// 
     /// This option is only used for testing.
     // TODO: cfg[test]
     pub send_dont_haves: bool,

--- a/beetle/iroh-bitswap/src/server/decision.rs
+++ b/beetle/iroh-bitswap/src/server/decision.rs
@@ -52,7 +52,7 @@ pub struct Config {
     /// for a block that is not in the blockstore. Either
     /// - Send a DONT_HAVE message
     /// - Simply don't respond
-    /// 
+    ///
     /// This option is only used for testing.
     // TODO: cfg[test]
     pub send_dont_haves: bool,

--- a/ci-scripts/gen_api_server.sh
+++ b/ci-scripts/gen_api_server.sh
@@ -20,12 +20,13 @@ cd $DIR/..
 # Add missing clippy allow directive to example code
 # This can be removed once the openapi-generator-cli generates code that passes clippy.
 echo "#![allow(suspicious_double_ref_op)]" | cat - ./api-server/examples/server/server.rs > ./api-server/examples/server/server.rs.tmp
-echo "#![allow(clippy::useless_vec)]" | cat - - ./api-server/src/models.rs > ./api-server/src/models.rs.tmp
-echo "#![allow(clippy::to_string_trait_impl)]" | cat - - ./api-server/src/models.rs > ./api-server/src/models.rs.tmp
-echo "#![allow(clippy::blocks_in_conditions)]" | cat - - ./api-server/src/server/mod.rs > ./api-server/src/server/mod.rs.tmp
+echo "#![allow(clippy::to_string_trait_impl)] #![allow(unexpected_cfgs)]" | cat - ./api-server/src/models.rs > ./api-server/src/models.rs.tmp
+echo "#![allow(clippy::blocks_in_conditions)]" | cat - ./api-server/src/server/mod.rs > ./api-server/src/server/mod.rs.tmp
+echo "#![allow(clippy::duplicated_attributes)]" | cat - ./api-server/src/lib.rs > ./api-server/src/lib.rs.tmp
 mv ./api-server/examples/server/server.rs.tmp ./api-server/examples/server/server.rs
 mv ./api-server/src/models.rs.tmp ./api-server/src/models.rs
 mv ./api-server/src/server/mod.rs.tmp ./api-server/src/server/mod.rs
+mv ./api-server/src/lib.rs.tmp ./api-server/src/lib.rs
 
 # Remove conversion feature from generated code because it doesn't build and we do not use it.
 augtool -s -L \

--- a/ci-scripts/gen_kubo_rpc_server.sh
+++ b/ci-scripts/gen_kubo_rpc_server.sh
@@ -20,9 +20,11 @@ cd $DIR/..
 # Add missing clippy allow directive to example code
 # This can be removed once the openapi-generator-cli generates code that passes clippy.
 echo "#![allow(suspicious_double_ref_op)]" | cat - ./kubo-rpc-server/examples/server/server.rs > ./kubo-rpc-server/examples/server/server.rs.tmp
-echo "#![allow(clippy::to_string_trait_impl)]" | cat - - ./kubo-rpc-server/src/models.rs > ./kubo-rpc-server/src/models.rs.tmp
+echo "#![allow(clippy::to_string_trait_impl)] #![allow(unexpected_cfgs)]" | cat - ./kubo-rpc-server/src/models.rs > ./kubo-rpc-server/src/models.rs.tmp
+echo "#![allow(clippy::duplicated_attributes)]" | cat - ./kubo-rpc-server/src/lib.rs > ./kubo-rpc-server/src/lib.rs.tmp
 mv ./kubo-rpc-server/examples/server/server.rs.tmp ./kubo-rpc-server/examples/server/server.rs
 mv ./kubo-rpc-server/src/models.rs.tmp ./kubo-rpc-server/src/models.rs
+mv ./kubo-rpc-server/src/lib.rs.tmp ./kubo-rpc-server/src/lib.rs
 
 # Remove conversion feature from generated code because it doesn't build and we do not use it.
 augtool -s -L \

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-29T15:13:07.774305723Z[Etc/UTC]
+- Build date: 2024-07-29T11:20:09.604278-06:00[America/Denver]
 
 
 

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::duplicated_attributes)]
 #![allow(
     missing_docs,
     trivial_casts,

--- a/kubo-rpc-server/src/models.rs
+++ b/kubo-rpc-server/src/models.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::to_string_trait_impl)]
+#![allow(unexpected_cfgs)]
 #![allow(unused_qualifications)]
 
 use validator::Validate;

--- a/recon/src/libp2p/handler.rs
+++ b/recon/src/libp2p/handler.rs
@@ -127,23 +127,6 @@ pub enum FromHandler {
     Failed(anyhow::Error),
 }
 
-#[derive(Debug)]
-pub struct Failure {
-    error: Box<dyn std::error::Error + Send + 'static>,
-}
-
-impl std::fmt::Display for Failure {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Error: {}", self.error)
-    }
-}
-
-impl std::error::Error for Failure {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(&*self.error)
-    }
-}
-
 impl<I, M> ConnectionHandler for Handler<I, M>
 where
     I: Recon<Key = Interest, Hash = Sha256a> + Clone + Send + 'static,


### PR DESCRIPTION
Modified the server generator scripts to ignore some new warnings and removed some unused code. I considered upgrading the generator to version 7.7.0 as it removes the duplicate allow_unused statements, but it didn't compile when I regenerated the server. 

It looks like axum support is in beta and hyper 1.0 support was merged but I'm not sure the ETA on arrival. Maybe a breaking release in September, which would be nice to have.