### PR TITLE
fix: use cacao timestamp strings and parse

### DIFF
--- a/event/Cargo.toml
+++ b/event/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 base64.workspace = true
 ceramic-car.workspace = true
 ceramic-core.workspace = true
+chrono.workspace = true
 cid.workspace = true
 ipld-core.workspace = true
 multihash-codetable.workspace = true
@@ -24,7 +25,6 @@ serde_json.workspace = true
 ssi.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-chrono = "0.4"
 
 [dev-dependencies]
 multibase.workspace = true

--- a/validation/src/signature/pkh_ethereum.rs
+++ b/validation/src/signature/pkh_ethereum.rs
@@ -48,7 +48,7 @@ impl PkhEthereum {
             }
         }
 
-        if recovered != issuer && cacao.payload.issued_at < *LEGACY_CHAIN_ID_REORG_DATE {
+        if recovered != issuer && cacao.payload.issued_at()? < *LEGACY_CHAIN_ID_REORG_DATE {
             // might be an old CACAOv1 format
             recovered = Self::verify_message(
                 &siwx.as_legacy_chain_id_message(ETH_CHAIN),

--- a/validation/src/siwx_message.rs
+++ b/validation/src/siwx_message.rs
@@ -34,13 +34,13 @@ pub struct SiwxMessage<'a> {
     /// characters.
     nonce: &'a str,
     /// ISO 8601 datetime String of the current time.
-    issued_at: &'a DateTime<Utc>,
+    issued_at: DateTime<Utc>,
     /// Presented to the user as an ISO 8601 datetime String that, if present,
     /// indicates when the signed authentication message is no longer valid.
-    expiration_time: Option<&'a DateTime<Utc>>,
+    expiration_time: Option<DateTime<Utc>>,
     /// Presented to the user as a ISO 8601 datetime String that, if present,
     /// indicates when the signed authentication message will become valid.
-    not_before: Option<&'a DateTime<Utc>>,
+    not_before: Option<DateTime<Utc>>,
     /// System-specific identifier that may be used to uniquely refer to the
     /// sign-in request.
     request_id: Option<&'a str>,
@@ -65,9 +65,9 @@ impl<'a> SiwxMessage<'a> {
             uri: &cacao.payload.audience,
             version: &cacao.payload.version,
             nonce: &cacao.payload.nonce,
-            issued_at: &cacao.payload.issued_at,
-            expiration_time: cacao.payload.expiration.as_ref(),
-            not_before: cacao.payload.not_before.as_ref(),
+            issued_at: cacao.payload.issued_at()?,
+            expiration_time: cacao.payload.expiration()?,
+            not_before: cacao.payload.not_before()?,
             request_id: cacao.payload.request_id.as_deref(),
             resources: cacao.payload.resources.as_deref(),
             signature: Some(cacao.signature.signature.as_ref()),

--- a/validation/src/verifier/cacao_verifier.rs
+++ b/validation/src/verifier/cacao_verifier.rs
@@ -61,16 +61,16 @@ impl Verifier for Capability {
     fn verify_time_checks(&self, opts: &VerifyOpts) -> anyhow::Result<()> {
         let at_time = opts.at_time.unwrap_or_else(chrono::Utc::now);
 
-        if self.payload.issued_at > at_time + opts.clock_skew
+        if self.payload.issued_at()? > at_time + opts.clock_skew
             || self
                 .payload
-                .not_before
+                .not_before()?
                 .map_or(false, |nb| nb > at_time + opts.clock_skew)
         {
             anyhow::bail!("CACAO is not valid yet")
         }
         if opts.check_exp {
-            if let Some(exp) = self.payload.expiration {
+            if let Some(exp) = self.payload.expiration()? {
                 if exp + opts.revocation_phaseout_secs + opts.clock_skew < at_time {
                     anyhow::bail!("CACAO has expired")
                 }


### PR DESCRIPTION
In order to ensure that CACAOs round trip without changing the CID, we use a string when deserializing rather than a chrono::DateTime which can change the second precision that was originally included. It's a bit clunky, open to better ideas.