### PR TITLE
feat: add peer id filter to interests

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-07-30T18:32:38.681994-06:00[America/Denver]
+- Build date: 2024-08-01T09:09:55.265121722-06:00[America/Denver]
 
 
 

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.30.0
-- Build date: 2024-08-01T09:09:55.265121722-06:00[America/Denver]
+- Build date: 2024-08-01T13:09:32.848445379-06:00[America/Denver]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -290,7 +290,7 @@ paths:
       - description: Only return interests from the specified peer ID.
         explode: true
         in: query
-        name: peer_id
+        name: peerId
         required: false
         schema:
           type: string
@@ -320,7 +320,7 @@ paths:
       - description: Only return interests from the specified peer ID.
         explode: true
         in: query
-        name: peer_id
+        name: peerId
         required: false
         schema:
           type: string

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -286,6 +286,15 @@ paths:
       summary: cors
   /experimental/interests:
     get:
+      parameters:
+      - description: Only return interests from the specified peer ID.
+        explode: true
+        in: query
+        name: peer_id
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -307,6 +316,15 @@ paths:
           description: Internal server error
       summary: Get the interests stored on the node
     options:
+      parameters:
+      - description: Only return interests from the specified peer ID.
+        explode: true
+        in: query
+        name: peer_id
+        required: false
+        schema:
+          type: string
+        style: form
       responses:
         "200":
           description: cors

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -282,11 +282,21 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> models::InterestsGet ()
+> models::InterestsGet (optional)
 Get the interests stored on the node
 
 ### Required Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **peer_id** | **String**| Only return interests from the specified peer ID. | 
 
 ### Return type
 
@@ -304,11 +314,21 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # ****
-> ()
+> (optional)
 cors
 
 ### Required Parameters
-This endpoint does not need any parameter.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **peer_id** | **String**| Only return interests from the specified peer ID. | 
 
 ### Return type
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -210,7 +210,8 @@ fn main() {
             );
         }
         Some("ExperimentalInterestsGet") => {
-            let result = rt.block_on(client.experimental_interests_get());
+            let result =
+                rt.block_on(client.experimental_interests_get(Some("peer_id_example".to_string())));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,
@@ -218,7 +219,9 @@ fn main() {
             );
         }
         Some("ExperimentalInterestsOptions") => {
-            let result = rt.block_on(client.experimental_interests_options());
+            let result = rt.block_on(
+                client.experimental_interests_options(Some("peer_id_example".to_string())),
+            );
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -243,10 +243,12 @@ where
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
+        peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError> {
         info!(
-            "experimental_interests_get() - X-Span-ID: {:?}",
+            "experimental_interests_get({:?}) - X-Span-ID: {:?}",
+            peer_id,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))
@@ -255,10 +257,12 @@ where
     /// cors
     async fn experimental_interests_options(
         &self,
+        peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
         info!(
-            "experimental_interests_options() - X-Span-ID: {:?}",
+            "experimental_interests_options({:?}) - X-Span-ID: {:?}",
+            peer_id,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -1328,7 +1328,7 @@ where
         let query_string = {
             let mut query_string = form_urlencoded::Serializer::new("".to_owned());
             if let Some(param_peer_id) = param_peer_id {
-                query_string.append_pair("peer_id", &param_peer_id);
+                query_string.append_pair("peerId", &param_peer_id);
             }
             query_string.finish()
         };
@@ -1442,7 +1442,7 @@ where
         let query_string = {
             let mut query_string = form_urlencoded::Serializer::new("".to_owned());
             if let Some(param_peer_id) = param_peer_id {
-                query_string.append_pair("peer_id", &param_peer_id);
+                query_string.append_pair("peerId", &param_peer_id);
             }
             query_string.finish()
         };

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -1318,6 +1318,7 @@ where
 
     async fn experimental_interests_get(
         &self,
+        param_peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError> {
         let mut client_service = self.client_service.clone();
@@ -1326,6 +1327,9 @@ where
         // Query parameters
         let query_string = {
             let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            if let Some(param_peer_id) = param_peer_id {
+                query_string.append_pair("peer_id", &param_peer_id);
+            }
             query_string.finish()
         };
         if !query_string.is_empty() {
@@ -1428,6 +1432,7 @@ where
 
     async fn experimental_interests_options(
         &self,
+        param_peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
         let mut client_service = self.client_service.clone();
@@ -1436,6 +1441,9 @@ where
         // Query parameters
         let query_string = {
             let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            if let Some(param_peer_id) = param_peer_id {
+                query_string.append_pair("peer_id", &param_peer_id);
+            }
             query_string.finish()
         };
         if !query_string.is_empty() {

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -302,12 +302,14 @@ pub trait Api<C: Send + Sync> {
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
+        peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError>;
 
     /// cors
     async fn experimental_interests_options(
         &self,
+        peer_id: Option<String>,
         context: &C,
     ) -> Result<ExperimentalInterestsOptionsResponse, ApiError>;
 
@@ -445,11 +447,13 @@ pub trait ApiNoContext<C: Send + Sync> {
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
+        peer_id: Option<String>,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError>;
 
     /// cors
     async fn experimental_interests_options(
         &self,
+        peer_id: Option<String>,
     ) -> Result<ExperimentalInterestsOptionsResponse, ApiError>;
 
     /// Get all new event keys since resume token
@@ -625,17 +629,23 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     /// Get the interests stored on the node
     async fn experimental_interests_get(
         &self,
+        peer_id: Option<String>,
     ) -> Result<ExperimentalInterestsGetResponse, ApiError> {
         let context = self.context().clone();
-        self.api().experimental_interests_get(&context).await
+        self.api()
+            .experimental_interests_get(peer_id, &context)
+            .await
     }
 
     /// cors
     async fn experimental_interests_options(
         &self,
+        peer_id: Option<String>,
     ) -> Result<ExperimentalInterestsOptionsResponse, ApiError> {
         let context = self.context().clone();
-        self.api().experimental_interests_options(&context).await
+        self.api()
+            .experimental_interests_options(peer_id, &context)
+            .await
     }
 
     /// Get all new event keys since resume token

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -931,7 +931,7 @@ where
                             .collect::<Vec<_>>();
                     let param_peer_id = query_params
                         .iter()
-                        .filter(|e| e.0 == "peer_id")
+                        .filter(|e| e.0 == "peerId")
                         .map(|e| e.1.clone())
                         .next();
                     let param_peer_id = match param_peer_id {
@@ -942,8 +942,8 @@ where
                             Ok(param_peer_id) => Some(param_peer_id),
                             Err(e) => return Ok(Response::builder()
                                 .status(StatusCode::BAD_REQUEST)
-                                .body(Body::from(format!("Couldn't parse query parameter peer_id - doesn't match schema: {}", e)))
-                                .expect("Unable to create Bad Request response for invalid query parameter peer_id")),
+                                .body(Body::from(format!("Couldn't parse query parameter peerId - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter peerId")),
                         }
                         }
                         None => None,
@@ -1020,7 +1020,7 @@ where
                             .collect::<Vec<_>>();
                     let param_peer_id = query_params
                         .iter()
-                        .filter(|e| e.0 == "peer_id")
+                        .filter(|e| e.0 == "peerId")
                         .map(|e| e.1.clone())
                         .next();
                     let param_peer_id = match param_peer_id {
@@ -1031,8 +1031,8 @@ where
                             Ok(param_peer_id) => Some(param_peer_id),
                             Err(e) => return Ok(Response::builder()
                                 .status(StatusCode::BAD_REQUEST)
-                                .body(Body::from(format!("Couldn't parse query parameter peer_id - doesn't match schema: {}", e)))
-                                .expect("Unable to create Bad Request response for invalid query parameter peer_id")),
+                                .body(Body::from(format!("Couldn't parse query parameter peerId - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter peerId")),
                         }
                         }
                         None => None,

--- a/api-server/src/server/mod.rs
+++ b/api-server/src/server/mod.rs
@@ -925,7 +925,33 @@ where
 
                 // ExperimentalInterestsGet - GET /experimental/interests
                 hyper::Method::GET if path.matched(paths::ID_EXPERIMENTAL_INTERESTS) => {
-                    let result = api_impl.experimental_interests_get(&context).await;
+                    // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
+                    let query_params =
+                        form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+                            .collect::<Vec<_>>();
+                    let param_peer_id = query_params
+                        .iter()
+                        .filter(|e| e.0 == "peer_id")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_peer_id = match param_peer_id {
+                        Some(param_peer_id) => {
+                            let param_peer_id =
+                                <String as std::str::FromStr>::from_str(&param_peer_id);
+                            match param_peer_id {
+                            Ok(param_peer_id) => Some(param_peer_id),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter peer_id - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter peer_id")),
+                        }
+                        }
+                        None => None,
+                    };
+
+                    let result = api_impl
+                        .experimental_interests_get(param_peer_id, &context)
+                        .await;
                     let mut response = Response::new(Body::empty());
                     response.headers_mut().insert(
                         HeaderName::from_static("x-span-id"),
@@ -988,7 +1014,33 @@ where
 
                 // ExperimentalInterestsOptions - OPTIONS /experimental/interests
                 hyper::Method::OPTIONS if path.matched(paths::ID_EXPERIMENTAL_INTERESTS) => {
-                    let result = api_impl.experimental_interests_options(&context).await;
+                    // Query parameters (note that non-required or collection query parameters will ignore garbage values, rather than causing a 400 response)
+                    let query_params =
+                        form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes())
+                            .collect::<Vec<_>>();
+                    let param_peer_id = query_params
+                        .iter()
+                        .filter(|e| e.0 == "peer_id")
+                        .map(|e| e.1.clone())
+                        .next();
+                    let param_peer_id = match param_peer_id {
+                        Some(param_peer_id) => {
+                            let param_peer_id =
+                                <String as std::str::FromStr>::from_str(&param_peer_id);
+                            match param_peer_id {
+                            Ok(param_peer_id) => Some(param_peer_id),
+                            Err(e) => return Ok(Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body(Body::from(format!("Couldn't parse query parameter peer_id - doesn't match schema: {}", e)))
+                                .expect("Unable to create Bad Request response for invalid query parameter peer_id")),
+                        }
+                        }
+                        None => None,
+                    };
+
+                    let result = api_impl
+                        .experimental_interests_options(param_peer_id, &context)
+                        .await;
                     let mut response = Response::new(Body::empty());
                     response.headers_mut().insert(
                         HeaderName::from_static("x-span-id"),

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -273,7 +273,7 @@ paths:
     options:
       summary: cors
       parameters:
-        - name: peer_id
+        - name: peerId
           in: query
           required: false
           description: Only return interests from the specified peer ID.
@@ -285,7 +285,7 @@ paths:
     get:
       summary: Get the interests stored on the node
       parameters:
-        - name: peer_id
+        - name: peerId
           in: query
           required: false
           description: Only return interests from the specified peer ID.

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -272,11 +272,25 @@ paths:
   /experimental/interests:
     options:
       summary: cors
+      parameters:
+        - name: peer_id
+          in: query
+          required: false
+          description: Only return interests from the specified peer ID.
+          schema:
+            type: string
       responses:
         "200":
           description: cors
     get:
       summary: Get the interests stored on the node
+      parameters:
+        - name: peer_id
+          in: query
+          required: false
+          description: Only return interests from the specified peer ID.
+          schema:
+            type: string
       responses:
         "200":
           description: success


### PR DESCRIPTION
Add simple ability to filter interests by a peer. Useful in debugging the interests for a local node.