### PR TITLE
feat: migrate from file list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,6 +2552,7 @@ dependencies = [
  "tokio",
  "tokio-metrics",
  "tokio-prometheus-client",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/event-svc/src/tests/migration.rs
+++ b/event-svc/src/tests/migration.rs
@@ -25,7 +25,7 @@ struct InMemBlockStore {
 
 #[async_trait]
 impl BlockStore for InMemBlockStore {
-    fn blocks_from_dir(&self) -> BoxStream<'static, Result<(Cid, Vec<u8>)>> {
+    fn blocks(&self) -> BoxStream<'static, Result<(Cid, Vec<u8>)>> {
         let blocks = self.blocks.clone();
         futures::stream::iter(blocks.into_iter().map(Result::Ok)).boxed()
     }

--- a/event-svc/src/tests/migration.rs
+++ b/event-svc/src/tests/migration.rs
@@ -25,7 +25,7 @@ struct InMemBlockStore {
 
 #[async_trait]
 impl BlockStore for InMemBlockStore {
-    fn blocks(&self) -> BoxStream<'static, Result<(Cid, Vec<u8>)>> {
+    fn blocks_from_dir(&self) -> BoxStream<'static, Result<(Cid, Vec<u8>)>> {
         let blocks = self.blocks.clone();
         futures::stream::iter(blocks.into_iter().map(Result::Ok)).boxed()
     }

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -50,6 +50,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 swagger.workspace = true
 tokio-metrics = { version = "0.3.1", features = ["rt"] }
 tokio-prometheus-client = "0.1"
+tokio-stream = { workspace = true, features = ["io-util"] }
 tokio.workspace = true
 tracing.workspace = true
 

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -64,7 +64,7 @@ pub struct FromIpfsOpts {
     #[command(flatten)]
     log_opts: LogOpts,
 
-    /// Path of file containing list of newline-delimited absolute file paths to migrate.
+    /// Path of file containing list of newline-delimited file paths to migrate.
     ///
     /// See below for example usage when running a migration for a live IPFS node. Multiple migration runs using lists
     /// of files that have changed between runs is useful for incremental migrations. This method can also be used for


### PR DESCRIPTION
This PR adds support for migrating IPFS blocks from an input file list. It also introduces both an `offset` and a `limit` that can be used to paginate migrations, whether from a directory or from a file list.

This is needed for being able to apply incremental ZFS snapshots without having to re-migrate the entire blockstore. The list of added blocks can be extracted from the incremental snapshot and input to the migration so that only new blocks are migrated. This will dramatically reduce the amount of time needed for migrating new blocks added after the first snapshot was taken.


Note that paginating over a directory might have unpredictable results if it is receiving live updates.