### PR TITLE
chore: Change EventInsertable to store the parsed Event object instead of its raw blocks

### DIFF
--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -49,17 +49,13 @@ impl OrderEvents {
         let mut deliverable = Vec::with_capacity(candidate_events.len());
         let mut remaining_candidates = Vec::with_capacity(candidate_events.len());
 
-        while !candidate_events.is_empty() {
-            let (e, h) = candidate_events.pop().unwrap();
+        for (e, h) in candidate_events {
             if e.deliverable() {
                 deliverable.push((e, h))
             } else {
                 remaining_candidates.push((e, h))
             }
         }
-        // Need to reverse the vectors because we popped events off of candidate_events from back to front
-        deliverable.reverse();
-        remaining_candidates.reverse();
 
         if remaining_candidates.is_empty() {
             return Ok(OrderEvents {

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -131,7 +131,7 @@ impl StreamEvent {
                 .await
                 .map_err(Error::new_app)?;
 
-            let metadata = EventMetadata::from(parsed);
+            let metadata = EventMetadata::from(&parsed);
 
             let known_prev = match &metadata {
                 EventMetadata::Init => {
@@ -541,7 +541,7 @@ impl OrderingState {
         let mut event_cnt = 0;
         let mut discovered_inits = Vec::new();
         for (cid, parsed_event) in event_data {
-            let metadata = EventMetadata::from(parsed_event);
+            let metadata = EventMetadata::from(&parsed_event);
 
             let (stream_cid, loaded) = match &metadata {
                 EventMetadata::Init => {
@@ -610,7 +610,7 @@ mod test {
         let mut res = Vec::with_capacity(n);
         let events = get_n_events(n).await;
         for event in events {
-            let (event, _) = CeramicEventService::parse_discovered_event(&event)
+            let event = CeramicEventService::parse_discovered_event(&event)
                 .await
                 .unwrap();
             res.push(event);

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -630,7 +630,7 @@ mod test {
     async fn insert_10_with_9_undelivered(pool: &SqlitePool) {
         let insertable = get_n_insertable_events(10).await;
         let mut init = insertable.first().unwrap().to_owned();
-        init.body.set_deliverable(true);
+        init.set_deliverable(true);
         let undelivered = insertable.into_iter().skip(1).collect::<Vec<_>>();
 
         let new = CeramicOneEvent::insert_many(pool, undelivered.iter())

--- a/service/src/event/ordering_task.rs
+++ b/service/src/event/ordering_task.rs
@@ -628,12 +628,11 @@ mod test {
     }
 
     async fn insert_10_with_9_undelivered(pool: &SqlitePool) {
-        let insertable = get_n_insertable_events(10).await;
-        let mut init = insertable.first().unwrap().to_owned();
+        let mut insertable = get_n_insertable_events(10).await;
+        let mut init = insertable.remove(0);
         init.set_deliverable(true);
-        let undelivered = insertable.into_iter().skip(1).collect::<Vec<_>>();
 
-        let new = CeramicOneEvent::insert_many(pool, undelivered.iter())
+        let new = CeramicOneEvent::insert_many(pool, insertable.iter())
             .await
             .unwrap();
 

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -126,6 +126,14 @@ impl CeramicEventService {
                 .await
                 .map_err(Error::new_app)?;
 
+        // TODO Remove this stuff
+        let tmp_new_car = parsed_event.encode_car().await.unwrap();
+        let new_car = tmp_new_car.as_slice();
+        let old_car = item.value.as_slice();
+        if new_car != old_car {
+            panic!("CAR files don't match!")
+        }
+
         if event_cid != cid {
             return Err(Error::new_app(anyhow::anyhow!(
                 "EventId CID ({}) does not match the root CID of the CAR file ({})",

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use ceramic_core::{EventId, Network};
 use ceramic_event::unvalidated;
-use ceramic_store::{CeramicOneEvent, EventInsertable, EventInsertableBody, SqlitePool};
+use ceramic_store::{CeramicOneEvent, EventInsertable, SqlitePool};
 use cid::Cid;
 use futures::stream::BoxStream;
 use ipld_core::ipld::Ipld;
@@ -134,13 +134,11 @@ impl CeramicEventService {
             )));
         }
 
-        let body = EventInsertableBody::try_from_carfile(cid, item.value.as_slice()).await?;
+        let event_insertable =
+            EventInsertable::try_from_carfile(item.key.to_owned(), item.value.as_slice()).await?;
         let metadata = EventMetadata::from(parsed_event);
 
-        Ok((
-            EventInsertable::try_new(item.key.to_owned(), body)?,
-            metadata,
-        ))
+        Ok((event_insertable, metadata))
     }
 
     pub(crate) async fn insert_events(
@@ -169,7 +167,7 @@ impl CeramicEventService {
                 let to_insert = ordered.deliverable().iter().map(|(e, _)| e);
                 invalid.extend(ordered.missing_history().iter().map(|(e, _)| {
                     InvalidItem::RequiresHistory {
-                        key: e.order_key.clone(),
+                        key: e.order_key().clone(),
                     }
                 }));
                 CeramicOneEvent::insert_many(&self.pool, to_insert).await?

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -116,7 +116,7 @@ impl CeramicEventService {
     /// In the future, we will need to do more event validation (verify all EventID pieces, hashes, signatures, etc).
     pub(crate) async fn parse_discovered_event(
         item: &ReconItem<EventId>,
-    ) -> Result<(EventInsertable, EventMetadata)> {
+    ) -> Result<EventInsertable> {
         let event_cid = item.key.cid().ok_or_else(|| {
             Error::new_app(anyhow::anyhow!("EventId missing CID. EventID={}", item.key))
         })?;
@@ -128,17 +128,17 @@ impl CeramicEventService {
 
         if event_cid != cid {
             return Err(Error::new_app(anyhow::anyhow!(
-                "EventId CID ({}) does not match the body CID ({})",
+                "EventId CID ({}) does not match the root CID of the CAR file ({})",
                 event_cid,
                 cid
             )));
         }
 
-        let event_insertable =
-            EventInsertable::try_from_carfile(item.key.to_owned(), item.value.as_slice()).await?;
-        let metadata = EventMetadata::from(parsed_event);
-
-        Ok((event_insertable, metadata))
+        Ok(EventInsertable::new(
+            item.key.to_owned(),
+            parsed_event,
+            false,
+        ))
     }
 
     pub(crate) async fn insert_events(
@@ -164,8 +164,8 @@ impl CeramicEventService {
         // we can skip notifying the ordering task because it's impossible to be waiting on them
         let store_result = match source {
             DeliverableRequirement::Immediate => {
-                let to_insert = ordered.deliverable().iter().map(|(e, _)| e);
-                invalid.extend(ordered.missing_history().iter().map(|(e, _)| {
+                let to_insert = ordered.deliverable().iter();
+                invalid.extend(ordered.missing_history().iter().map(|e| {
                     InvalidItem::RequiresHistory {
                         key: e.order_key().clone(),
                     }
@@ -176,8 +176,7 @@ impl CeramicEventService {
                 let to_insert = ordered
                     .deliverable()
                     .iter()
-                    .map(|(e, _)| e)
-                    .chain(ordered.missing_history().iter().map(|(e, _)| e));
+                    .chain(ordered.missing_history().iter());
 
                 let store_result = CeramicOneEvent::insert_many(&self.pool, to_insert).await?;
 
@@ -206,11 +205,13 @@ impl CeramicEventService {
             .filter_map(|i| if i.new_key { i.order_key.cid() } else { None })
             .collect::<HashSet<_>>();
 
-        for (ev, metadata) in ordered
+        for ev in ordered
             .deliverable()
             .iter()
             .chain(ordered.missing_history().iter())
         {
+            let metadata = EventMetadata::from(ev.event());
+
             if new.contains(&ev.cid()) {
                 self.send_discovered_event(DiscoveredEvent {
                     cid: ev.cid(),
@@ -292,8 +293,9 @@ pub(crate) enum EventMetadata {
     },
 }
 
-impl From<unvalidated::Event<Ipld>> for EventMetadata {
-    fn from(value: unvalidated::Event<Ipld>) -> Self {
+impl From<&unvalidated::Event<Ipld>> for EventMetadata {
+    // todo can we remove EventMetadata entirely?
+    fn from(value: &unvalidated::Event<Ipld>) -> Self {
         match value {
             unvalidated::Event::Time(t) => EventMetadata::Time {
                 stream_cid: t.id(),
@@ -308,15 +310,6 @@ impl From<unvalidated::Event<Ipld>> for EventMetadata {
                 unvalidated::Payload::Init(_init) => EventMetadata::Init,
             },
             unvalidated::Event::Unsigned(_init) => EventMetadata::Init,
-        }
-    }
-}
-
-impl EventMetadata {
-    pub(crate) fn prev(&self) -> Option<ceramic_core::Cid> {
-        match self {
-            EventMetadata::Init { .. } => None,
-            EventMetadata::Data { prev, .. } | EventMetadata::Time { prev, .. } => Some(*prev),
         }
     }
 }

--- a/store/src/lib.rs
+++ b/store/src/lib.rs
@@ -9,7 +9,7 @@ mod sql;
 pub use error::Error;
 pub use metrics::{Metrics, StoreMetricsMiddleware};
 pub use sql::{
-    entities::{BlockHash, EventBlockRaw, EventInsertable, EventInsertableBody},
+    entities::{BlockHash, EventBlockRaw, EventInsertable},
     CeramicOneBlock, CeramicOneEvent, CeramicOneEventBlock, CeramicOneInterest, CeramicOneVersion,
     InsertResult, InsertedEvent, Migrations, SqlitePool, SqliteRootStore, SqliteTransaction,
 };

--- a/store/src/sql/access/event.rs
+++ b/store/src/sql/access/event.rs
@@ -176,7 +176,7 @@ impl CeramicOneEvent {
                 item.deliverable(),
             ));
             if new_key {
-                for block in item.blocks().iter() {
+                for block in item.get_raw_blocks().await?.iter() {
                     CeramicOneBlock::insert(&mut tx, block.multihash.inner(), &block.bytes).await?;
                     CeramicOneEventBlock::insert(&mut tx, block).await?;
                 }

--- a/store/src/sql/access/event.rs
+++ b/store/src/sql/access/event.rs
@@ -169,14 +169,14 @@ impl CeramicOneEvent {
         let mut tx = pool.begin_tx().await.map_err(Error::from)?;
 
         for item in to_add {
-            let new_key = Self::insert_event(&mut tx, &item.order_key, item.deliverable()).await?;
+            let new_key = Self::insert_event(&mut tx, item.order_key(), item.deliverable()).await?;
             inserted.push(InsertedEvent::new(
-                item.order_key.clone(),
+                item.order_key().clone(),
                 new_key,
                 item.deliverable(),
             ));
             if new_key {
-                for block in item.body.blocks().iter() {
+                for block in item.blocks().iter() {
                     CeramicOneBlock::insert(&mut tx, block.multihash.inner(), &block.bytes).await?;
                     CeramicOneEventBlock::insert(&mut tx, block).await?;
                 }

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -43,46 +43,7 @@ pub async fn rebuild_car(blocks: Vec<BlockRow>) -> Result<Option<Vec<u8>>> {
 /// The type we use to insert events into the database
 pub struct EventInsertable {
     /// The event order key (e.g. EventID)
-    pub order_key: EventId,
-    /// The data that makes up the event
-    pub body: EventInsertableBody,
-}
-
-impl EventInsertable {
-    /// Try to build the EventInsertable struct from a carfile.
-    pub async fn try_from_carfile(order_key: EventId, body: &[u8]) -> Result<Self> {
-        let cid = order_key.cid().ok_or_else(|| {
-            Error::new_invalid_arg(anyhow::anyhow!("EventID is missing a CID: {}", order_key))
-        })?;
-        let body = EventInsertableBody::try_from_carfile(cid, body).await?;
-        Ok(Self { order_key, body })
-    }
-
-    /// Build the EventInsertable struct from an EventID and EventInsertableBody.
-    /// Will error if the CID in the EventID doesn't match the CID in the EventInsertableBody.
-    pub fn try_new(order_key: EventId, body: EventInsertableBody) -> Result<Self> {
-        if order_key.cid() != Some(body.cid()) {
-            return Err(Error::new_invalid_arg(anyhow!(
-                "EventID CID does not match the body CID"
-            )));
-        }
-        Ok(Self { order_key, body })
-    }
-
-    /// Get the CID of the event
-    pub fn cid(&self) -> Cid {
-        self.body.cid
-    }
-
-    /// Whether this event is deliverable currently
-    pub fn deliverable(&self) -> bool {
-        self.body.deliverable()
-    }
-}
-
-#[derive(Debug, Clone)]
-/// The type we use to insert events into the database
-pub struct EventInsertableBody {
+    order_key: EventId,
     /// The event CID i.e. the root CID from the car file
     cid: Cid,
     /// Whether the event is deliverable i.e. it's prev has been delivered and the chain is continuous to an init event
@@ -92,14 +53,22 @@ pub struct EventInsertableBody {
     blocks: Vec<EventBlockRaw>,
 }
 
-impl EventInsertableBody {
-    /// Create a new EventInsertRaw struct. Deliverable is set to false by default.
-    pub fn new(cid: Cid, blocks: Vec<EventBlockRaw>, deliverable: bool) -> Self {
+impl EventInsertable {
+    /// EventInsertable constructor
+    pub fn new(order_key: EventId, blocks: Vec<EventBlockRaw>, deliverable: bool) -> Self {
+        let cid = order_key.cid().unwrap();
+
         Self {
+            order_key,
             cid,
             deliverable,
             blocks,
         }
+    }
+
+    /// Get the Recon order key (EventId) of the event.
+    pub fn order_key(&self) -> &EventId {
+        &self.order_key
     }
 
     /// Get the CID of the event
@@ -107,7 +76,7 @@ impl EventInsertableBody {
         self.cid
     }
 
-    /// Whether this event is deliverable currently
+    /// Underlying bytes that make up the event
     pub fn blocks(&self) -> &Vec<EventBlockRaw> {
         &self.blocks
     }
@@ -123,30 +92,20 @@ impl EventInsertableBody {
         self.deliverable = deliverable;
     }
 
-    /// Find a block from the carfile for a given CID if it's included
-    pub fn block_for_cid_opt(&self, cid: &Cid) -> Option<&EventBlockRaw> {
-        self.blocks
-            .iter()
-            .find(|b| Cid::new_v1(b.codec.try_into().unwrap(), *b.multihash.inner()) == *cid)
-    }
+    /// Try to build the EventInsertable struct from a carfile.
+    pub async fn try_from_carfile(order_key: EventId, car_bytes: &[u8]) -> Result<Self> {
+        let event_cid = order_key.cid().ok_or_else(|| {
+            Error::new_invalid_arg(anyhow::anyhow!("EventID is missing a CID: {}", order_key))
+        })?;
 
-    /// Find a block from the carfile for a given CID if it's included
-    pub fn block_for_cid(&self, cid: &Cid) -> Result<&EventBlockRaw> {
-        self.block_for_cid_opt(cid)
-            .ok_or_else(|| Error::new_app(anyhow!("Event data is missing data for CID {}", cid)))
-    }
-
-    /// Builds a new EventInsertRaw from a CAR file. Will error if the CID in the EventID doesn't match the
-    /// first root of the carfile.
-    pub async fn try_from_carfile(event_cid: Cid, val: &[u8]) -> Result<Self> {
-        if val.is_empty() {
+        if car_bytes.is_empty() {
             return Err(Error::new_app(anyhow!(
                 "CAR file is empty: cid={}",
                 event_cid
             )))?;
         }
 
-        let mut reader = CarReader::new(val)
+        let mut reader = CarReader::new(car_bytes)
             .await
             .map_err(|e| Error::new_app(anyhow!(e)))?;
         let root_cid = reader
@@ -169,6 +128,11 @@ impl EventInsertableBody {
             blocks.push(ebr);
             idx += 1;
         }
-        Ok(Self::new(event_cid, blocks, false))
+        Ok(Self {
+            order_key,
+            cid: event_cid,
+            blocks,
+            deliverable: false,
+        })
     }
 }

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -39,7 +39,7 @@ pub async fn rebuild_car(blocks: Vec<BlockRow>) -> Result<Option<Vec<u8>>> {
     Ok(Some(car))
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 /// The type we use to insert events into the database
 pub struct EventInsertable {
     /// The event order key (e.g. EventID)

--- a/store/src/sql/entities/mod.rs
+++ b/store/src/sql/entities/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 mod version;
 
 pub use block::{BlockBytes, BlockRow};
-pub use event::{rebuild_car, EventInsertable, EventInsertableBody};
+pub use event::{rebuild_car, EventInsertable};
 pub use event_block::{EventBlockRaw, ReconEventBlockRaw};
 pub use hash::{BlockHash, ReconHash};
 pub use version::VersionRow;

--- a/store/src/sql/test.rs
+++ b/store/src/sql/test.rs
@@ -8,7 +8,7 @@ use cid::Cid;
 use expect_test::expect;
 use test_log::test;
 
-use crate::{CeramicOneEvent, EventInsertable, EventInsertableBody, SqlitePool};
+use crate::{CeramicOneEvent, EventInsertable, SqlitePool};
 
 const MODEL_ID: &str = "k2t6wz4yhfp1r5pwi52gw89nzjbu53qk7m32o5iguw42c6knsaj0feuf927agb";
 const CONTROLLER: &str = "did:key:z6Mkqtw7Pj5Lv9xc4PgUYAnwfaVoMC6FRneGWVr5ekTEfKVL";
@@ -28,11 +28,7 @@ fn random_event(cid: &str) -> EventInsertable {
     let order_key = event_id_builder()
         .with_event(&Cid::from_str(cid).unwrap())
         .build();
-    let cid = order_key.cid().unwrap();
-    EventInsertable {
-        order_key,
-        body: EventInsertableBody::new(cid, vec![], true),
-    }
+    EventInsertable::new(order_key, vec![], true)
 }
 
 #[test(tokio::test)]

--- a/store/src/sql/test.rs
+++ b/store/src/sql/test.rs
@@ -1,14 +1,14 @@
 use std::str::FromStr;
 
+use crate::{CeramicOneEvent, EventInsertable, SqlitePool};
 use ceramic_core::{
     event_id::{Builder, WithInit},
     EventId, Network,
 };
+use ceramic_event::unvalidated;
 use cid::Cid;
 use expect_test::expect;
 use test_log::test;
-
-use crate::{CeramicOneEvent, EventInsertable, SqlitePool};
 
 const MODEL_ID: &str = "k2t6wz4yhfp1r5pwi52gw89nzjbu53qk7m32o5iguw42c6knsaj0feuf927agb";
 const CONTROLLER: &str = "did:key:z6Mkqtw7Pj5Lv9xc4PgUYAnwfaVoMC6FRneGWVr5ekTEfKVL";
@@ -28,7 +28,12 @@ fn random_event(cid: &str) -> EventInsertable {
     let order_key = event_id_builder()
         .with_event(&Cid::from_str(cid).unwrap())
         .build();
-    EventInsertable::new(order_key, vec![], true)
+
+    let header =
+        unvalidated::init::Header::new(vec![], "model".to_string(), vec![], None, None, None);
+    let payload = unvalidated::init::Payload::new(header, None);
+    let event = unvalidated::Event::from(payload);
+    EventInsertable::new(order_key, event, true)
 }
 
 #[test(tokio::test)]


### PR DESCRIPTION
builds on https://github.com/ceramicnetwork/rust-ceramic/pull/481