### PR TITLE
chore: Remove EventMetadata type

### DIFF
--- a/api/src/server/event.rs
+++ b/api/src/server/event.rs
@@ -33,36 +33,36 @@ where
 {
     match event {
         unvalidated::Event::Time(time_event) => {
-            let init_payload = get_init_event_payload_from_store(&time_event.id(), store).await?;
-            event_id_from_init_payload(event_cid, network, time_event.id(), &init_payload)
+            let init_payload = get_init_event_payload_from_store(time_event.id(), store).await?;
+            event_id_from_init_payload(&event_cid, network, time_event.id(), &init_payload)
         }
         unvalidated::Event::Signed(signed_event) => {
             let payload = signed_event.payload();
 
             match payload {
                 unvalidated::Payload::Init(init_payload) => event_id_from_init_payload(
-                    event_cid,
+                    &event_cid,
                     network,
                     signed_event.envelope_cid(),
                     init_payload,
                 ),
                 unvalidated::Payload::Data(payload) => {
-                    let init_cid = *payload.id();
-                    let init_payload = get_init_event_payload_from_store(&init_cid, store).await?;
-                    event_id_from_init_payload(event_cid, network, init_cid, &init_payload)
+                    let init_cid = payload.id();
+                    let init_payload = get_init_event_payload_from_store(init_cid, store).await?;
+                    event_id_from_init_payload(&event_cid, network, init_cid, &init_payload)
                 }
             }
         }
         unvalidated::Event::Unsigned(payload) => {
-            event_id_from_init_payload(event_cid, network, event_cid, &payload)
+            event_id_from_init_payload(&event_cid, network, &event_cid, &payload)
         }
     }
 }
 
 fn event_id_from_init_payload(
-    event_cid: Cid,
+    event_cid: &Cid,
     network: Network,
-    init_cid: Cid,
+    init_cid: &Cid,
     init_payload: &unvalidated::init::Payload<Ipld>,
 ) -> Result<EventId> {
     let controller = init_payload
@@ -76,8 +76,8 @@ fn event_id_from_init_payload(
         init_payload.header().sep(),
         init_payload.header().model(),
         controller,
-        &init_cid,
-        &event_cid,
+        init_cid,
+        event_cid,
     ))
 }
 

--- a/event/src/unvalidated/event.rs
+++ b/event/src/unvalidated/event.rs
@@ -79,11 +79,11 @@ where
     }
 
     /// Returns the prev CID (or None if the event is an init event)
-    pub fn prev(&self) -> Option<Cid> {
+    pub fn prev(&self) -> Option<&Cid> {
         match self {
             Event::Time(t) => Some(t.prev()),
             Event::Signed(event) => match event.payload() {
-                Payload::Data(d) => Some(*d.prev()),
+                Payload::Data(d) => Some(d.prev()),
                 Payload::Init(_) => None,
             },
             Event::Unsigned(_) => None,
@@ -277,18 +277,18 @@ impl TimeEvent {
     }
 
     ///  Get the id
-    pub fn id(&self) -> Cid {
-        self.event.id
+    pub fn id(&self) -> &Cid {
+        &self.event.id
     }
 
     ///  Get the prev
-    pub fn prev(&self) -> Cid {
-        self.event.prev
+    pub fn prev(&self) -> &Cid {
+        &self.event.prev
     }
 
     ///  Get the proof
-    pub fn proof(&self) -> Cid {
-        self.event.proof
+    pub fn proof(&self) -> &Cid {
+        &self.event.proof
     }
 
     ///  Get the path

--- a/event/src/unvalidated/event.rs
+++ b/event/src/unvalidated/event.rs
@@ -90,6 +90,19 @@ where
         }
     }
 
+    /// Returns the 'id' field of the event, which is the Cid of the stream's init event.
+    /// If this event *is* the init event, then it doesn't know its own Cid and returns None.
+    pub fn id(&self) -> Option<&Cid> {
+        match self {
+            Event::Time(t) => Some(t.id()),
+            Event::Signed(event) => match event.payload() {
+                Payload::Data(d) => Some(d.id()),
+                Payload::Init(_) => None,
+            },
+            Event::Unsigned(_) => None,
+        }
+    }
+
     /// Encode the event into a CAR bytes containing all blocks of the event.
     pub fn encode_car(&self) -> anyhow::Result<Vec<u8>> {
         match self {

--- a/event/src/unvalidated/signed/mod.rs
+++ b/event/src/unvalidated/signed/mod.rs
@@ -125,18 +125,18 @@ impl<D: serde::Serialize> Event<D> {
     }
 
     /// Get the CID of the signature envelope
-    pub fn envelope_cid(&self) -> Cid {
-        self.envelope_cid
+    pub fn envelope_cid(&self) -> &Cid {
+        &self.envelope_cid
     }
 
     /// Get the CID of the payload
-    pub fn payload_cid(&self) -> Cid {
-        self.payload_cid
+    pub fn payload_cid(&self) -> &Cid {
+        &self.payload_cid
     }
 
     /// Get the CID of the capability
-    pub fn capability_cid(&self) -> Option<Cid> {
-        self.capability.as_ref().map(|c| c.0)
+    pub fn capability_cid(&self) -> Option<&Cid> {
+        self.capability.as_ref().map(|c| &c.0)
     }
 
     /// Encodes the full signed event into a CAR file.

--- a/service/src/event/order_events.rs
+++ b/service/src/event/order_events.rs
@@ -42,7 +42,7 @@ impl OrderEvents {
         let mut new_cids: HashMap<Cid, bool> =
             HashMap::from_iter(candidate_events.into_iter().map(|mut e| {
                 // all init events are deliverable so we mark them as such before we do anything else
-                let cid = e.cid();
+                let cid = *e.cid();
                 let deliverable = if e.event().is_init() {
                     e.set_deliverable(true);
                     deliverable.push(e);
@@ -70,20 +70,20 @@ impl OrderEvents {
                     unreachable!("Init events should have been filtered out since they're always deliverable");
                 }
                 Some(prev) => {
-                    if let Some(in_mem_is_deliverable) = new_cids.get(&prev) {
+                    if let Some(in_mem_is_deliverable) = new_cids.get(prev) {
                         if *in_mem_is_deliverable {
                             event.set_deliverable(true);
-                            *new_cids.get_mut(&event.cid()).expect("CID must exist") = true;
+                            *new_cids.get_mut(event.cid()).expect("CID must exist") = true;
                             deliverable.push(event);
                         } else {
                             undelivered_prevs_in_memory.push_back(event);
                         }
                     } else {
                         let (_exists, prev_deliverable) =
-                            CeramicOneEvent::deliverable_by_cid(pool, &prev).await?;
+                            CeramicOneEvent::deliverable_by_cid(pool, prev).await?;
                         if prev_deliverable {
                             event.set_deliverable(true);
-                            *new_cids.get_mut(&event.cid()).expect("CID must exist") = true;
+                            *new_cids.get_mut(event.cid()).expect("CID must exist") = true;
                             deliverable.push(event);
                         } else {
                             missing_history.push(event);
@@ -107,8 +107,8 @@ impl OrderEvents {
                     unreachable!("Init events should have been filtered out of the in memory set");
                 }
                 Some(prev) => {
-                    if new_cids.get(&prev).map_or(false, |v| *v) {
-                        *new_cids.get_mut(&event.cid()).expect("CID must exist") = true;
+                    if new_cids.get(prev).map_or(false, |v| *v) {
+                        *new_cids.get_mut(event.cid()).expect("CID must exist") = true;
                         event.set_deliverable(true);
                         deliverable.push(event);
                         // reset the iteration count since we made changes. once it doesn't change for a loop through the queue we're done

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -200,9 +200,9 @@ impl CeramicEventService {
         {
             let metadata = EventMetadata::from(ev.event());
 
-            if new.contains(&ev.cid()) {
+            if new.contains(ev.cid()) {
                 self.send_discovered_event(DiscoveredEvent {
-                    cid: ev.cid(),
+                    cid: *ev.cid(),
                     known_deliverable: ev.deliverable(),
                     metadata: metadata.to_owned(),
                 })
@@ -286,8 +286,8 @@ impl From<&unvalidated::Event<Ipld>> for EventMetadata {
     fn from(value: &unvalidated::Event<Ipld>) -> Self {
         match value {
             unvalidated::Event::Time(t) => EventMetadata::Time {
-                stream_cid: t.id(),
-                prev: t.prev(),
+                stream_cid: *t.id(),
+                prev: *t.prev(),
             },
 
             unvalidated::Event::Signed(signed) => match signed.payload() {

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -128,8 +128,8 @@ async fn random_signed_data_event() -> Vec<unvalidated::Event<Ipld>> {
     let init = random_signed_init_event().await;
     let data = ipld_core::ipld!({"key": thread_rng().gen::<u32>()});
     let payload = unvalidated::Builder::data()
-        .with_id(init.envelope_cid())
-        .with_prev(init.envelope_cid())
+        .with_id(*init.envelope_cid())
+        .with_prev(*init.envelope_cid())
         .with_data(data)
         .build();
     vec![
@@ -169,7 +169,7 @@ async fn random_unsigned_init_time_event() -> Vec<unvalidated::Event<Ipld>> {
 async fn random_signed_init_time_event() -> Vec<unvalidated::Event<Ipld>> {
     let init = random_signed_init_event().await;
 
-    let time_event = random_time_event(init.envelope_cid()).await.into();
+    let time_event = random_time_event(*init.envelope_cid()).await.into();
     vec![init.into(), time_event]
 }
 

--- a/service/src/tests/mod.rs
+++ b/service/src/tests/mod.rs
@@ -89,11 +89,11 @@ async fn build_event_fixed_model(model: StreamId) -> TestEventInfo {
         blocks: vec![
             Block::new(
                 signed.encode_envelope().unwrap().into(),
-                signed.envelope_cid(),
+                *signed.envelope_cid(),
             ),
             Block::new(
                 signed.encode_payload().unwrap().into(),
-                signed.payload_cid(),
+                *signed.payload_cid(),
             ),
         ],
         car,

--- a/store/src/sql/access/event.rs
+++ b/store/src/sql/access/event.rs
@@ -183,7 +183,7 @@ impl CeramicOneEvent {
             }
             // the item already existed so we didn't mark it as deliverable on insert
             if !new_key && item.deliverable() {
-                Self::mark_ready_to_deliver(&mut tx, &item.cid()).await?;
+                Self::mark_ready_to_deliver(&mut tx, item.cid()).await?;
             }
         }
         tx.commit().await.map_err(Error::from)?;

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -91,8 +91,8 @@ impl EventInsertable {
     }
 
     /// Get the CID of the event
-    pub fn cid(&self) -> Cid {
-        self.cid
+    pub fn cid(&self) -> &Cid {
+        &self.cid
     }
 
     /// Get the parsed Event structure.


### PR DESCRIPTION
Also changes a bunch of places to use references to Cids instead of returning or taking by value.  Cid implements Copy which means there might a lot of silent copying happening under the hood without it being obvious from the code, and since Cids can be larger than a memory address, using references where possible seems prudent.  Have that change split into its own commit if you want to see the changes separately.  Can also split into two PRs if preferred.