### PR TITLE
fix: updates detection of tile docs and doesn't log them by default

### DIFF
--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -51,9 +51,9 @@ pub struct FromIpfsOpts {
     #[arg(long, env = "CERAMIC_ONE_LOCAL_NETWORK_ID")]
     local_network_id: Option<u32>,
 
-    /// Do not log information about tile documents found during the migration.
-    #[arg(long, env = "CERAMIC_ONE_IGNORE_TILE_DOCS", default_value_t = true)]
-    ignore_tile_docs: bool,
+    /// Log information about tile documents found during the migration.
+    #[arg(long, env = "CERAMIC_ONE_LOG_TILE_DOCS", default_value_t = false)]
+    log_tile_docs: bool,
 
     #[command(flatten)]
     log_opts: LogOpts,
@@ -98,7 +98,7 @@ async fn from_ipfs(opts: FromIpfsOpts) -> Result<()> {
         input_ipfs_path: opts.input_ipfs_path,
     };
     db.event_store
-        .migrate_from_ipfs(network, blocks, opts.ignore_tile_docs)
+        .migrate_from_ipfs(network, blocks, opts.log_tile_docs)
         .await?;
     Ok(())
 }

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -51,6 +51,10 @@ pub struct FromIpfsOpts {
     #[arg(long, env = "CERAMIC_ONE_LOCAL_NETWORK_ID")]
     local_network_id: Option<u32>,
 
+    /// Do not log information about tile documents found during the migration.
+    #[arg(long, env = "CERAMIC_ONE_IGNORE_TILE_DOCS", default_value_t = true)]
+    ignore_tile_docs: bool,
+
     #[command(flatten)]
     log_opts: LogOpts,
 }
@@ -93,7 +97,9 @@ async fn from_ipfs(opts: FromIpfsOpts) -> Result<()> {
     let blocks = FSBlockStore {
         input_ipfs_path: opts.input_ipfs_path,
     };
-    db.event_store.migrate_from_ipfs(network, blocks).await?;
+    db.event_store
+        .migrate_from_ipfs(network, blocks, opts.ignore_tile_docs)
+        .await?;
     Ok(())
 }
 

--- a/service/src/event/migration.rs
+++ b/service/src/event/migration.rs
@@ -62,7 +62,7 @@ impl<'a, S: BlockStore> Migrator<'a, S> {
         if let Some(block) = self.blocks.block_data(cid).await? {
             Ok(block)
         } else {
-            Err(Error::MissingBlock(*cid).into())
+            Err(Error::MissingBlock(*cid))
         }
     }
 

--- a/service/src/event/migration.rs
+++ b/service/src/event/migration.rs
@@ -21,7 +21,7 @@ pub struct Migrator<'a, S> {
     network: Network,
     blocks: S,
     batch: Vec<ReconItem<EventId>>,
-    ignore_tile_docs: bool,
+    log_tile_docs: bool,
 
     // All unsigned init payloads we have found.
     unsigned_init_payloads: BTreeSet<Cid>,
@@ -42,13 +42,13 @@ impl<'a, S: BlockStore> Migrator<'a, S> {
         service: &'a CeramicEventService,
         network: Network,
         blocks: S,
-        ignore_tile_docs: bool,
+        log_tile_docs: bool,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             network,
             service,
             blocks,
-            ignore_tile_docs,
+            log_tile_docs,
             batch: Default::default(),
             unsigned_init_payloads: Default::default(),
             referenced_unsigned_init_payloads: Default::default(),
@@ -78,7 +78,7 @@ impl<'a, S: BlockStore> Migrator<'a, S> {
                 let log = match err {
                     Error::FoundInitTileDoc(_) | Error::FoundDataTileDoc(_) => {
                         self.tile_doc_count += 1;
-                        !self.ignore_tile_docs
+                        self.log_tile_docs
                     }
                     Error::MissingBlock(_) | Error::Fatal(_) => {
                         self.error_count += 1;

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -97,8 +97,13 @@ impl CeramicEventService {
         .await
     }
 
-    pub async fn migrate_from_ipfs(&self, network: Network, blocks: impl BlockStore) -> Result<()> {
-        let migrator = Migrator::new(self, network, blocks)
+    pub async fn migrate_from_ipfs(
+        &self,
+        network: Network,
+        blocks: impl BlockStore,
+        ignore_tile_docs: bool,
+    ) -> Result<()> {
+        let migrator = Migrator::new(self, network, blocks, ignore_tile_docs)
             .await
             .map_err(Error::new_fatal)?;
         migrator.migrate().await.map_err(Error::new_fatal)?;

--- a/service/src/event/service.rs
+++ b/service/src/event/service.rs
@@ -101,9 +101,9 @@ impl CeramicEventService {
         &self,
         network: Network,
         blocks: impl BlockStore,
-        ignore_tile_docs: bool,
+        log_tile_docs: bool,
     ) -> Result<()> {
-        let migrator = Migrator::new(self, network, blocks, ignore_tile_docs)
+        let migrator = Migrator::new(self, network, blocks, log_tile_docs)
             .await
             .map_err(Error::new_fatal)?;
         migrator.migrate().await.map_err(Error::new_fatal)?;

--- a/service/src/tests/migration.rs
+++ b/service/src/tests/migration.rs
@@ -60,7 +60,7 @@ async fn test_migration(cars: Vec<Vec<u8>>) {
         .await
         .unwrap();
     service
-        .migrate_from_ipfs(Network::Local(42), blocks)
+        .migrate_from_ipfs(Network::Local(42), blocks, false)
         .await
         .unwrap();
     let actual_events: BTreeSet<_> = recon::Store::range_with_values(


### PR DESCRIPTION
With this change we catch two more cases where we can detect tile docs. Additionally by default we only count the number of tile docs we find and do not log any errors about them. This way any tile docs do not create a feeling of failure when migrating.