### PR TITLE
feat: recon event insert batching

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -4,7 +4,8 @@ mod server;
 pub use resume_token::ResumeToken;
 
 pub use server::{
-    EventDataResult, EventInsertResult, EventStore, IncludeEventData, InterestStore, Server,
+    ApiItem, EventDataResult, EventInsertResult, EventStore, IncludeEventData, InterestStore,
+    Server,
 };
 
 #[cfg(test)]

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1174,7 +1174,7 @@ mod tests {
     use futures::TryStreamExt;
     use rand::prelude::*;
     use rand_chacha::ChaCha8Rng;
-    use recon::{RangeHash, Result as ReconResult, Sha256a, SyncState};
+    use recon::{RangeHash, ReconItem, Result as ReconResult, Sha256a, SyncState};
     use ssh_key::private::Ed25519Keypair;
 
     use libp2p::{identity::Keypair as Libp2pKeypair, kad::RecordKey};
@@ -1256,7 +1256,7 @@ mod tests {
         type Key = K;
         type Hash = Sha256a;
 
-        async fn insert(&self, _key: Self::Key, _value: Vec<u8>) -> ReconResult<()> {
+        async fn insert(&self, _items: Vec<ReconItem<Self::Key>>) -> ReconResult<()> {
             unreachable!()
         }
 

--- a/recon/src/client.rs
+++ b/recon/src/client.rs
@@ -242,7 +242,7 @@ where
                     Request::Insert { key, value, ret } => {
                         let val = self
                             .recon
-                            .insert(ReconItem::new(&key, &value))
+                            .insert(ReconItem::new(key, value))
                             .await
                             .map_err(Error::from);
                         send(ret, val);

--- a/recon/src/client.rs
+++ b/recon/src/client.rs
@@ -242,7 +242,7 @@ where
                     Request::Insert { key, value, ret } => {
                         let val = self
                             .recon
-                            .insert(&ReconItem::new(&key, &value))
+                            .insert(ReconItem::new(&key, &value))
                             .await
                             .map_err(Error::from);
                         send(ret, val);

--- a/recon/src/client.rs
+++ b/recon/src/client.rs
@@ -23,7 +23,7 @@ where
     H: AssociativeHash,
 {
     /// Sends an insert request to the server and awaits the response.
-    pub async fn insert(&self, key: K, value: Vec<u8>) -> Result<bool> {
+    pub async fn insert(&self, key: K, value: Vec<u8>) -> Result<()> {
         let (ret, rx) = oneshot::channel();
         self.sender
             .send(Request::Insert { key, value, ret })
@@ -142,7 +142,7 @@ enum Request<K, H> {
     Insert {
         key: K,
         value: Vec<u8>,
-        ret: oneshot::Sender<Result<bool>>,
+        ret: oneshot::Sender<Result<()>>,
     },
     Len {
         ret: oneshot::Sender<Result<usize>>,

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -15,7 +15,7 @@ use crate::{
 // before recomputing a range, but it will be used when we're processing large ranges we don't yet have.
 const INSERT_BATCH_SIZE: usize = 100;
 
-// Intiate Recon synchronization with a peer over a stream.
+// Initiate Recon synchronization with a peer over a stream.
 #[tracing::instrument(skip(recon, stream, ), ret(level = Level::DEBUG))]
 pub async fn initiate_synchronize<S, R>(
     remote_peer_id: PeerId,      // included for context only

--- a/recon/src/libp2p/protocol.rs
+++ b/recon/src/libp2p/protocol.rs
@@ -10,6 +10,11 @@ use crate::{
     protocol::{self, Recon},
 };
 
+// The max number of writes we'll batch up before flushing anything to disk.
+// As we descend the tree and find smaller ranges, this won't apply as we have to flush
+// before recomputing a range, but it will be used when we're processing large ranges we don't yet have.
+const INSERT_BATCH_SIZE: usize = 100;
+
 // Intiate Recon synchronization with a peer over a stream.
 #[tracing::instrument(skip(recon, stream, ), ret(level = Level::DEBUG))]
 pub async fn initiate_synchronize<S, R>(
@@ -25,7 +30,7 @@ where
 {
     let codec = CborCodec::new();
     let stream = Framed::new(stream, codec);
-    protocol::initiate_synchronize(recon, stream).await?;
+    protocol::initiate_synchronize(recon, stream, INSERT_BATCH_SIZE).await?;
     Ok(stream_set)
 }
 // Intiate Recon synchronization with a peer over a stream.
@@ -43,6 +48,6 @@ where
 {
     let codec = CborCodec::new();
     let stream = Framed::new(stream, codec);
-    protocol::respond_synchronize(recon, stream).await?;
+    protocol::respond_synchronize(recon, stream, INSERT_BATCH_SIZE).await?;
     Ok(stream_set)
 }

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -75,12 +75,6 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert<'a>(&self, item: &ReconItem<'a, Self::Key>) -> ReconResult<bool> {
-        self.as_error()?;
-
-        self.inner.insert(item).await
-    }
-
     async fn insert_many<'a>(&self, items: &[ReconItem<'a, K>]) -> ReconResult<InsertResult> {
         self.as_error()?;
 

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -75,7 +75,7 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert_many<'a>(&self, items: &[ReconItem<'a, K>]) -> ReconResult<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<K>]) -> ReconResult<InsertResult> {
         self.as_error()?;
 
         self.inner.insert_many(items).await

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use crate::{
     metrics::{MessageLabels, MessageRecv, MessageSent, Metrics, ProtocolRun, ProtocolWriteLoop},
     recon::{RangeHash, SyncState},
-    AssociativeHash, Client, Key, Result as ReconResult,
+    AssociativeHash, Client, Key, ReconItem, Result as ReconResult,
 };
 
 // Limit to the number of pending range requests.
@@ -49,7 +49,11 @@ type RM<K, H> = ReconMessage<ResponderMessage<K, H>>;
 
 /// Intiate Recon synchronization with a peer over a stream.
 #[tracing::instrument(skip(recon, stream), ret(level = Level::DEBUG))]
-pub async fn initiate_synchronize<S, R, E>(recon: R, stream: S) -> Result<()>
+pub async fn initiate_synchronize<S, R, E>(
+    recon: R,
+    stream: S,
+    insert_batch_size: usize,
+) -> Result<()>
 where
     R: Recon,
     S: Stream<Item = Result<RM<R::Key, R::Hash>, E>>
@@ -60,12 +64,22 @@ where
 {
     let metrics = recon.metrics();
     let sync_id = Some(Uuid::new_v4().to_string());
-    protocol(sync_id, Initiator::new(recon), stream, metrics).await?;
+    protocol(
+        sync_id,
+        Initiator::new(recon, insert_batch_size),
+        stream,
+        metrics,
+    )
+    .await?;
     Ok(())
 }
 /// Respond to an initiated Recon synchronization with a peer over a stream.
 #[tracing::instrument(skip(recon, stream), ret(level = Level::DEBUG))]
-pub async fn respond_synchronize<S, R, E>(recon: R, stream: S) -> Result<()>
+pub async fn respond_synchronize<S, R, E>(
+    recon: R,
+    stream: S,
+    insert_batch_size: usize,
+) -> Result<()>
 where
     R: Recon,
     S: Stream<Item = std::result::Result<IM<R::Key, R::Hash>, E>>
@@ -75,7 +89,13 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     let metrics = recon.metrics();
-    protocol(None, Responder::new(recon), stream, metrics).await?;
+    protocol(
+        None,
+        Responder::new(recon, insert_batch_size),
+        stream,
+        metrics,
+    )
+    .await?;
     Ok(())
 }
 
@@ -204,7 +224,7 @@ where
     //
     //  1. Initator Read determines there is no more work to do when there are no interests in
     //     common, or it reads the final [`ResponderMessage::RangeResponse`] from the Responder.
-    //  2. Initator Read sends [`ToWrite::Finish`] to the Initator Writer.
+    //  2. Initator Read sends [`ToWriter::Finish`] to the Initator Writer.
     //  3. Initiator Writer sends the [`InitiatorMessage::Finished`] to the Responder and
     //     completes.
     //  4. Responder Read receives the Finished message and completes, dropping the
@@ -417,9 +437,9 @@ impl<R> Initiator<R>
 where
     R: Recon,
 {
-    fn new(recon: R) -> Self {
+    fn new(recon: R, batch_size: usize) -> Self {
         Self {
-            common: Common { recon },
+            common: Common::new(recon, batch_size),
             pending_ranges: 0,
         }
     }
@@ -429,6 +449,7 @@ where
         to_writer: &mut ToWriterSender<InitiatorMessage<R::Key, R::Hash>>,
         remote_range: RangeHash<R::Key, R::Hash>,
     ) -> Result<()> {
+        self.common.persist_all().await?;
         let sync_state = self.common.recon.process_range(remote_range).await?;
         match sync_state {
             SyncState::Synchronized { .. } => {}
@@ -531,6 +552,7 @@ where
                 if self.pending_ranges == 0 {
                     // All work has completed, we no longer expect any messages from the remote
                     // responder.
+                    self.common.persist_all().await?;
                     to_writer
                         .send(ToWriter::Finish)
                         .await
@@ -561,9 +583,9 @@ impl<R> Responder<R>
 where
     R: Recon,
 {
-    fn new(recon: R) -> Self {
+    fn new(recon: R, batch_size: usize) -> Self {
         Self {
-            common: Common { recon },
+            common: Common::new(recon, batch_size),
         }
     }
 
@@ -572,6 +594,10 @@ where
         to_writer: &mut ToWriterSender<ResponderMessage<R::Key, R::Hash>>,
         range: RangeHash<R::Key, R::Hash>,
     ) -> Result<()> {
+        // We have to make sure to flush the pending writes before responding to a range so we have the same hash.
+        // There are optimizations we can make here (to the protocol or using in memory data), but for now we keep it simple
+        // and should still get some benefit as we were previously writing every value individually.
+        self.common.persist_all().await?;
         let sync_state = self.common.recon.process_range(range).await?;
         match sync_state {
             SyncState::Synchronized { range } => {
@@ -654,7 +680,10 @@ where
                 self.common.process_value_response(key, value).await?;
                 Ok(RemoteStatus::Active)
             }
-            InitiatorMessage::Finished => Ok(RemoteStatus::Finished),
+            InitiatorMessage::Finished => {
+                self.common.persist_all().await?;
+                Ok(RemoteStatus::Finished)
+            }
         }
     }
 }
@@ -662,17 +691,27 @@ where
 // Common implements common behaviors to both [`Initiator`] and [`Responder`].
 struct Common<R: Recon> {
     recon: R,
+    event_q: Vec<ReconItem<R::Key>>,
+    batch_size: usize,
 }
 
 impl<R> Common<R>
 where
     R: Recon,
 {
+    fn new(recon: R, batch_size: usize) -> Self {
+        Self {
+            recon,
+            event_q: Vec::with_capacity(batch_size.saturating_add(1)),
+            batch_size,
+        }
+    }
     async fn process_value_response(&mut self, key: R::Key, value: Vec<u8>) -> Result<()> {
-        self.recon
-            .insert(key, value)
-            .await
-            .context("process value response")?;
+        // update queue and update range min/max
+        self.event_q.push(ReconItem::new(key, value));
+        if self.event_q.len() >= self.batch_size {
+            self.persist_all().await?;
+        }
         Ok(())
     }
     // The remote is missing all keys in the range send them over.
@@ -695,6 +734,14 @@ where
             }
         }
     }
+
+    async fn persist_all(&mut self) -> Result<()> {
+        let evs: Vec<_> = self.event_q.drain(..).collect();
+        if !evs.is_empty() {
+            self.recon.insert(evs).await?;
+        }
+        Ok(())
+    }
 }
 
 enum RemoteStatus {
@@ -712,8 +759,8 @@ pub trait Recon: Clone + Send + Sync + 'static {
     /// The type of Hash to compute over the keys.
     type Hash: AssociativeHash + std::fmt::Debug + Serialize + for<'de> Deserialize<'de>;
 
-    /// Insert a new key into the key space.
-    async fn insert(&self, key: Self::Key, value: Vec<u8>) -> ReconResult<()>;
+    /// Insert new keys into the key space.
+    async fn insert(&self, items: Vec<ReconItem<Self::Key>>) -> ReconResult<()>;
 
     /// Get all keys in the specified range
     async fn range(
@@ -769,8 +816,8 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert(&self, key: Self::Key, value: Vec<u8>) -> ReconResult<()> {
-        let _ = Client::insert(self, key, value).await?;
+    async fn insert(&self, items: Vec<ReconItem<K>>) -> ReconResult<()> {
+        let _ = Client::insert(self, items).await?;
         Ok(())
     }
 

--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -707,7 +707,6 @@ where
         }
     }
     async fn process_value_response(&mut self, key: R::Key, value: Vec<u8>) -> Result<()> {
-        // update queue and update range min/max
         self.event_q.push(ReconItem::new(key, value));
         if self.event_q.len() >= self.batch_size {
             self.persist_all().await?;

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -282,8 +282,8 @@ where
     /// Insert key into the key space.
     /// Returns Ok if the result was accepted. It may be validated and stored
     /// out of band, meaning it may not immediately return in range queries.
-    pub async fn insert(&self, item: ReconItem<K>) -> Result<()> {
-        let _res = self.store.insert_many(&[item]).await?;
+    pub async fn insert(&self, items: Vec<ReconItem<K>>) -> Result<()> {
+        let _res = self.store.insert_many(&items).await?;
         Ok(())
     }
 
@@ -805,8 +805,7 @@ pub struct RangeHash<K, H> {
     pub hash: HashCount<H>,
     /// Last key in the range,
     /// This key may be a fencepost, meaning its not an actual key but simply a boundary.
-    pub last: K,
-}
+    pub last: K,}
 
 impl<K, H> From<RangeHash<K, H>> for RangeOpen<K> {
     fn from(value: RangeHash<K, H>) -> Self {

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -6,6 +6,7 @@ use std::{
     fmt::Display,
     marker::PhantomData,
     ops::{Add, Range},
+    sync::Arc,
 };
 
 use anyhow::anyhow;
@@ -412,7 +413,7 @@ where
     /// The key.
     pub key: K,
     /// The value of the data for the given key.
-    pub value: std::sync::Arc<Vec<u8>>,
+    pub value: Arc<Vec<u8>>,
 }
 
 impl<K> ReconItem<K>
@@ -423,7 +424,7 @@ where
     pub fn new(key: K, value: Vec<u8>) -> Self {
         Self {
             key,
-            value: std::sync::Arc::new(value),
+            value: Arc::new(value),
         }
     }
 }
@@ -805,7 +806,8 @@ pub struct RangeHash<K, H> {
     pub hash: HashCount<H>,
     /// Last key in the range,
     /// This key may be a fencepost, meaning its not an actual key but simply a boundary.
-    pub last: K,}
+    pub last: K,
+}
 
 impl<K, H> From<RangeHash<K, H>> for RangeOpen<K> {
     fn from(value: RangeHash<K, H>) -> Self {

--- a/recon/src/recon.rs
+++ b/recon/src/recon.rs
@@ -280,15 +280,11 @@ where
     }
 
     /// Insert key into the key space.
-    /// Returns a boolean (true) indicating if the key was new.
-    pub async fn insert<'a>(&self, item: ReconItem<'a, K>) -> Result<bool> {
-        Ok(self
-            .store
-            .insert_many(&[item])
-            .await?
-            .keys
-            .first()
-            .map_or(false, |k| *k))
+    /// Returns Ok if the result was accepted. It may be validated and stored
+    /// out of band, meaning it may not immediately return in range queries.
+    pub async fn insert<'a>(&self, item: ReconItem<'a, K>) -> Result<()> {
+        let _res = self.store.insert_many(&[item]).await?;
+        Ok(())
     }
 
     /// Reports total number of keys

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use std::{collections::BTreeMap, ops::Range, sync::Arc};
 use tokio::sync::Mutex;
+use tracing::instrument;
 
 use crate::{
     recon::{AssociativeHash, Key, MaybeHashedKey, ReconItem, Store},
@@ -143,7 +144,9 @@ where
     type Key = K;
     type Hash = H;
 
+    #[instrument(skip(self))]
     async fn insert_many(&self, items: &[ReconItem<Self::Key>]) -> Result<InsertResult> {
+        tracing::trace!("inserting items: {}", items.len());
         let mut new = vec![false; items.len()];
         for (idx, item) in items.iter().enumerate() {
             new[idx] = self.insert(item).await?;

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -121,6 +121,17 @@ where
             .collect();
         Ok(Box::new(keys.into_iter()))
     }
+
+    async fn insert<'a>(&self, item: &ReconItem<'a, K>) -> Result<bool> {
+        let mut inner = self.inner.lock().await;
+        let new = inner
+            .keys
+            .insert(item.key.clone(), H::digest(item.key))
+            .is_none();
+
+        inner.values.insert(item.key.clone(), item.value.to_vec());
+        Ok(new)
+    }
 }
 
 #[async_trait]
@@ -131,17 +142,6 @@ where
 {
     type Key = K;
     type Hash = H;
-
-    async fn insert<'a>(&self, item: &ReconItem<'a, Self::Key>) -> Result<bool> {
-        let mut inner = self.inner.lock().await;
-        let new = inner
-            .keys
-            .insert(item.key.clone(), H::digest(item.key))
-            .is_none();
-
-        inner.values.insert(item.key.clone(), item.value.to_vec());
-        Ok(new)
-    }
 
     async fn insert_many<'a>(&self, items: &[ReconItem<'a, K>]) -> Result<InsertResult> {
         let mut new = vec![false; items.len()];

--- a/recon/src/recon/btreestore.rs
+++ b/recon/src/recon/btreestore.rs
@@ -122,11 +122,11 @@ where
         Ok(Box::new(keys.into_iter()))
     }
 
-    async fn insert<'a>(&self, item: &ReconItem<'a, K>) -> Result<bool> {
+    async fn insert(&self, item: &ReconItem<K>) -> Result<bool> {
         let mut inner = self.inner.lock().await;
         let new = inner
             .keys
-            .insert(item.key.clone(), H::digest(item.key))
+            .insert(item.key.clone(), H::digest(&item.key))
             .is_none();
 
         inner.values.insert(item.key.clone(), item.value.to_vec());
@@ -143,7 +143,7 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert_many<'a>(&self, items: &[ReconItem<'a, K>]) -> Result<InsertResult> {
+    async fn insert_many(&self, items: &[ReconItem<Self::Key>]) -> Result<InsertResult> {
         let mut new = vec![false; items.len()];
         for (idx, item) in items.iter().enumerate() {
             new[idx] = self.insert(item).await?;

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -580,7 +580,8 @@ async fn word_lists() {
         // Spawn a task for each half to make things go quick, we do not care about determinism
         // here.
         let local_handle = tokio::spawn(protocol::initiate_synchronize(local, local_channel, 100));
-        let remote_handle = tokio::spawn(protocol::respond_synchronize(remote, remote_channel, 100));
+        let remote_handle =
+            tokio::spawn(protocol::respond_synchronize(remote, remote_channel, 100));
         // Error if either synchronize method errors
         let (local, remote) = tokio::join!(local_handle, remote_handle);
         local.unwrap().unwrap();
@@ -1919,7 +1920,7 @@ async fn small_diff_zz() {
 
 #[test(tokio::test)]
 async fn dog_linear_download() {
-    recon_test(expect![[r#"
+    let recon = expect![[r#"
         cat: [a, b, c, d, e, f, g]
         dog: []
         -> interest_req((𝚨, 𝛀 ))
@@ -1952,12 +1953,15 @@ async fn dog_linear_download() {
             cat: [a, b, c, d, e, f, g]
         cat: [a, b, c, d, e, f, g]
         dog: [a, b, c, d, e, f, g]
-    "#]])
-    .await
+    "#]];
+    let actual = format!("{}", recon_do(recon.data()).await);
+    recon.assert_eq(&actual);
+    let batching = format!("{}", recon_do_batch_size(recon.data(), 100).await);
+    recon.assert_eq(&batching)
 }
 #[test(tokio::test)]
 async fn cat_linear_download() {
-    recon_test(expect![[r#"
+    let recon = expect![[r#"
         cat: []
         dog: [a, b, c, d, e, f, g]
         -> interest_req((𝚨, 𝛀 ))
@@ -1986,8 +1990,12 @@ async fn cat_linear_download() {
             cat: [a, b, c, d, e, f, g]
         cat: [a, b, c, d, e, f, g]
         dog: [a, b, c, d, e, f, g]
-    "#]])
-    .await
+    "#]];
+
+    let actual = format!("{}", recon_do(recon.data()).await);
+    recon.assert_eq(&actual);
+    let batching = format!("{}", recon_do_batch_size(recon.data(), 100).await);
+    recon.assert_eq(&batching)
 }
 #[test(tokio::test)]
 async fn subset_interest() {

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -522,10 +522,10 @@ async fn word_lists() {
         );
         for key in s.split_whitespace().map(|s| s.to_string()) {
             if !s.is_empty() {
-                r.insert(ReconItem::new(
+                r.insert(vec![ReconItem::new(
                     key.as_bytes().into(),
                     key.to_uppercase().as_bytes().to_vec(),
-                ))
+                )])
                 .await
                 .unwrap();
             }
@@ -579,8 +579,8 @@ async fn word_lists() {
 
         // Spawn a task for each half to make things go quick, we do not care about determinism
         // here.
-        let local_handle = tokio::spawn(protocol::initiate_synchronize(local, local_channel));
-        let remote_handle = tokio::spawn(protocol::respond_synchronize(remote, remote_channel));
+        let local_handle = tokio::spawn(protocol::initiate_synchronize(local, local_channel, 100));
+        let remote_handle = tokio::spawn(protocol::respond_synchronize(remote, remote_channel, 100));
         // Error if either synchronize method errors
         let (local, remote) = tokio::join!(local_handle, remote_handle);
         local.unwrap().unwrap();
@@ -1081,8 +1081,10 @@ where
     )
 }
 
-// Run the recon simulation
-async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
+async fn recon_do_batch_size(
+    recon: &str,
+    batch_size: usize,
+) -> Sequence<AlphaNumBytes, MemoryAHash> {
     async fn snapshot_state(
         client: Client<AlphaNumBytes, MemoryAHash>,
     ) -> Result<BTreeSet<AlphaNumBytes>> {
@@ -1145,8 +1147,8 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
         })
     };
 
-    let cat_fut = protocol::initiate_synchronize(cat.clone(), cat_channel);
-    let dog_fut = protocol::respond_synchronize(dog.clone(), dog_channel);
+    let cat_fut = protocol::initiate_synchronize(cat.clone(), cat_channel, batch_size);
+    let dog_fut = protocol::respond_synchronize(dog.clone(), dog_channel, batch_size);
     // Drive both synchronize futures on the same thread
     // This is to ensure a deterministic behavior.
     let (cat_ret, dog_ret) = tokio::join!(cat_fut, dog_fut);
@@ -1165,6 +1167,11 @@ async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
             dog: snapshot_state(dog).await.unwrap(),
         },
     }
+}
+
+// Run the recon simulation
+async fn recon_do(recon: &str) -> Sequence<AlphaNumBytes, MemoryAHash> {
+    recon_do_batch_size(recon, 0).await
 }
 
 // A recon test is composed of a single expect value.
@@ -1294,6 +1301,57 @@ async fn disjoint() {
         dog: [a, b, c, e, f, g]
     "#]])
     .await
+}
+
+#[test(tokio::test)]
+async fn disjoint_batch_size() {
+    // this sends the same messages as disjoint but they arrive in a slightly different order
+    let recon = expect![[r#"
+        cat: [a, b, c]
+        dog: [e, f, g]
+        -> interest_req((𝚨, 𝛀 ))
+            cat: [a, b, c]
+        <- interest_resp((𝚨, 𝛀 ))
+            dog: [e, f, g]
+        -> range_req({𝚨 h(a, b, c)#3 𝛀 })
+            cat: [a, b, c]
+        <- range_resp({𝚨 0 e}, {e h(e)#1 f}, {f h(f)#1 g}, {g h(g)#1 𝛀 })
+            dog: [e, f, g]
+        -> value(a: a)
+            cat: [a, b, c]
+        -> value(b: b)
+            cat: [a, b, c]
+        -> value(c: c)
+            cat: [a, b, c]
+        -> range_req({𝚨 h(a, b, c)#3 e})
+            cat: [a, b, c]
+        <- range_resp({𝚨 h(a, b, c)#3 e})
+            dog: [a, b, c, e, f, g]
+        -> range_req({e 0 f})
+            cat: [a, b, c]
+        -> range_req({f 0 g})
+            cat: [a, b, c]
+        <- value(e: e)
+            dog: [a, b, c, e, f, g]
+        -> range_req({g 0 𝛀 })
+            cat: [a, b, c]
+        <- range_resp({e h(e)#1 f})
+            dog: [a, b, c, e, f, g]
+        <- value(f: f)
+            dog: [a, b, c, e, f, g]
+        <- range_resp({f h(f)#1 g})
+            dog: [a, b, c, e, f, g]
+        <- value(g: g)
+            dog: [a, b, c, e, f, g]
+        <- range_resp({g h(g)#1 𝛀 })
+            dog: [a, b, c, e, f, g]
+        -> finished
+            cat: [a, b, c, e, f, g]
+        cat: [a, b, c, e, f, g]
+        dog: [a, b, c, e, f, g]
+    "#]];
+    let actual = format!("{}", recon_do_batch_size(recon.data(), 10).await);
+    recon.assert_eq(&actual)
 }
 
 #[test(tokio::test)]

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -522,7 +522,7 @@ async fn word_lists() {
         );
         for key in s.split_whitespace().map(|s| s.to_string()) {
             if !s.is_empty() {
-                r.insert(&ReconItem::new(
+                r.insert(ReconItem::new(
                     &key.as_bytes().into(),
                     key.to_uppercase().as_bytes(),
                 ))

--- a/recon/src/recon/tests.rs
+++ b/recon/src/recon/tests.rs
@@ -523,8 +523,8 @@ async fn word_lists() {
         for key in s.split_whitespace().map(|s| s.to_string()) {
             if !s.is_empty() {
                 r.insert(ReconItem::new(
-                    &key.as_bytes().into(),
-                    key.to_uppercase().as_bytes(),
+                    key.as_bytes().into(),
+                    key.to_uppercase().as_bytes().to_vec(),
                 ))
                 .await
                 .unwrap();

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -611,7 +611,7 @@ mod test {
         let events = get_n_events(n).await;
         for event in events {
             let (event, _) =
-                CeramicEventService::validate_discovered_event(event.0.to_owned(), &event.1)
+                CeramicEventService::validate_discovered_event(event.key.to_owned(), &event.value)
                     .await
                     .unwrap();
             res.push(event);

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -139,20 +139,16 @@ impl CeramicEventService {
         Ok((EventInsertable::try_new(event_id, body)?, metadata))
     }
 
-    pub(crate) async fn insert_events<'a>(
+    pub(crate) async fn insert_events(
         &self,
-        items: &[recon::ReconItem<'a, EventId>],
+        items: &[recon::ReconItem<EventId>],
         source: DeliverableRequirement,
     ) -> Result<InsertResult> {
-        if items.is_empty() {
-            return Ok(InsertResult::default());
-        }
-
-        let mut to_insert = Vec::with_capacity(items.len());
+        let mut to_insert = Vec::new();
 
         for event in items {
             let insertable =
-                Self::validate_discovered_event(event.key.to_owned(), event.value).await?;
+                Self::validate_discovered_event(event.key.to_owned(), &event.value).await?;
             to_insert.push(insertable);
         }
 

--- a/service/src/event/store.rs
+++ b/service/src/event/store.rs
@@ -14,18 +14,6 @@ impl recon::Store for CeramicEventService {
     type Key = EventId;
     type Hash = Sha256a;
 
-    async fn insert<'a>(&self, item: &ReconItem<'a, Self::Key>) -> ReconResult<bool> {
-        let res = self
-            .insert_events(&[item.to_owned()], DeliverableRequirement::Asap)
-            .await?;
-
-        Ok(res
-            .store_result
-            .inserted
-            .first()
-            .map_or(false, |i| i.new_key))
-    }
-
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.

--- a/service/src/event/store.rs
+++ b/service/src/event/store.rs
@@ -17,9 +17,9 @@ impl recon::Store for CeramicEventService {
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.
-    async fn insert_many<'a>(
+    async fn insert_many(
         &self,
-        items: &[ReconItem<'a, Self::Key>],
+        items: &[ReconItem<Self::Key>],
     ) -> ReconResult<recon::InsertResult> {
         let res = self
             .insert_events(items, DeliverableRequirement::Asap)
@@ -31,7 +31,7 @@ impl recon::Store for CeramicEventService {
                 .store_result
                 .inserted
                 .iter()
-                .find(|e| e.order_key == *item.key)
+                .find(|e| e.order_key == item.key)
                 .map_or(false, |e| e.new_key); // TODO: should we error if it's not in this set
             keys[i] = new_key;
         }
@@ -114,14 +114,17 @@ impl iroh_bitswap::Store for CeramicEventService {
 impl ceramic_api::EventStore for CeramicEventService {
     async fn insert_many(
         &self,
-        items: &[(EventId, Vec<u8>)],
+        items: Vec<ceramic_api::ApiItem>,
     ) -> anyhow::Result<Vec<ceramic_api::EventInsertResult>> {
         let items = items
-            .iter()
-            .map(|(key, val)| ReconItem::new(key, val.as_slice()))
+            .into_iter()
+            .map(|i| ReconItem {
+                key: i.key,
+                value: i.value,
+            })
             .collect::<Vec<_>>();
         let res = self
-            .insert_events(&items[..], DeliverableRequirement::Immediate)
+            .insert_events(&items, DeliverableRequirement::Immediate)
             .await?;
 
         Ok(res.into())

--- a/service/src/interest/store.rs
+++ b/service/src/interest/store.rs
@@ -15,12 +15,9 @@ impl recon::Store for CeramicInterestService {
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.
-    #[instrument(skip(self))]
-    async fn insert_many<'a>(
-        &self,
-        items: &[ReconItem<'a, Self::Key>],
-    ) -> ReconResult<InsertResult> {
-        let keys = items.iter().map(|item| item.key).collect::<Vec<_>>();
+    #[instrument(skip(self, items))]
+    async fn insert_many(&self, items: &[ReconItem<Self::Key>]) -> ReconResult<InsertResult> {
+        let keys = items.iter().map(|item| &item.key).collect::<Vec<_>>();
         Ok(CeramicOneInterest::insert_many(&self.pool, &keys).await?)
     }
 

--- a/service/src/interest/store.rs
+++ b/service/src/interest/store.rs
@@ -12,11 +12,6 @@ impl recon::Store for CeramicInterestService {
     type Key = Interest;
     type Hash = Sha256a;
 
-    #[instrument(skip(self))]
-    async fn insert<'a>(&self, item: &ReconItem<'a, Self::Key>) -> ReconResult<bool> {
-        Ok(CeramicOneInterest::insert(&self.pool, item.key).await?)
-    }
-
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.

--- a/service/src/interest/store.rs
+++ b/service/src/interest/store.rs
@@ -15,7 +15,7 @@ impl recon::Store for CeramicInterestService {
     /// Insert new keys into the key space.
     /// Returns true for each key if it did not previously exist, in the
     /// same order as the input iterator.
-    #[instrument(skip(self, items))]
+    #[instrument(skip(self))]
     async fn insert_many(&self, items: &[ReconItem<Self::Key>]) -> ReconResult<InsertResult> {
         let keys = items.iter().map(|item| &item.key).collect::<Vec<_>>();
         Ok(CeramicOneInterest::insert_many(&self.pool, &keys).await?)

--- a/service/src/tests/event.rs
+++ b/service/src/tests/event.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use anyhow::Error;
 use bytes::Bytes;
-use ceramic_api::EventStore;
+use ceramic_api::{ApiItem, EventStore};
 use cid::{Cid, CidGeneric};
 use expect_test::expect;
 use iroh_bitswap::Store;
@@ -54,15 +54,15 @@ where
     S: recon::Store<Key = EventId, Hash = Sha256a>,
 {
     let (model, events) = get_events_return_model().await;
-    let (one_id, one_car) = (&events[0].0, &events[0].1);
-    let (two_id, two_car) = (&events[1].0, &events[1].1);
-    let init_cid = one_id.cid().unwrap();
+    let one = &events[0];
+    let two = &events[1];
+    let init_cid = one.key.cid().unwrap();
     let min_id = event_id_min(&init_cid, &model);
     let max_id = event_id_max(&init_cid, &model);
-    recon::Store::insert_many(&store, &[ReconItem::new(one_id, one_car)])
+    recon::Store::insert_many(&store, &[one.clone()])
         .await
         .unwrap();
-    recon::Store::insert_many(&store, &[ReconItem::new(two_id, two_car)])
+    recon::Store::insert_many(&store, &[two.clone()])
         .await
         .unwrap();
     let values: Vec<(EventId, Vec<u8>)> =
@@ -72,8 +72,8 @@ where
             .collect();
 
     let mut expected = vec![
-        (one_id.to_owned(), one_car.clone()),
-        (two_id.to_owned(), two_car.clone()),
+        (one.key.to_owned(), one.value.to_vec()),
+        (two.key.to_owned(), two.value.to_vec()),
     ];
     expected.sort();
     assert_eq!(expected, values);
@@ -95,22 +95,19 @@ where
     let TestEventInfo {
         event_id: id, car, ..
     } = build_event().await;
+    let item = &[ReconItem::new(id, car)];
 
     // first insert reports its a new key
-    assert!(
-        recon::Store::insert_many(&store, &[ReconItem::new(&id, &car)])
-            .await
-            .unwrap()
-            .included_new_key()
-    );
+    assert!(recon::Store::insert_many(&store, item)
+        .await
+        .unwrap()
+        .included_new_key());
 
     // second insert of same key reports it already existed
-    assert!(
-        !recon::Store::insert_many(&store, &[ReconItem::new(&id, &car)])
-            .await
-            .unwrap()
-            .included_new_key()
-    );
+    assert!(!recon::Store::insert_many(&store, item)
+        .await
+        .unwrap()
+        .included_new_key());
 }
 
 test_with_dbs!(
@@ -132,6 +129,7 @@ where
         ..
     } = build_event().await;
     let TestEventInfo { car: car2, .. } = build_event().await;
+    let expected = hex::encode(&car1);
 
     expect![
         r#"
@@ -144,9 +142,9 @@ where
             )
             "#
     ]
-    .assert_debug_eq(&recon::Store::insert_many(&store, &[ReconItem::new(&id, &car1)]).await);
+    .assert_debug_eq(&recon::Store::insert_many(&store, &[ReconItem::new(id.clone(), car1)]).await);
 
-    match recon::Store::insert_many(&store, &[ReconItem::new(&id, &car2)]).await {
+    match recon::Store::insert_many(&store, &[ReconItem::new(id.clone(), car2)]).await {
         Ok(_) => panic!("expected error"),
         Err(recon::Error::Application { .. }) => {
             // Event ID does not match the root CID of the CAR file
@@ -155,7 +153,7 @@ where
     }
 
     assert_eq!(
-        hex::encode(&car1),
+        expected,
         hex::encode(
             recon::Store::value_for_key(&store, &id)
                 .await
@@ -183,14 +181,15 @@ where
         car: store_value,
         ..
     } = build_event().await;
-    recon::Store::insert_many(&store, &[ReconItem::new(&key, store_value.as_slice())])
+    let expected = hex::encode(&store_value);
+    recon::Store::insert_many(&store, &[ReconItem::new(key.clone(), store_value)])
         .await
         .unwrap();
     let value = recon::Store::value_for_key(&store, &key)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(hex::encode(store_value), hex::encode(value));
+    assert_eq!(expected, hex::encode(value));
 }
 
 test_with_dbs!(
@@ -212,14 +211,15 @@ where
         blocks,
         ..
     } = build_event().await;
-    recon::Store::insert_many(&store, &[ReconItem::new(&key, store_value.as_slice())])
+    let expected = hex::encode(&store_value);
+    recon::Store::insert_many(&store, &[ReconItem::new(key.clone(), store_value)])
         .await
         .unwrap();
     let value = recon::Store::value_for_key(&store, &key)
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(hex::encode(store_value), hex::encode(value));
+    assert_eq!(expected, hex::encode(value));
 
     // Read each block from the CAR
     for block in blocks {
@@ -239,15 +239,15 @@ async fn prep_highwater_tests(store: &dyn EventStore) -> (Cid, Cid, Cid) {
             car: store_value,
             ..
         } = build_event().await;
-        keys.push((key, store_value));
+        keys.push(ceramic_api::ApiItem::new(key, store_value));
     }
-    store.insert_many(&keys[..]).await.unwrap();
-
-    (
-        keys[0].0.cid().unwrap(),
-        keys[1].0.cid().unwrap(),
-        keys[2].0.cid().unwrap(),
-    )
+    let res = (
+        keys[0].key.cid().unwrap(),
+        keys[1].key.cid().unwrap(),
+        keys[2].key.cid().unwrap(),
+    );
+    store.insert_many(keys).await.unwrap();
+    res
 }
 
 test_with_dbs!(
@@ -442,13 +442,11 @@ where
         car: store_value,
         ..
     } = build_event().await;
-    store
-        .insert_many(&[(key.to_owned(), store_value.clone())])
-        .await
-        .unwrap();
+    let item = ApiItem::new(key, store_value);
+    store.insert_many(vec![item.clone()]).await.unwrap();
 
-    let res = store.value_for_order_key(&key).await.unwrap().unwrap();
-    assert_eq!(res, store_value);
+    let res = store.value_for_order_key(&item.key).await.unwrap().unwrap();
+    assert_eq!(&res, item.value.as_ref());
 }
 
 test_with_dbs!(
@@ -470,18 +468,16 @@ where
         car: store_value,
         ..
     } = build_event().await;
+    let item = ApiItem::new(key, store_value);
 
-    store
-        .insert_many(&[(key.to_owned(), store_value.clone())])
-        .await
-        .unwrap();
+    store.insert_many(vec![item.clone()]).await.unwrap();
 
     let res = store
-        .value_for_cid(&key.cid().unwrap())
+        .value_for_cid(&item.key.cid().unwrap())
         .await
         .unwrap()
         .unwrap();
-    assert_eq!(res, store_value);
+    assert_eq!(&res, item.value.as_ref());
 }
 
 test_with_dbs!(

--- a/service/src/tests/interest.rs
+++ b/service/src/tests/interest.rs
@@ -113,8 +113,8 @@ where
     recon::Store::insert_many(
         &store,
         &[ReconItem::new(
-            &random_interest(Some((&[0], &[1])), Some(42)),
-            &[],
+            random_interest(Some((&[0], &[1])), Some(42)),
+            vec![],
         )],
     )
     .await
@@ -123,8 +123,8 @@ where
     recon::Store::insert_many(
         &store,
         &[ReconItem::new(
-            &random_interest(Some((&[0], &[1])), Some(24)),
-            &[],
+            random_interest(Some((&[0], &[1])), Some(24)),
+            vec![],
         )],
     )
     .await
@@ -150,10 +150,10 @@ where
     let interest_0 = random_interest(None, None);
     let interest_1 = random_interest(None, None);
 
-    recon::Store::insert_many(&store, &[ReconItem::new(&interest_0, &[])])
+    recon::Store::insert_many(&store, &[ReconItem::new(interest_0.clone(), Vec::new())])
         .await
         .unwrap();
-    recon::Store::insert_many(&store, &[ReconItem::new(&interest_1, &[])])
+    recon::Store::insert_many(&store, &[ReconItem::new(interest_1.clone(), Vec::new())])
         .await
         .unwrap();
     let ids = recon::Store::range(
@@ -182,11 +182,11 @@ where
     let interest_1 = random_interest(None, None);
 
     store
-        .insert_many(&[ReconItem::new(&interest_0, &[])])
+        .insert_many(&[ReconItem::new(interest_0.clone(), Vec::new())])
         .await
         .unwrap();
     store
-        .insert_many(&[ReconItem::new(&interest_1, &[])])
+        .insert_many(&[ReconItem::new(interest_1.clone(), Vec::new())])
         .await
         .unwrap();
     let ids = store
@@ -217,7 +217,7 @@ where
     let interest = random_interest(None, None);
     // do take the first one
     assert!(
-        &recon::Store::insert_many(&store, &[ReconItem::new(&interest, &[])])
+        &recon::Store::insert_many(&store, &[ReconItem::new(interest.clone(), Vec::new())])
             .await
             .unwrap()
             .included_new_key(),
@@ -225,7 +225,7 @@ where
 
     // reject the second insert of same key
     assert!(
-        !recon::Store::insert_many(&store, &[ReconItem::new(&interest, &[])],)
+        !recon::Store::insert_many(&store, &[ReconItem::new(interest.clone(), Vec::new())],)
             .await
             .unwrap()
             .included_new_key()
@@ -243,7 +243,7 @@ where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
     let key = random_interest(None, None);
-    recon::Store::insert_many(&store, &[ReconItem::new(&key, &[])])
+    recon::Store::insert_many(&store, &[ReconItem::new(key.clone(), Vec::new())])
         .await
         .unwrap();
     let value = store.value_for_key(&key).await.unwrap();

--- a/service/src/tests/interest.rs
+++ b/service/src/tests/interest.rs
@@ -110,16 +110,22 @@ async fn test_hash_range_query<S>(store: S)
 where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
-    recon::Store::insert(
+    recon::Store::insert_many(
         &store,
-        &ReconItem::new(&random_interest(Some((&[0], &[1])), Some(42)), &[]),
+        &[ReconItem::new(
+            &random_interest(Some((&[0], &[1])), Some(42)),
+            &[],
+        )],
     )
     .await
     .unwrap();
 
-    recon::Store::insert(
+    recon::Store::insert_many(
         &store,
-        &ReconItem::new(&random_interest(Some((&[0], &[1])), Some(24)), &[]),
+        &[ReconItem::new(
+            &random_interest(Some((&[0], &[1])), Some(24)),
+            &[],
+        )],
     )
     .await
     .unwrap();
@@ -144,10 +150,10 @@ where
     let interest_0 = random_interest(None, None);
     let interest_1 = random_interest(None, None);
 
-    recon::Store::insert(&store, &ReconItem::new(&interest_0, &[]))
+    recon::Store::insert_many(&store, &[ReconItem::new(&interest_0, &[])])
         .await
         .unwrap();
-    recon::Store::insert(&store, &ReconItem::new(&interest_1, &[]))
+    recon::Store::insert_many(&store, &[ReconItem::new(&interest_1, &[])])
         .await
         .unwrap();
     let ids = recon::Store::range(
@@ -176,11 +182,11 @@ where
     let interest_1 = random_interest(None, None);
 
     store
-        .insert(&ReconItem::new(&interest_0, &[]))
+        .insert_many(&[ReconItem::new(&interest_0, &[])])
         .await
         .unwrap();
     store
-        .insert(&ReconItem::new(&interest_1, &[]))
+        .insert_many(&[ReconItem::new(&interest_1, &[])])
         .await
         .unwrap();
     let ids = store
@@ -210,24 +216,20 @@ where
 {
     let interest = random_interest(None, None);
     // do take the first one
-    expect![
-        r#"
-        Ok(
-            true,
-        )
-        "#
-    ]
-    .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new(&interest, &[])).await);
+    assert!(
+        &recon::Store::insert_many(&store, &[ReconItem::new(&interest, &[])])
+            .await
+            .unwrap()
+            .included_new_key(),
+    );
 
     // reject the second insert of same key
-    expect![
-        r#"
-        Ok(
-            false,
-        )
-        "#
-    ]
-    .assert_debug_eq(&recon::Store::insert(&store, &ReconItem::new(&interest, &[])).await);
+    assert!(
+        !recon::Store::insert_many(&store, &[ReconItem::new(&interest, &[])],)
+            .await
+            .unwrap()
+            .included_new_key()
+    );
 }
 
 test_with_dbs!(
@@ -241,7 +243,7 @@ where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
     let key = random_interest(None, None);
-    recon::Store::insert(&store, &ReconItem::new(&key, &[]))
+    recon::Store::insert_many(&store, &[ReconItem::new(&key, &[])])
         .await
         .unwrap();
     let value = store.value_for_key(&key).await.unwrap();

--- a/service/src/tests/mod.rs
+++ b/service/src/tests/mod.rs
@@ -10,6 +10,7 @@ use ipld_core::{ipld, ipld::Ipld};
 use iroh_bitswap::Block;
 use multihash_codetable::{Code, MultihashDigest};
 use rand::{thread_rng, Rng};
+use recon::ReconItem;
 
 const CONTROLLER: &str = "did:key:z6Mkk3rtfoKDMMG4zyarNGwCQs44GSQ49pcYKQspHJPXSnVw";
 const SEP_KEY: &str = "model";
@@ -167,7 +168,7 @@ async fn data_event(
 async fn get_init_plus_n_events_with_model(
     model: &StreamId,
     number: usize,
-) -> Vec<(EventId, Vec<u8>)> {
+) -> Vec<ReconItem<EventId>> {
     let signer = Box::new(signer().await);
 
     let init = init_event(model, &signer).await;
@@ -180,7 +181,7 @@ async fn get_init_plus_n_events_with_model(
     let init_cid = event_id.cid().unwrap();
 
     let mut events = Vec::with_capacity(number);
-    events.push((event_id, car));
+    events.push(ReconItem::new(event_id, car));
     let mut prev = init_cid;
     for _ in 0..number {
         let data = gen_rand_bytes::<50>();
@@ -198,25 +199,25 @@ async fn get_init_plus_n_events_with_model(
             data.encode_car().await.unwrap(),
         );
         prev = data_id.cid().unwrap();
-        events.push((data_id, data_car));
+        events.push(ReconItem::new(data_id, data_car));
     }
     events
 }
 
-pub(crate) async fn get_events_return_model() -> (StreamId, Vec<(EventId, Vec<u8>)>) {
+pub(crate) async fn get_events_return_model() -> (StreamId, Vec<ReconItem<EventId>>) {
     let model = StreamId::document(random_cid());
     let events = get_init_plus_n_events_with_model(&model, 3).await;
     (model, events)
 }
 
 // builds init -> data -> data that are a stream (will be a different stream each call)
-pub(crate) async fn get_events() -> Vec<(EventId, Vec<u8>)> {
+pub(crate) async fn get_events() -> Vec<ReconItem<EventId>> {
     let model = StreamId::document(random_cid());
     get_init_plus_n_events_with_model(&model, 3).await
 }
 
 // Get N events with the same model (init + N-1 data events)
-pub(crate) async fn get_n_events(number: usize) -> Vec<(EventId, Vec<u8>)> {
+pub(crate) async fn get_n_events(number: usize) -> Vec<ReconItem<EventId>> {
     let model = &StreamId::document(random_cid());
     get_init_plus_n_events_with_model(model, number - 1).await
 }

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -23,8 +23,8 @@ async fn setup_service() -> CeramicEventService {
 
 async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {
     tracing::trace!("inserted event: {}", item.key.cid().unwrap());
-    let new = recon::Store::insert(store, &item).await.unwrap();
-    assert!(new);
+    let new = recon::Store::insert_many(store, &[item]).await.unwrap();
+    assert!(new.included_new_key());
 }
 
 async fn add_and_assert_new_local_event(store: &CeramicEventService, item: ReconItem<'_, EventId>) {

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -160,7 +160,7 @@ where
 {
     async fn insert_many(
         &self,
-        items: &[(EventId, Vec<u8>)],
+        items: Vec<ceramic_api::ApiItem>,
     ) -> anyhow::Result<Vec<ceramic_api::EventInsertResult>> {
         let new_keys = StoreMetricsMiddleware::<S>::record(
             &self.metrics,
@@ -250,9 +250,9 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert_many<'a>(
+    async fn insert_many(
         &self,
-        items: &[ReconItem<'a, K>],
+        items: &[ReconItem<Self::Key>],
     ) -> ReconResult<recon::InsertResult> {
         let res = StoreMetricsMiddleware::<S>::record(
             &self.metrics,

--- a/store/src/metrics.rs
+++ b/store/src/metrics.rs
@@ -250,14 +250,6 @@ where
     type Key = K;
     type Hash = H;
 
-    async fn insert<'a>(&self, item: &ReconItem<'a, Self::Key>) -> ReconResult<bool> {
-        let new =
-            StoreMetricsMiddleware::<S>::record(&self.metrics, "insert", self.store.insert(item))
-                .await?;
-        self.record_key_insert(new);
-        Ok(new)
-    }
-
     async fn insert_many<'a>(
         &self,
         items: &[ReconItem<'a, K>],


### PR DESCRIPTION
The main feature added is some basic insert batching in recon. Originally, we thought we might use a channel and manage the result of batches outside of the recon protocol, but it would require substantial changes to make it work without reading its writes currently. If we add RedTree or another in memory state to capture the known keys before persisting them, that would work. In the end, this only really ends up batching writes if we're receiving a lot of values without sending ranges. Previously we always inserted every key immediately, so this should still be an improvement but it will require benchmarking to say for certain. The messages may arrive in a slightly different order, but the non-deterministic word order test passes fine, as does a new test using disjoint and demonstrating the same messages being sent but in a slightly different order.

This is mostly refactoring to simplify the insert/insert_many operations. It removes the lifetime and uses an `Arc` over the value to make it cheap to clone if needed. We send things to recon on a channel, we have to use an owned value (and it generally simplifies things to remove lifetimes as they can feel a bit like code pollution until proven necessary). If we need to bring it back, it's possible that a higher ranked lifetime bound would be better, but the Arc shouldn't be too bad and we still pass in slices to the store generally. The `ceramic_api` uses a new type that wraps the tuple, and we just pass a `Vec` to make it simple to map into one thing in the service since we the API no longer needs the data, but that could be adjusted.