### PR TITLE
feat: jws signature validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1722,6 +1722,7 @@ name = "ceramic-validation"
 version = "0.33.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64 0.21.7",
  "ceramic-car",
  "ceramic-core",
@@ -1734,9 +1735,11 @@ dependencies = [
  "multibase 0.9.1",
  "serde",
  "serde_ipld_dagcbor",
+ "serde_json",
  "sha3",
  "ssi",
  "test-log",
+ "tokio",
  "tracing",
 ]
 

--- a/event/src/unvalidated/payload/init.rs
+++ b/event/src/unvalidated/payload/init.rs
@@ -29,7 +29,7 @@ impl<D> Payload<D> {
 
 impl<D: serde::Serialize> Payload<D> {
     /// Compute CID of encoded event.
-    pub async fn encoded_cid(&self) -> Result<Cid, anyhow::Error> {
+    pub fn encoded_cid(&self) -> Result<Cid, anyhow::Error> {
         let event = serde_ipld_dagcbor::to_vec(self)?;
         Ok(cid_from_dag_cbor(&event))
     }

--- a/event/src/unvalidated/signed/cacao.rs
+++ b/event/src/unvalidated/signed/cacao.rs
@@ -1,6 +1,6 @@
 //! Structures for encoding and decoding CACAO capability objects.
 
-use serde::{Deserialize, Serialize};
+use serde::{ser::SerializeMap as _, Deserialize, Serialize};
 use ssi::jwk::Algorithm;
 use std::collections::HashMap;
 
@@ -164,4 +164,46 @@ pub struct Signature {
     /// Signature bytes
     #[serde(rename = "s")]
     pub signature: String,
+}
+
+#[derive(Debug)]
+/// A sorted version of the metadata that can be used when verifying signatures
+pub struct SortedMetadata<'a> {
+    /// The header data
+    pub header_data: Vec<(&'a str, &'a MetadataValue)>,
+    /// The algorithm used
+    pub alg: MetadataValue,
+    /// The key ID used
+    pub kid: MetadataValue,
+}
+
+impl<'a> From<&'a SignatureMetadata> for SortedMetadata<'a> {
+    fn from(metadata: &'a SignatureMetadata) -> Self {
+        let header_data: Vec<_> = metadata.rest.iter().map(|(k, v)| (k.as_str(), v)).collect();
+        Self {
+            header_data,
+            alg: MetadataValue::String(metadata.alg.clone()),
+            kid: MetadataValue::String(metadata.kid.clone()),
+        }
+    }
+}
+
+impl<'a> Serialize for SortedMetadata<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        let mut header_data: Vec<_> = self
+            .header_data
+            .iter()
+            .map(|(k, v)| (*k, *v))
+            .chain(vec![("alg", &self.alg), ("kid", &self.kid)])
+            .collect();
+        header_data.sort_by(|a, b| a.0.cmp(b.0));
+        let mut s = serializer.serialize_map(Some(header_data.len()))?;
+        for (k, v) in &header_data {
+            s.serialize_entry(k, v)?;
+        }
+        s.end()
+    }
 }

--- a/event/src/unvalidated/signed/mod.rs
+++ b/event/src/unvalidated/signed/mod.rs
@@ -237,11 +237,11 @@ impl Envelope {
 pub struct Signature {
     /// The optional unprotected header.
     #[serde(skip_serializing_if = "Option::is_none")]
-    header: Option<BTreeMap<String, Ipld>>,
+    pub header: Option<BTreeMap<String, Ipld>>,
     /// The protected header as a JSON object
-    protected: Option<Bytes>,
+    pub protected: Option<Bytes>,
     /// The web signature
-    signature: Bytes,
+    pub signature: Bytes,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -162,7 +162,7 @@ fn cid_from_dag_cbor(data: &[u8]) -> Cid {
 // create random time event with a previous unsigned init event
 async fn random_unsigned_init_time_event() -> Vec<unvalidated::Event<Ipld>> {
     let init = random_unsigned_init_event().await;
-    let init_cid = init.encoded_cid().await.unwrap();
+    let init_cid = init.encoded_cid().unwrap();
     vec![init.into(), random_time_event(init_cid).await.into()]
 }
 // create random time event with a previous signed init event

--- a/validation/Cargo.toml
+++ b/validation/Cargo.toml
@@ -11,17 +11,21 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 base64.workspace = true
 ceramic-core.workspace = true
 ceramic-event.workspace = true
 chrono.workspace = true
-ipld-core.workspace = true
-hex.workspace = true
-multibase.workspace = true
-ssi.workspace = true
-k256.workspace = true
-sha3.workspace = true
 ed25519-dalek.workspace = true
+hex.workspace = true
+ipld-core.workspace = true
+k256.workspace = true
+multibase.workspace = true
+serde_json.workspace = true
+sha3.workspace = true
+ssi.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 ceramic-car.workspace = true

--- a/validation/src/lib.rs
+++ b/validation/src/lib.rs
@@ -5,4 +5,4 @@ mod test;
 mod verifier;
 
 pub use ceramic_event::unvalidated::signed::cacao;
-pub use verifier::cacao_verifier;
+pub use verifier::{cacao_verifier, event_verifier, key_verifier, opts::VerifyOpts};

--- a/validation/src/signature/key_ed25519.rs
+++ b/validation/src/signature/key_ed25519.rs
@@ -3,7 +3,7 @@ mod test {
 
     use test_log::test;
 
-    use crate::test::get_test_event;
+    use crate::test::{get_test_event, verify_event_envelope};
 
     #[test]
     fn deterministic_generates() {
@@ -13,19 +13,21 @@ mod test {
         );
     }
 
-    #[test]
-    fn data_generates() {
-        let (_cid, _event) = get_test_event(
+    #[test(tokio::test)]
+    async fn data_validates() {
+        verify_event_envelope(
             crate::test::SigningType::Ed2559,
             crate::test::TestEventType::SignedData,
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn init_generates() {
-        let (_cid, _event) = get_test_event(
+    #[test(tokio::test)]
+    async fn init_validates() {
+        verify_event_envelope(
             crate::test::SigningType::Ed2559,
             crate::test::TestEventType::SignedInit,
-        );
+        )
+        .await;
     }
 }

--- a/validation/src/signature/key_edcsa.rs
+++ b/validation/src/signature/key_edcsa.rs
@@ -3,7 +3,7 @@ mod test {
 
     use test_log::test;
 
-    use crate::test::get_test_event;
+    use crate::test::{get_test_event, verify_event_envelope};
 
     #[test]
     fn deterministic_generates() {
@@ -13,19 +13,21 @@ mod test {
         );
     }
 
-    #[test]
-    fn data_generates() {
-        let (_cid, _event) = get_test_event(
+    #[test(tokio::test)]
+    async fn data_validates() {
+        verify_event_envelope(
             crate::test::SigningType::EcdsaP256,
             crate::test::TestEventType::SignedData,
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn init_generates() {
-        let (_cid, _event) = get_test_event(
+    #[test(tokio::test)]
+    async fn init_validates() {
+        verify_event_envelope(
             crate::test::SigningType::EcdsaP256,
             crate::test::TestEventType::SignedInit,
-        );
+        )
+        .await;
     }
 }

--- a/validation/src/signature/pkh_ethereum.rs
+++ b/validation/src/signature/pkh_ethereum.rs
@@ -95,38 +95,41 @@ mod test {
     use test_log::test;
 
     use crate::{
-        cacao_verifier::{Verifier, VerifyOpts},
+        cacao_verifier::Verifier,
         test::{get_test_event, verify_event_cacao, CACAO_SIGNED_DATA_EVENT_CAR},
+        VerifyOpts,
     };
 
-    #[test]
-    fn eth_pkh_valid_init() {
+    #[test(tokio::test)]
+    async fn eth_pkh_valid_init() {
         verify_event_cacao(
             crate::test::SigningType::Ethereum,
             crate::test::TestEventType::SignedInit,
             &VerifyOpts::default(),
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn eth_pkh_valid_data() {
+    #[test(tokio::test)]
+    async fn eth_pkh_valid_data() {
         verify_event_cacao(
             crate::test::SigningType::Ethereum,
             crate::test::TestEventType::SignedData,
             &VerifyOpts::default(),
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn eth_pkh_deterministic_generates() {
+    #[test(tokio::test)]
+    async fn eth_pkh_deterministic_generates() {
         let (_cid, _event) = get_test_event(
             crate::test::SigningType::Ethereum,
             crate::test::TestEventType::DeterministicInit,
         );
     }
 
-    #[test]
-    fn eth_pkh_valid_data_expired_time_checks() {
+    #[test(tokio::test)]
+    async fn eth_pkh_valid_data_expired_time_checks() {
         let (_base, data) = multibase::decode(CACAO_SIGNED_DATA_EVENT_CAR).unwrap();
         let (_, event) = unvalidated::Event::<Ipld>::decode_car(data.as_slice(), false).unwrap();
         let expired_message = "CACAO has expired";
@@ -136,10 +139,13 @@ mod test {
                 let cap = s.capability().unwrap();
 
                 // valid without expired check
-                match cap.verify(&VerifyOpts {
-                    check_exp: false,
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        check_exp: false,
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         panic!("{:#}", e)
@@ -147,10 +153,13 @@ mod test {
                 }
 
                 // invalid with expired check
-                match cap.verify(&VerifyOpts {
-                    check_exp: true,
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        check_exp: true,
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {
                         panic!("Should have been expired")
                     }
@@ -162,28 +171,34 @@ mod test {
                 // "iat": "2024-06-12T20:04:42.464Z"
                 // "exp": "2024-06-19T20:04:42.464Z"
                 // valid with at_time check
-                match cap.verify(&VerifyOpts {
-                    at_time: Some(
-                        chrono::DateTime::parse_from_rfc3339("2024-06-15T20:04:42.464Z")
-                            .unwrap()
-                            .to_utc(),
-                    ),
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        at_time: Some(
+                            chrono::DateTime::parse_from_rfc3339("2024-06-15T20:04:42.464Z")
+                                .unwrap()
+                                .to_utc(),
+                        ),
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         panic!("should not have been expired using at_time: {}", e);
                     }
                 }
                 // valid 1 min before iat with at_time and clock skew check
-                match cap.verify(&VerifyOpts {
-                    at_time: Some(
-                        chrono::DateTime::parse_from_rfc3339("2024-06-12T20:03:42.464Z")
-                            .unwrap()
-                            .to_utc(),
-                    ),
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        at_time: Some(
+                            chrono::DateTime::parse_from_rfc3339("2024-06-12T20:03:42.464Z")
+                                .unwrap()
+                                .to_utc(),
+                        ),
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         panic!(
@@ -194,14 +209,17 @@ mod test {
                 }
 
                 // valid 1 min after exp with at_time and clock skew check
-                match cap.verify(&VerifyOpts {
-                    at_time: Some(
-                        chrono::DateTime::parse_from_rfc3339("2024-06-19T20:05:42.464Z")
-                            .unwrap()
-                            .to_utc(),
-                    ),
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        at_time: Some(
+                            chrono::DateTime::parse_from_rfc3339("2024-06-19T20:05:42.464Z")
+                                .unwrap()
+                                .to_utc(),
+                        ),
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         panic!(
@@ -212,14 +230,17 @@ mod test {
                 }
 
                 // invalid 10 min after exp with at_time w/o recovation seconds
-                match cap.verify(&VerifyOpts {
-                    at_time: Some(
-                        chrono::DateTime::parse_from_rfc3339("2024-06-19T20:14:42.464Z")
-                            .unwrap()
-                            .to_utc(),
-                    ),
-                    ..Default::default()
-                }) {
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        at_time: Some(
+                            chrono::DateTime::parse_from_rfc3339("2024-06-19T20:14:42.464Z")
+                                .unwrap()
+                                .to_utc(),
+                        ),
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {
                         panic!(
                             "should have been expired using at_time after exp + skew w/o recovation",
@@ -231,19 +252,22 @@ mod test {
                 }
 
                 // valid 10 min after exp with at_time with recovation seconds
-                match cap.verify(&VerifyOpts {
-                    at_time: Some(
-                        chrono::DateTime::parse_from_rfc3339("2024-06-19T20:14:42.464Z")
-                            .unwrap()
-                            .to_utc(),
-                    ),
-                    revocation_phaseout_secs: chrono::TimeDelta::from_std(
-                        std::time::Duration::from_secs(60 * 5),
-                    )
-                    .unwrap(),
+                match cap
+                    .verify_signature(&VerifyOpts {
+                        at_time: Some(
+                            chrono::DateTime::parse_from_rfc3339("2024-06-19T20:14:42.464Z")
+                                .unwrap()
+                                .to_utc(),
+                        ),
+                        revocation_phaseout_secs: chrono::TimeDelta::from_std(
+                            std::time::Duration::from_secs(60 * 5),
+                        )
+                        .unwrap(),
 
-                    ..Default::default()
-                }) {
+                        ..Default::default()
+                    })
+                    .await
+                {
                     Ok(_) => {}
                     Err(e) => {
                         panic!(

--- a/validation/src/signature/pkh_solana.rs
+++ b/validation/src/signature/pkh_solana.rs
@@ -50,26 +50,28 @@ mod test {
     use test_log::test;
 
     use crate::{
-        cacao_verifier::VerifyOpts,
         test::{get_test_event, verify_event_cacao},
+        VerifyOpts,
     };
 
-    #[test]
-    fn sol_pkh_valid_init() {
+    #[test(tokio::test)]
+    async fn sol_pkh_valid_init() {
         verify_event_cacao(
             crate::test::SigningType::Solana,
             crate::test::TestEventType::SignedInit,
             &VerifyOpts::default(),
-        );
+        )
+        .await;
     }
 
-    #[test]
-    fn sol_pkh_valid_data() {
+    #[test(tokio::test)]
+    async fn sol_pkh_valid_data() {
         verify_event_cacao(
             crate::test::SigningType::Solana,
             crate::test::TestEventType::SignedData,
             &VerifyOpts::default(),
-        );
+        )
+        .await;
     }
 
     #[test]

--- a/validation/src/verifier/cacao_verifier.rs
+++ b/validation/src/verifier/cacao_verifier.rs
@@ -1,39 +1,24 @@
-use anyhow::Result;
-use ceramic_event::unvalidated::signed::cacao::{Capability, HeaderType, SignatureType};
+use anyhow::{Context, Result};
+use base64::Engine as _;
+use ceramic_event::unvalidated::signed::cacao::{
+    Capability, HeaderType, SignatureType, SortedMetadata,
+};
+
+use super::{key_verifier::verify_did_jws, opts::VerifyOpts};
 
 use crate::signature::{pkh_ethereum::PkhEthereum, pkh_solana::PkhSolana};
 
-#[derive(Clone, Debug)]
-pub struct VerifyOpts {
-    /// The point in time at which the capability must be valid, defaults to `now`
-    pub at_time: Option<chrono::DateTime<chrono::Utc>>,
-    /// How long the capability stays valid for after it was expired
-    pub revocation_phaseout_secs: chrono::Duration,
-    /// The clock tolerance when verifying iat, nbf, and exp
-    pub clock_skew: chrono::Duration,
-    /// Do not verify expiration time when false
-    pub check_exp: bool,
-}
-
-impl Default for VerifyOpts {
-    fn default() -> Self {
-        Self {
-            at_time: None,
-            revocation_phaseout_secs: chrono::Duration::new(0, 0).expect("0 is a valid duration"),
-            clock_skew: chrono::Duration::new(5 * 60, 0).expect("5 minutes is a valid duration"),
-            check_exp: true,
-        }
-    }
-}
-
+#[async_trait::async_trait]
 pub trait Verifier {
-    #[allow(dead_code)]
-    fn verify(&self, opts: &VerifyOpts) -> Result<()>;
-    fn verify_time_checks(&self, opts: &VerifyOpts) -> anyhow::Result<()>;
+    /// Verify the signature of the CACAO and ensure it is valid.
+    async fn verify_signature(&self, opts: &VerifyOpts) -> Result<()>;
+    /// Verify the time checks for the CACAO using the `VerifyOpts`
+    fn verify_time_checks(&self, opts: &VerifyOpts) -> Result<()>;
 }
 
+#[async_trait::async_trait]
 impl Verifier for Capability {
-    fn verify(&self, opts: &VerifyOpts) -> anyhow::Result<()> {
+    async fn verify_signature(&self, opts: &VerifyOpts) -> anyhow::Result<()> {
         // verify signed from js-did is not required as it won't deserialize without a signature
         // is that something that is ever expected?
         self.verify_time_checks(opts)?;
@@ -47,7 +32,34 @@ impl Verifier for Capability {
                 SignatureType::TezosED25519 => todo!(),
                 SignatureType::StacksSECP256K1 => todo!(),
                 SignatureType::WebAuthNP256 => todo!(),
-                SignatureType::JWS => todo!(),
+                SignatureType::JWS => {
+                    let meta = if let Some(meta) = &self.signature.metadata {
+                        meta
+                    } else {
+                        anyhow::bail!("no metadata found for jws");
+                    };
+                    let did = meta
+                        .kid
+                        .split_once("#")
+                        .map_or(meta.kid.as_str(), |(k, _)| k);
+
+                    let payload =
+                        serde_json::to_vec(&self.payload).context("failed to serialize payload")?;
+                    let header = serde_json::to_vec(&SortedMetadata::from(meta))
+                        .context("failed to seralize metadata")?;
+                    let sig = base64::prelude::BASE64_URL_SAFE_NO_PAD
+                        .decode(self.signature.signature.as_bytes())
+                        .map_err(|e| anyhow::anyhow!("invalid signature: {}", e))?;
+                    verify_did_jws(
+                        did,
+                        header.as_slice(),
+                        payload.as_slice(),
+                        self.signature.r#type.algorithm(),
+                        &sig,
+                        None,
+                    )
+                    .await
+                }
             },
         }
     }

--- a/validation/src/verifier/event_verifier.rs
+++ b/validation/src/verifier/event_verifier.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use ceramic_event::unvalidated::signed;
+use ipld_core::ipld::Ipld;
+
+use super::{cacao_verifier::Verifier as _, key_verifier::Verifier as _, opts::VerifyOpts};
+
+#[async_trait::async_trait]
+pub trait Verifier {
+    async fn verify_signature(&self, opts: &VerifyOpts) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+impl Verifier for signed::Event<Ipld> {
+    async fn verify_signature(&self, opts: &VerifyOpts) -> Result<()> {
+        let envelope = self.envelope();
+        let delegated_kid = if let Some(cacao) = self.capability() {
+            cacao.verify_signature(opts).await?;
+            Some(cacao.payload.audience.as_str())
+        } else {
+            None
+        };
+        // verify envelope signature ensuring cacao aud matches DID for cacao
+        envelope.verify_signature(delegated_kid).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use test_log::test;
+
+    use crate::{
+        test::{verify_event, SigningType, TestEventType},
+        VerifyOpts,
+    };
+
+    #[test(tokio::test)]
+    async fn valid_init_signatures() {
+        for e_type in [
+            SigningType::Solana,
+            SigningType::Ethereum,
+            SigningType::Ed2559,
+            SigningType::EcdsaP256,
+        ] {
+            verify_event(e_type, TestEventType::SignedInit, &VerifyOpts::default()).await;
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn valid_data_signatures() {
+        for e_type in [
+            SigningType::Solana,
+            SigningType::Ethereum,
+            SigningType::Ed2559,
+            SigningType::EcdsaP256,
+        ] {
+            verify_event(e_type, TestEventType::SignedData, &VerifyOpts::default()).await;
+        }
+    }
+}

--- a/validation/src/verifier/key_verifier.rs
+++ b/validation/src/verifier/key_verifier.rs
@@ -1,0 +1,76 @@
+use anyhow::{anyhow, bail, Context, Result};
+use base64::engine::{self, Engine as _};
+use ceramic_core::Jwk;
+use ceramic_event::unvalidated::signed::Envelope;
+use tracing::{debug, warn};
+
+#[async_trait::async_trait]
+pub trait Verifier {
+    /// Verify the signature. Optoinally requiring it matches a delegated KID
+    async fn verify_signature(&self, delegated_kid: Option<&str>) -> Result<()>;
+}
+
+#[async_trait::async_trait]
+impl Verifier for Envelope {
+    async fn verify_signature(&self, delegated_kid: Option<&str>) -> Result<()> {
+        let signature = self
+            .signature()
+            .first()
+            .ok_or_else(|| anyhow!("missing signature on signed event"))?;
+        let jws_header = self.jws_header().context("event envelope is not a jws")?;
+        let protected = signature
+            .protected
+            .as_ref()
+            .ok_or_else(|| anyhow!("missing protected field"))?;
+
+        let did = &jws_header
+            .key_id
+            .ok_or_else(|| anyhow!("missing jws kid"))?;
+
+        verify_did_jws(
+            did,
+            protected.as_slice(),
+            self.payload().as_slice(),
+            jws_header.algorithm,
+            signature.signature.as_slice(),
+            delegated_kid,
+        )
+        .await
+    }
+}
+
+pub(crate) async fn verify_did_jws(
+    did: &str,
+    header: &[u8],
+    payload: &[u8],
+    alg: ssi::jwk::Algorithm,
+    signature: &[u8],
+    delegated_kid: Option<&str>,
+) -> Result<()> {
+    let did_doc = Jwk::resolve_did(did)
+        .await
+        .context("failed to resolve did")?;
+    if delegated_kid.is_some() && delegated_kid.unwrap() != did_doc.id {
+        debug!(
+            ?delegated_kid,
+            kid = %did_doc.id,
+            "jws kid not delegated access"
+        );
+        bail!("jws kid not delegated access",);
+    }
+
+    let jwk = Jwk::new(&did_doc)
+        .await
+        .map_err(|e| anyhow!("failed to generate jws for did: {}", e))?;
+
+    let header_str = engine::general_purpose::STANDARD_NO_PAD.encode(header);
+    let payload_cid = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(payload);
+    let digest = format!("{header_str}.{payload_cid}");
+    let warnings = ssi::jws::verify_bytes_warnable(alg, digest.as_bytes(), &jwk, signature)
+        .map_err(|e| anyhow!("failed to verify jws: {}", e))?;
+
+    if !warnings.is_empty() {
+        warn!(?warnings, "warnings while verifying jws");
+    }
+    Ok(())
+}

--- a/validation/src/verifier/mod.rs
+++ b/validation/src/verifier/mod.rs
@@ -1,1 +1,4 @@
 pub mod cacao_verifier;
+pub mod event_verifier;
+pub mod key_verifier;
+pub mod opts;

--- a/validation/src/verifier/opts.rs
+++ b/validation/src/verifier/opts.rs
@@ -1,0 +1,22 @@
+#[derive(Clone, Debug)]
+pub struct VerifyOpts {
+    /// The point in time at which the capability must be valid, defaults to `now`
+    pub at_time: Option<chrono::DateTime<chrono::Utc>>,
+    /// How long the capability stays valid for after it was expired
+    pub revocation_phaseout_secs: chrono::Duration,
+    /// The clock tolerance when verifying iat, nbf, and exp
+    pub clock_skew: chrono::Duration,
+    /// Do not verify expiration time when false
+    pub check_exp: bool,
+}
+
+impl Default for VerifyOpts {
+    fn default() -> Self {
+        Self {
+            at_time: None,
+            revocation_phaseout_secs: chrono::Duration::new(0, 0).expect("0 is a valid duration"),
+            clock_skew: chrono::Duration::new(5 * 60, 0).expect("5 minutes is a valid duration"),
+            check_exp: true,
+        }
+    }
+}


### PR DESCRIPTION
Implements event validation using did:key/JWS. This verifies the envelope and makes sure the cacao grants access to the key that signed the payload. This builds on #495 (current target) and I had to make the cacao/pkh `Verifier` async since it can be a JWS based on the metadata.

This is not invoked anywhere and the tests currently only verify signatures for the valid events from the ceramic-sdk test vectors.