### PR TITLE
feat: change default dir back to shared home location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "expect-test",
  "futures",
  "git-version",
+ "home",
  "hyper",
  "iroh-bitswap",
  "iroh-rpc-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ceramic-service = { path = "./service" }
 ceramic-store = { path = "./store" }
 chrono = "0.4.31"
 cid = { version = "0.11", features = ["serde-codec"] }
-clap = { version = "4", features = ["derive", "env"] }
+clap = { version = "4", features = ["derive", "env", "string"] }
 clap_mangen = "0.2.2"
 console = { version = "0.15", default-features = false }
 console-subscriber = "0.2"

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -26,6 +26,7 @@ cid.workspace = true
 clap.workspace = true
 futures.workspace = true
 git-version = "0.3"
+home = "0.5"
 hyper.workspace = true
 iroh-bitswap.workspace = true
 iroh-rpc-client.workspace = true

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -56,7 +56,7 @@ struct DaemonOpts {
     db_opts: DBOpts,
 
     /// Path to libp2p private key directory
-    #[arg(short, long, default_value = ".", env = "CERAMIC_ONE_P2P_KEY_DIR")]
+    #[arg(short, long, default_value=default_directory().into_os_string(), env = "CERAMIC_ONE_P2P_KEY_DIR")]
     p2p_key_dir: PathBuf,
 
     /// Bind address of the API endpoint.
@@ -189,10 +189,19 @@ struct DaemonOpts {
     feature_flags: Vec<FeatureFlags>,
 }
 
+/// The default storage directory to use if none is provided. In order:
+///     - `$HOME/.ceramic-one`
+///     -  `./.ceramic-one`
+fn default_directory() -> PathBuf {
+    home::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".ceramic-one")
+}
+
 #[derive(Args, Debug)]
 struct DBOpts {
-    /// Path to storage directory
-    #[arg(short, long, default_value = ".", env = "CERAMIC_ONE_STORE_DIR")]
+    /// Path to storage directory.
+    #[arg(short, long, default_value=default_directory().into_os_string(), env = "CERAMIC_ONE_STORE_DIR")]
     store_dir: PathBuf,
 }
 

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -12,7 +12,7 @@ use futures::{stream::BoxStream, StreamExt};
 use multihash_codetable::{Code, Multihash, MultihashDigest};
 use tracing::{debug, info};
 
-use crate::{DBOpts, Info, LogOpts};
+use crate::{default_directory, DBOpts, Info, LogOpts};
 
 #[derive(Subcommand, Debug)]
 pub enum EventsCommand {
@@ -38,7 +38,7 @@ pub struct FromIpfsOpts {
     #[clap(
         long,
         short,
-        default_value = ".",
+        default_value=default_directory().into_os_string(),
         env = "CERAMIC_ONE_OUTPUT_STORE_PATH"
     )]
     output_store_path: PathBuf,


### PR DESCRIPTION
BREAKING CHANGE: We've decided to change the default storage location back to a shared location (`$HOME/.ceramic-one` or `./.ceramic-one` if home cannot be determined). While I believe the reasoning in #431 was sound, we've decided to optimize for the unboxing experience where things "just work" no matter where you run ceramic-one, rather than experienced users or operators who will likely want to provide a directory and run multiple nodes.

Rather than simply revert that PR, I made a slight change to show the default value in the command line help, which was previously not the case when we used the shared location.

```
  -s, --store-dir <STORE_DIR>
          Path to storage directory. The default is ~/.ceramic-one [env: CERAMIC_ONE_STORE_DIR=] [default: /Users/david/.ceramic-one]
  -p, --p2p-key-dir <P2P_KEY_DIR>
          Path to libp2p private key directory [env: CERAMIC_ONE_P2P_KEY_DIR=] [default: /Users/david/.ceramic-one]
```