### PR TITLE
fix: create release prs via bot

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -26,7 +26,7 @@ jobs:
       # See https://github.com/3box/rust-builder
       image: public.ecr.aws/r5b3e0r5/3box/rust-builder:latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GH_TOKEN_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
...so that they're not all created using my token.

[This](https://github.com/ceramicnetwork/rust-ceramic/pull/453) is an example of what they'll look like now.