### PR TITLE
feat: validate signed events

### DIFF
--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -436,7 +436,7 @@ impl OrderingState {
     /// Relies on `add_stream_event` to handle updating the internal state.
     fn add_inserted_events(&mut self, events: Vec<DiscoveredEvent>) {
         for ev in events {
-            let stream_cid = ev.stream_cid();
+            let stream_cid = ev.id;
             let event = ev.into();
             self.add_stream_event(stream_cid, event);
         }

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -110,9 +110,9 @@ impl EventService {
         Self::try_new(pool, false, true).await
     }
 
-    /// Currently, we track events that were ASAP deliverable but we don't know the init event.
-    /// Immediately deliverable require the init event existing so don't need tracking.
-    /// Lazy deliverable don't require the init event to exist for validation so don't need tracking.
+    /// Currently, we track events when the [`ValidationRequirement`] allows. Right now, this applies to
+    /// recon discovered events when the init event isn't yet known to the node due to out of order sync
+    /// but might apply to other cases in the future.
     fn track_pending(&self, pending: Vec<UnvalidatedEvent>) {
         let mut map = self.pending_writes.lock().unwrap();
         if map.len() + pending.len() >= PENDING_VALIDATION_QUEUE_DEPTH {

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -223,7 +223,7 @@ impl EventService {
 
         let ValidatedEvents {
             valid,
-            unvalidated: pending,
+            unvalidated,
             invalid,
         } = EventValidator::validate_events(&self.pool, validation_requirement, to_validate)
             .await?;
@@ -231,7 +231,7 @@ impl EventService {
 
         Ok(ValidatedEvents {
             valid,
-            unvalidated: pending,
+            unvalidated,
             invalid: invalid_events,
         })
     }

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -437,7 +437,7 @@ impl EventService {
                 self.send_discovered_event(DiscoveredEvent {
                     cid: *ev.cid(),
                     prev: ev.event().prev().copied(),
-                    id: Some(*ev.event().id()),
+                    id: *ev.event().id(),
                     known_deliverable: ev.deliverable(),
                 })
                 .await?;
@@ -488,18 +488,9 @@ pub(crate) struct DiscoveredEvent {
     /// The prev event that this event builds on.
     pub(crate) prev: Option<Cid>,
     /// The Cid of the init event that identifies the stream this event belongs to.
-    pub(crate) id: Option<Cid>,
+    pub(crate) id: Cid,
     /// Whether this event is known to already be deliverable.
     pub(crate) known_deliverable: bool,
-}
-
-impl DiscoveredEvent {
-    pub(crate) fn stream_cid(&self) -> Cid {
-        match self.id {
-            None => self.cid, // init event
-            Some(id) => id,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -9,7 +9,7 @@ use tokio::try_join;
 use crate::{
     event::{
         service::{ValidationError, ValidationRequirement},
-        validator::signed::SignedValidator,
+        validator::signed::SignedEventValidator,
     },
     store::{EventInsertable, SqlitePool},
     Result,
@@ -178,7 +178,7 @@ impl<'a> EventValidator<'a> {
                 ..Default::default()
             }
         };
-        SignedValidator::validate_events(self.pool, &opts, events).await
+        SignedEventValidator::validate_events(self.pool, &opts, events).await
     }
 
     async fn validate_time_events(&self, events: TimeValidationBatch) -> Result<ValidatedEvents> {

--- a/event-svc/src/event/validator/grouped.rs
+++ b/event-svc/src/event/validator/grouped.rs
@@ -1,0 +1,140 @@
+use ceramic_event::unvalidated::{self, signed};
+use ipld_core::ipld::Ipld;
+
+use super::{UnvalidatedEvent, ValidatedEvent};
+
+#[derive(Debug)]
+pub enum ValidationNeeded {
+    SignedInit(SignedInit),
+    SignedData(SignedData),
+    Time(Time),
+    None(Unsigned),
+}
+
+impl From<UnvalidatedEvent> for ValidationNeeded {
+    fn from(value: UnvalidatedEvent) -> Self {
+        match value.event.as_ref() {
+            unvalidated::Event::Time(_) => Self::Time(Time(value)),
+            unvalidated::Event::Signed(signed) => match signed.payload() {
+                unvalidated::Payload::Data(_) => Self::SignedData(SignedData(value)),
+                unvalidated::Payload::Init(_) => Self::SignedInit(SignedInit(value)),
+            },
+            unvalidated::Event::Unsigned(_) => Self::None(Unsigned(value)),
+        }
+    }
+}
+
+/// This is a simple macro to create a tuple struct around UnvalidatedEvent and allow access
+/// to the inner value. It's purpose is to support implementing `From<UnvalidatedEvent> for ValidationNeeded`
+/// and get the correct structs that can be required in fn signatures, but still dereferenced as the
+/// original event type without having to match on all the branches when we require it to be a specific variant.
+macro_rules! unvalidated_wrapper {
+    ($name: ident) => {
+        #[derive(Debug)]
+        pub(crate) struct $name(UnvalidatedEvent);
+
+        impl $name {
+            #[allow(dead_code)]
+            /// Get the inner tuple struct value
+            pub fn into_inner(self) -> UnvalidatedEvent {
+                self.0
+            }
+
+            #[allow(dead_code)]
+            /// Get the inner tuple struct value by reference
+            pub fn as_inner(&self) -> &UnvalidatedEvent {
+                &self.0
+            }
+        }
+
+        impl From<$name> for ValidatedEvent {
+            // We wrap the unchecked here since we expect these to get validated and it makes it easy
+            fn from(value: $name) -> Self {
+                Self::from_unvalidated_unchecked(value.into_inner())
+            }
+        }
+    };
+}
+
+/// Create an as `as_signed` function that panics for unsigned events.
+/// Will be derived on our signed structs to
+macro_rules! as_signed {
+    ($name: ident) => {
+        impl $name {
+            pub fn as_signed(&self) -> &signed::Event<Ipld> {
+                match self.0.event.as_ref() {
+                    unvalidated::Event::Time(_) => unreachable!("time event is not signed"),
+                    unvalidated::Event::Signed(s) => s,
+                    unvalidated::Event::Unsigned(_) => unreachable!("unsigned event is not signed"),
+                }
+            }
+        }
+    };
+}
+
+impl Time {
+    #[allow(dead_code)]
+    pub fn as_time(&self) -> &unvalidated::TimeEvent {
+        match self.0.event.as_ref() {
+            unvalidated::Event::Time(t) => t,
+            unvalidated::Event::Signed(_) => unreachable!("signed event event is not time"),
+            unvalidated::Event::Unsigned(_) => unreachable!("unsigned event is not time"),
+        }
+    }
+}
+
+// Generate the tuple structs to use in the `ValidationNeeded` enum variants
+unvalidated_wrapper!(SignedData);
+unvalidated_wrapper!(SignedInit);
+unvalidated_wrapper!(Time);
+unvalidated_wrapper!(Unsigned);
+
+// Add `as_signed(&self) -> &signed::Event<Ipld>` functions to the signed types
+as_signed!(SignedData);
+as_signed!(SignedInit);
+
+#[derive(Debug)]
+pub struct GroupedEvents {
+    pub time: Vec<Time>,
+    pub unsigned: Vec<Unsigned>,
+    pub signed: SignedEvents,
+}
+
+#[derive(Debug)]
+pub struct SignedEvents {
+    pub data: Vec<SignedData>,
+    pub init: Vec<SignedInit>,
+}
+
+impl From<Vec<UnvalidatedEvent>> for GroupedEvents {
+    fn from(value: Vec<UnvalidatedEvent>) -> Self {
+        let mut grouped = GroupedEvents::new(value.len() / 2);
+
+        value
+            .into_iter()
+            .for_each(|v| grouped.add(ValidationNeeded::from(v)));
+        grouped
+    }
+}
+
+impl GroupedEvents {
+    fn new(capacity: usize) -> Self {
+        Self {
+            time: Vec::with_capacity(capacity),
+            unsigned: Vec::with_capacity(capacity),
+            signed: SignedEvents {
+                data: Vec::with_capacity(capacity),
+                init: Vec::with_capacity(capacity),
+            },
+        }
+    }
+
+    fn add(&mut self, new: ValidationNeeded) {
+        match new {
+            ValidationNeeded::SignedInit(v) => self.signed.init.push(v),
+            ValidationNeeded::SignedData(v) => self.signed.data.push(v),
+            ValidationNeeded::Time(v) => self.time.push(v),
+            ValidationNeeded::None(v) => self.unsigned.push(v),
+        }
+    }
+}

--- a/event-svc/src/event/validator/mod.rs
+++ b/event-svc/src/event/validator/mod.rs
@@ -1,6 +1,6 @@
-// TODO: remove once this is actually used
-#[allow(dead_code)]
 mod event;
+mod grouped;
+mod signed;
 // this is not used yet
 // we should export the following and consume in the event validator
 // pub use time::{BlockchainVerifier, EthRpcProvider, EventTimestamper, Timestamp};

--- a/event-svc/src/event/validator/signed.rs
+++ b/event-svc/src/event/validator/signed.rs
@@ -1,0 +1,267 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use ceramic_core::{SerializeExt, StreamId};
+use ceramic_event::unvalidated::{self, init, signed};
+use ceramic_validation::{cacao_verifier::Verifier, event_verifier::Verifier as _, VerifyJwsOpts};
+use cid::Cid;
+use ipld_core::ipld::Ipld;
+use tracing::warn;
+
+use crate::{
+    event::service::ValidationError,
+    store::{CeramicOneEvent, SqlitePool},
+    Result,
+};
+
+use super::{
+    event::{ValidatedEvent, ValidatedEvents},
+    grouped::{SignedEvents, Unsigned},
+    UnvalidatedEvent,
+};
+
+#[derive(Debug)]
+/// A signed validator is expected to be constructed to validate a batch of events and then be dropped.
+/// It will cache init events for the batch to use at different stages of validation and then drop everything
+/// when it finishes.
+pub struct SignedValidator {
+    /// The init events needed to validate this batch of events.
+    init_map: HashMap<Cid, Arc<unvalidated::Event<Ipld>>>,
+    /// The set of invalid init CIDs that can be used to reject any events that depend on them without even looking at them.
+    invalid_init: HashSet<Cid>,
+    /// The result of this validation batch that is updated as we go.
+    validated: ValidatedEvents,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ValidationStatus {
+    ValidInit,
+    ValidData,
+    InvalidInit(String),
+    InvalidData(String),
+    Pending,
+}
+
+impl SignedValidator {
+    fn new(init_cnt: usize, data_cnt: usize) -> Self {
+        Self {
+            init_map: HashMap::with_capacity(init_cnt),
+            invalid_init: HashSet::new(),
+            validated: ValidatedEvents::new_with_expected_valid(init_cnt + data_cnt),
+        }
+    }
+
+    /// blindly trusts that this is indeed an init event
+    /// will error later if not
+    fn track_init(&mut self, cid: Cid, event: Arc<unvalidated::Event<Ipld>>) {
+        self.init_map.insert(cid, event);
+    }
+
+    fn add_invalid(&mut self, item: ValidationError) {
+        self.validated.invalid.push(item);
+    }
+
+    fn add_pending(&mut self, item: UnvalidatedEvent) {
+        self.validated.unvalidated.push(item);
+    }
+
+    fn add_valid(&mut self, item: ValidatedEvent) {
+        self.validated.valid.push(item);
+    }
+
+    fn add_valid_iter<I>(&mut self, item: I)
+    where
+        I: Iterator<Item = ValidatedEvent>,
+    {
+        self.validated.valid.extend(item);
+    }
+
+    pub async fn validate_events(
+        pool: &SqlitePool,
+        opts: &VerifyJwsOpts,
+        events: SignedEvents,
+        unsigned: Vec<Unsigned>,
+    ) -> Result<ValidatedEvents> {
+        let mut validator = Self::new(events.init.len() + unsigned.len(), events.data.len());
+        validator.init_map.extend(
+            unsigned
+                .iter()
+                .map(|i| (i.as_inner().cid, i.as_inner().event.to_owned())),
+        );
+        validator.add_valid_iter(unsigned.into_iter().map(|i| i.into()));
+
+        for event in events.init {
+            let status = validator
+                .validate_signed(pool, opts, event.as_signed())
+                .await?;
+            validator.process_result(status, event.into_inner());
+        }
+
+        for event in events.data {
+            let status = validator
+                .validate_signed(pool, opts, event.as_signed())
+                .await?;
+            validator.process_result(status, event.into_inner());
+        }
+
+        Ok(validator.validated)
+    }
+
+    fn process_result(&mut self, status: ValidationStatus, event: UnvalidatedEvent) {
+        match status {
+            ValidationStatus::ValidInit => {
+                self.init_map.insert(event.cid, event.event.clone());
+                self.add_valid(ValidatedEvent::from_unvalidated_unchecked(event));
+            }
+            ValidationStatus::ValidData => {
+                self.add_valid(ValidatedEvent::from_unvalidated_unchecked(event))
+            }
+            ValidationStatus::InvalidInit(reason) => {
+                self.invalid_init.insert(event.cid);
+                self.add_invalid(ValidationError::InvalidSignature {
+                    key: event.key,
+                    reason,
+                })
+            }
+            ValidationStatus::InvalidData(reason) => {
+                self.add_invalid(ValidationError::InvalidSignature {
+                    key: event.key,
+                    reason,
+                })
+            }
+            ValidationStatus::Pending => self.add_pending(event),
+        }
+    }
+
+    /// Returns an enum representing the validation status and what type of event it was
+    async fn validate_signed(
+        &mut self,
+        pool: &SqlitePool,
+        opts: &VerifyJwsOpts,
+        signed: &signed::Event<Ipld>,
+    ) -> Result<ValidationStatus> {
+        match signed.payload() {
+            unvalidated::Payload::Data(d) => {
+                let init = if let Some(init) = self.init_map.get(d.id()) {
+                    init.to_owned()
+                } else {
+                    match CeramicOneEvent::value_by_cid(pool, d.id()).await? {
+                        Some(init) => {
+                            let (init_cid, init) =
+                                            unvalidated::Event::<Ipld>::decode_car(
+                                                std::io::Cursor::new(init),
+                                                false,
+                                            )
+                                            .unwrap_or_else(|err| panic!("should not have stored invalid data in db for init cid={}. err={:#}", d.id(), err));
+                            let init = std::sync::Arc::new(init);
+                            self.track_init(init_cid, init.clone()); // cache in case other events need it
+                            init
+                        }
+                        None => {
+                            // if it depends on invalid item, it's invalid, else we have to wait for more info
+                            if self.invalid_init.contains(d.id()) {
+                                return Ok(ValidationStatus::InvalidData(format!(
+                                    "data event refers to stream with invalid init event (cid={})",
+                                    d.id()
+                                )));
+                            } else {
+                                return Ok(ValidationStatus::Pending);
+                            }
+                        }
+                    }
+                };
+
+                match self.verify_signature(init, signed, opts).await {
+                    Ok(_) => Ok(ValidationStatus::ValidData),
+                    Err(err) => Ok(ValidationStatus::InvalidData(err)),
+                }
+            }
+            unvalidated::Payload::Init(init) => {
+                // we pass the same event for the `init`` and `signed`` parameters which is a bit silly, but it works fine
+                match self
+                    .verify_signature_against_init_controller(init, signed, opts)
+                    .await
+                {
+                    Ok(_) => Ok(ValidationStatus::ValidInit),
+                    Err(err) => Ok(ValidationStatus::InvalidInit(err)),
+                }
+            }
+        }
+    }
+
+    /// The main entry point for validating a signed event's signatures for this struct.
+    /// It will delegate to [`SignedValidator::verify_signature_against_init_controller`] to validate the cacao and event signatures.
+    async fn verify_signature(
+        &mut self,
+        init: Arc<unvalidated::Event<Ipld>>,
+        signed: &signed::Event<Ipld>,
+        opts: &VerifyJwsOpts,
+    ) -> std::result::Result<(), String> {
+        match init.as_ref() {
+            unvalidated::Event::Time(_) => {
+                Err("init event pointer cannot reference a time event".to_string())
+            }
+            unvalidated::Event::Signed(s) => match s.payload() {
+                unvalidated::Payload::Data(_d) => {
+                    Err("init event pointer cannot reference a data event".to_string())
+                }
+                unvalidated::Payload::Init(init) => {
+                    self.verify_signature_against_init_controller(init, signed, opts)
+                        .await
+                }
+            },
+            unvalidated::Event::Unsigned(init) => {
+                self.verify_signature_against_init_controller(init.payload(), signed, opts)
+                    .await
+            }
+        }
+    }
+
+    /// An extension to the [`SignedValidator::verify_signature`] function that requires the init event to make sure the controller of the
+    /// new event is indeed the in the stream delegation chain. This should *almost* always be called, the only reason we
+    /// support validating without the init event is that we migrate data from an old ipfs install out of order and don't
+    /// want to pend everything in memory while try to put things back in order to verify signatures, so instead we make sure
+    /// each event is well structured and correctly signed, assuming that the original protocol rules were followed.
+    /// If we send invalid events to other nodes, they will ignore them or hang up on us, so it won't propagate around the network.
+    async fn verify_signature_against_init_controller(
+        &self,
+        init: &init::Payload<Ipld>,
+        signed: &signed::Event<Ipld>,
+        opts: &VerifyJwsOpts,
+    ) -> std::result::Result<(), String> {
+        // TODO: should we error if controller is missing?
+        let controller = init.header().controllers().first().cloned();
+        match signed.capability() {
+            Some((cid, cacao)) => {
+                let init_cid = init.to_cid().map_err(|e| {
+                    format!(
+                        "failed to determine init event CID for data event={}. err={:#}",
+                        signed.envelope_cid(),
+                        e
+                    )
+                })?;
+                let model_id = match StreamId::try_from(init.header().model()) {
+                    Ok(m) => Some(m),
+                    Err(e) => {
+                        warn!(error=?e, %init_cid, "failed to parse init event model field as stream");
+                        None
+                    }
+                };
+                // TODO(AES-351): this assumes all streams are MIDs
+                let stream_id = StreamId::document(init_cid);
+                cacao
+                    .verify_access(&stream_id, Some(*cid), model_id.as_ref())
+                    .map_err(|e| e.to_string())?;
+            }
+            None => {
+                // no cacao to verify so signature is sufficient
+            }
+        }
+        signed
+            .verify_signature(controller.as_deref(), opts)
+            .await
+            .map_err(|e| e.to_string())
+    }
+}

--- a/event-svc/src/event/validator/signed.rs
+++ b/event-svc/src/event/validator/signed.rs
@@ -26,7 +26,7 @@ use super::{
 /// A signed validator is expected to be constructed to validate a batch of events and then be dropped.
 /// It will cache init events for the batch to use at different stages of validation and then drop everything
 /// when it finishes.
-pub struct SignedValidator {
+pub struct SignedEventValidator {
     /// The init events needed to validate this batch of events.
     init_map: HashMap<Cid, Arc<unvalidated::Event<Ipld>>>,
     /// The set of invalid init CIDs that can be used to reject any events that depend on them without even looking at them.
@@ -44,7 +44,7 @@ enum ValidationStatus {
     Pending,
 }
 
-impl SignedValidator {
+impl SignedEventValidator {
     fn new(init_cnt: usize, data_cnt: usize) -> Self {
         Self {
             init_map: HashMap::with_capacity(init_cnt),

--- a/event-svc/src/tests/mod.rs
+++ b/event-svc/src/tests/mod.rs
@@ -63,10 +63,10 @@ pub(crate) struct TestEventInfo {
     pub(crate) blocks: Vec<Block>,
 }
 
-async fn build_event_fixed_model(model: StreamId) -> TestEventInfo {
+async fn build_event_fixed_model(model: StreamId, controller: String) -> TestEventInfo {
     let unique = gen_rand_bytes::<12>();
     let init = ceramic_event::unvalidated::Builder::init()
-        .with_controller(CONTROLLER.to_owned())
+        .with_controller(controller)
         .with_sep("model".to_string(), model.to_vec())
         .with_unique(unique.to_vec())
         .with_data(ipld!({"radius": 1, "red": 2, "green": 3, "blue": 4}))
@@ -96,10 +96,16 @@ async fn build_event_fixed_model(model: StreamId) -> TestEventInfo {
     }
 }
 
+pub(crate) async fn build_recon_item_with_controller(controller: String) -> ReconItem<EventId> {
+    let model = StreamId::document(random_cid());
+    let e = build_event_fixed_model(model, controller).await;
+    ReconItem::new(e.event_id, e.car)
+}
+
 /// returns (event ID, array of block CIDs, car bytes)
 pub(crate) async fn build_event() -> TestEventInfo {
     let model = StreamId::document(random_cid());
-    build_event_fixed_model(model).await
+    build_event_fixed_model(model, CONTROLLER.to_owned()).await
 }
 
 fn gen_rand_bytes<const SIZE: usize>() -> [u8; SIZE] {

--- a/event-svc/src/tests/ordering.rs
+++ b/event-svc/src/tests/ordering.rs
@@ -34,7 +34,7 @@ async fn add_and_assert_new_recon_event_not_inserted_yet(
     let new = recon::Store::insert_many(store, &[item], NodeId::random().unwrap().0)
         .await
         .unwrap();
-    assert!(new.included_new_key()); // should be !new.included_new_key() once pending validation is tracked
+    assert!(!new.included_new_key());
 }
 
 // insert a recon event without checking whether its persisted (could be pending or stored)


### PR DESCRIPTION
Initial implementation of validation for signed events. The Validation module accepts the list of events, partitions them into "time" and "signed" events and delegates the validation to the appropriate handler. 

The signed validator will validate events against the init controller and if it's unable to find the init event, will consider them unvalidated. The service decides whether this is an error or acceptable based on the `ValidationRequirement` `allow_pending` value. If pending is supported, they are tracked in memory until the required init event is found, otherwise they are considered an error.

When verifying against the init event we check the CACAO resources, the CACAO and envelope signatures and the delegation chain, but we currently assume all streams are MIDs when constructing the stream ID to use.

This targets ~~#505~~ #526 and is not enabled by default yet as it is behind an experimental feature flag: `--experimental-feature-flags event-validation`. 