### PR TITLE
feat: use key value pairs for experimental feature flags

### DIFF
--- a/one/src/feature_flags.rs
+++ b/one/src/feature_flags.rs
@@ -17,9 +17,16 @@ impl std::str::FromStr for ExperimentalFeatureFlags {
         }
 
         match parts[0].to_ascii_lowercase().as_str() {
-            "none" => Ok(ExperimentalFeatureFlags::None),
-            "authentication" => Ok(ExperimentalFeatureFlags::Authentication),
-            "event-validation" => Ok(ExperimentalFeatureFlags::EventValidation),
+            "authentication" => match parts[1].trim().to_ascii_lowercase().as_str() {
+                "true" => Ok(ExperimentalFeatureFlags::Authentication),
+                "false" => Ok(ExperimentalFeatureFlags::None),
+                _ => Err(anyhow!("invalid value for the 'authentication' flag, should be 'true' or 'false'")),
+            },
+            "event-validation" => match parts[1].trim().to_ascii_lowercase().as_str() {
+                "true" => Ok(ExperimentalFeatureFlags::EventValidation),
+                "false" => Ok(ExperimentalFeatureFlags::None),
+                _ => Err(anyhow!("invalid value for the 'event-validation' flag, should be 'true' or 'false'")),
+            },
             _ => Err(anyhow!("invalid value")),
         }
     }

--- a/one/src/feature_flags.rs
+++ b/one/src/feature_flags.rs
@@ -10,8 +10,13 @@ pub(crate) enum ExperimentalFeatureFlags {
 impl std::str::FromStr for ExperimentalFeatureFlags {
     type Err = anyhow::Error;
 
-    fn from_str(value: &str) -> Result<Self> {
-        match value.to_ascii_lowercase().as_str() {
+    fn from_str(s: &str) -> Result<Self> {
+        let parts: Vec<&str> = s.splitn(2, '=').collect();
+        if parts.len() != 2 {
+            return Err(anyhow!("Invalid key=value format: '{}'", s));
+        }
+
+        match parts[0].to_ascii_lowercase().as_str() {
             "none" => Ok(ExperimentalFeatureFlags::None),
             "authentication" => Ok(ExperimentalFeatureFlags::Authentication),
             "event-validation" => Ok(ExperimentalFeatureFlags::EventValidation),

--- a/one/src/feature_flags.rs
+++ b/one/src/feature_flags.rs
@@ -20,12 +20,16 @@ impl std::str::FromStr for ExperimentalFeatureFlags {
             "authentication" => match parts[1].trim().to_ascii_lowercase().as_str() {
                 "true" => Ok(ExperimentalFeatureFlags::Authentication),
                 "false" => Ok(ExperimentalFeatureFlags::None),
-                _ => Err(anyhow!("invalid value for the 'authentication' flag, should be 'true' or 'false'")),
+                _ => Err(anyhow!(
+                    "invalid value for the 'authentication' flag, should be 'true' or 'false'"
+                )),
             },
             "event-validation" => match parts[1].trim().to_ascii_lowercase().as_str() {
                 "true" => Ok(ExperimentalFeatureFlags::EventValidation),
                 "false" => Ok(ExperimentalFeatureFlags::None),
-                _ => Err(anyhow!("invalid value for the 'event-validation' flag, should be 'true' or 'false'")),
+                _ => Err(anyhow!(
+                    "invalid value for the 'event-validation' flag, should be 'true' or 'false'"
+                )),
             },
             _ => Err(anyhow!("invalid value")),
         }

--- a/one/src/feature_flags.rs
+++ b/one/src/feature_flags.rs
@@ -1,13 +1,12 @@
 use anyhow::{anyhow, Result};
 
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum ExperimentalFeatureFlags {
-    None,
-    Authentication,
-    EventValidation,
+pub(crate) enum FeatureFlags {
+    Authentication(bool),
+    EventValidation(bool),
 }
 
-impl std::str::FromStr for ExperimentalFeatureFlags {
+impl std::str::FromStr for FeatureFlags {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
@@ -17,55 +16,26 @@ impl std::str::FromStr for ExperimentalFeatureFlags {
         }
 
         match parts[0].to_ascii_lowercase().as_str() {
-            "authentication" => match parts[1].trim().to_ascii_lowercase().as_str() {
-                "true" => Ok(ExperimentalFeatureFlags::Authentication),
-                "false" => Ok(ExperimentalFeatureFlags::None),
-                _ => Err(anyhow!(
-                    "invalid value for the 'authentication' flag, should be 'true' or 'false'"
-                )),
-            },
-            "event-validation" => match parts[1].trim().to_ascii_lowercase().as_str() {
-                "true" => Ok(ExperimentalFeatureFlags::EventValidation),
-                "false" => Ok(ExperimentalFeatureFlags::None),
-                _ => Err(anyhow!(
-                    "invalid value for the 'event-validation' flag, should be 'true' or 'false'"
-                )),
-            },
+            "authentication" => Ok(FeatureFlags::Authentication(
+                parts[1].trim().to_ascii_lowercase().parse().expect(
+                    "Invalid value for the 'authentication' flag, should be 'true' or 'false'",
+                ),
+            )),
+            "event-validation" => Ok(FeatureFlags::EventValidation(
+                parts[1].trim().to_ascii_lowercase().parse().expect(
+                    "Invalid value for the 'event-validation' flag, should be 'true' or 'false'",
+                ),
+            )),
             _ => Err(anyhow!("invalid value")),
         }
     }
-}
-
-impl std::fmt::Display for ExperimentalFeatureFlags {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExperimentalFeatureFlags::None => write!(f, "none"),
-            ExperimentalFeatureFlags::Authentication => write!(f, "authentication"),
-            ExperimentalFeatureFlags::EventValidation => write!(f, "event-validation"),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub(crate) enum FeatureFlags {
-    None,
 }
 
 impl std::fmt::Display for FeatureFlags {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FeatureFlags::None => write!(f, "none"),
-        }
-    }
-}
-
-impl std::str::FromStr for FeatureFlags {
-    type Err = anyhow::Error;
-
-    fn from_str(value: &str) -> Result<Self> {
-        match value.to_ascii_lowercase().as_str() {
-            "none" => Ok(FeatureFlags::None),
-            _ => Err(anyhow!("invalid value")),
+            FeatureFlags::Authentication(b) => write!(f, "authentication={}", b),
+            FeatureFlags::EventValidation(b) => write!(f, "event-validation={}", b),
         }
     }
 }

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -170,15 +170,6 @@ struct DaemonOpts {
         )]
     cors_allow_origins: Vec<String>,
 
-    /// Enable experimental feature flags
-    #[arg(
-        long,
-        use_value_delimiter = true,
-        value_delimiter = ',',
-        env = "CERAMIC_ONE_EXPERIMENTAL_FEATURE_FLAGS"
-    )]
-    experimental_feature_flags: Vec<ExperimentalFeatureFlags>,
-
     /// Enable feature flags
     #[arg(
         long,
@@ -394,8 +385,8 @@ impl Daemon {
             .db_opts
             .get_database(
                 true,
-                opts.experimental_feature_flags
-                    .contains(&ExperimentalFeatureFlags::EventValidation),
+                opts.feature_flags
+                    .contains(&FeatureFlags::EventValidation(true)),
             )
             .await?;
 
@@ -585,8 +576,8 @@ impl Daemon {
             Arc::new(model_api_store),
         );
         if opts
-            .experimental_feature_flags
-            .contains(&ExperimentalFeatureFlags::Authentication)
+            .feature_flags
+            .contains(&FeatureFlags::Authentication(true))
         {
             ceramic_server.with_authentication(true);
         }


### PR DESCRIPTION
I removed none because I didn't know what to do with it
Used https://github.com/ceramicnetwork/rust-ceramic/pull/448#pullrequestreview-2213083696 as reference 
Can comma separate or set `--experimental-feature-flags` multiple times