### PR TITLE
feat: groundwork for event validation and some clean up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ ceramic-one = { path = "./one" }
 ceramic-p2p = { path = "./p2p" }
 ceramic-service = { path = "./service" }
 ceramic-store = { path = "./store" }
+ceramic-validation = { path = "./validation" }
 chrono = "0.4.31"
 cid = { version = "0.11", features = ["serde-codec"] }
 clap = { version = "4", features = ["derive", "env", "string"] }

--- a/one/src/feature_flags.rs
+++ b/one/src/feature_flags.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Result};
 pub(crate) enum ExperimentalFeatureFlags {
     None,
     Authentication,
+    EventValidation,
 }
 
 impl std::str::FromStr for ExperimentalFeatureFlags {
@@ -13,6 +14,7 @@ impl std::str::FromStr for ExperimentalFeatureFlags {
         match value.to_ascii_lowercase().as_str() {
             "none" => Ok(ExperimentalFeatureFlags::None),
             "authentication" => Ok(ExperimentalFeatureFlags::Authentication),
+            "event-validation" => Ok(ExperimentalFeatureFlags::EventValidation),
             _ => Err(anyhow!("invalid value")),
         }
     }
@@ -23,6 +25,7 @@ impl std::fmt::Display for ExperimentalFeatureFlags {
         match self {
             ExperimentalFeatureFlags::None => write!(f, "none"),
             ExperimentalFeatureFlags::Authentication => write!(f, "authentication"),
+            ExperimentalFeatureFlags::EventValidation => write!(f, "event-validation"),
         }
     }
 }

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -88,7 +88,8 @@ pub async fn migrate(cmd: EventsCommand) -> Result<()> {
 async fn from_ipfs(opts: FromIpfsOpts) -> Result<()> {
     let network = opts.network.to_network(&opts.local_network_id)?;
     let db_opts: DBOpts = (&opts).into();
-    let crate::Databases::Sqlite(db) = db_opts.get_database(false).await?;
+    // TODO: feature flags here? or just remove this entirely when enabling
+    let crate::Databases::Sqlite(db) = db_opts.get_database(false, false).await?;
     let blocks = FSBlockStore {
         input_ipfs_path: opts.input_ipfs_path,
     };

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1387,7 +1387,7 @@ mod tests {
             let sql_pool = SqlitePool::connect_in_memory().await.unwrap();
 
             let metrics = Metrics::register(&mut prometheus_client::registry::Registry::default());
-            let store = Arc::new(CeramicEventService::new(sql_pool).await?);
+            let store = Arc::new(CeramicEventService::new(sql_pool, true).await?);
             store.process_all_undelivered_events().await?;
             let mut p2p = Node::new(
                 network_config,

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -164,7 +164,7 @@ impl CeramicEventService {
         let mut signed_events = Vec::with_capacity(parsed_events.len());
         let mut time_events = Vec::with_capacity(parsed_events.len());
         for event in parsed_events {
-            match event.event() {
+            match event.event().as_ref() {
                 Event::Time(_) => {
                     time_events.push(event);
                 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -24,11 +24,11 @@ pub struct CeramicService {
 
 impl CeramicService {
     /// Create a new CeramicService and process undelivered events if requested
-    pub async fn try_new(pool: SqlitePool) -> Result<Self> {
+    pub async fn try_new(pool: SqlitePool, enable_event_validation: bool) -> Result<Self> {
         // In the future, we may need to check the previous version to make sure we're not downgrading and risking data loss
         CeramicOneVersion::insert_current(&pool).await?;
         let interest = Arc::new(CeramicInterestService::new(pool.clone()));
-        let event = Arc::new(CeramicEventService::new(pool).await?);
+        let event = Arc::new(CeramicEventService::new(pool, enable_event_validation).await?);
         Ok(Self { interest, event })
     }
 

--- a/service/src/tests/event.rs
+++ b/service/src/tests/event.rs
@@ -17,7 +17,7 @@ macro_rules! test_with_sqlite {
             async fn [<$test_name _sqlite>]() {
 
                 let conn = ceramic_store::SqlitePool::connect_in_memory().await.unwrap();
-                let store = $crate::CeramicEventService::new(conn).await.unwrap();
+                let store = $crate::CeramicEventService::new_with_event_validation(conn).await.unwrap();
                 store.process_all_undelivered_events().await.unwrap();
                 $(
                     for stmt in $sql_stmts {

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -57,7 +57,9 @@ async fn test_migration(cars: Vec<Vec<u8>>) {
     let conn = ceramic_store::SqlitePool::connect_in_memory()
         .await
         .unwrap();
-    let service = CeramicEventService::new(conn).await.unwrap();
+    let service = CeramicEventService::new_with_event_validation(conn)
+        .await
+        .unwrap();
     service
         .migrate_from_ipfs(Network::Local(42), blocks)
         .await

--- a/service/src/tests/ordering.rs
+++ b/service/src/tests/ordering.rs
@@ -18,7 +18,9 @@ async fn setup_service() -> CeramicEventService {
         .await
         .unwrap();
 
-    CeramicEventService::new(conn).await.unwrap()
+    CeramicEventService::new_with_event_validation(conn)
+        .await
+        .unwrap()
 }
 
 async fn add_and_assert_new_recon_event(store: &CeramicEventService, item: ReconItem<EventId>) {

--- a/store/src/sql/entities/event.rs
+++ b/store/src/sql/entities/event.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, sync::Arc};
 
 use anyhow::anyhow;
 use ceramic_car::{CarHeader, CarReader, CarWriter};
@@ -51,7 +51,7 @@ pub struct EventInsertable {
     /// Whether the event is deliverable i.e. it's prev has been delivered and the chain is continuous to an init event
     deliverable: bool,
     /// The parsed structure containing the actual Event data.
-    event: unvalidated::Event<Ipld>,
+    event: Arc<unvalidated::Event<Ipld>>,
 }
 
 impl EventInsertable {
@@ -81,7 +81,7 @@ impl EventInsertable {
             order_key,
             cid,
             deliverable,
-            event,
+            event: Arc::new(event),
         })
     }
 
@@ -96,7 +96,7 @@ impl EventInsertable {
     }
 
     /// Get the parsed Event structure.
-    pub fn event(&self) -> &unvalidated::Event<Ipld> {
+    pub fn event(&self) -> &Arc<unvalidated::Event<Ipld>> {
         &self.event
     }
 


### PR DESCRIPTION
Cleaned up some oversights like not adding the new crate to the workspace dependencies list and the benchmark not compiling. Also put an `Arc` around the event on `EventInsertable` so I can clone it to track in a map for the event validation work.

The main change is adding a new experimental feature flag that event validation is behind. It's a sub optimal representation, but my intention is that it's temporary and allows me to merge changes in #503 so we can benchmark and test more thoroughly before it's on everywhere, at which point the feature flag will be removed and it's the configured behavior. It's enabled with `--experimental-feature-flags event-validation`.

All of these changes were part of #503, so I'll rebase that one to use this as the source since these should be standalone and we can agree on this structure without getting into the weeds of the validation implementation. This should also allow us to merge imperfect changes and follow up rather than having to get everything right on the first attempt.