### PR TITLE
fix: start up ordering task bug

### DIFF
--- a/recon/src/protocol.rs
+++ b/recon/src/protocol.rs
@@ -764,7 +764,6 @@ where
     ///     - before we sign off on a conversation as either the initiator or responder
     ///     - when our in memory list gets too large
     async fn persist_all(&mut self) -> Result<()> {
-        tracing::info!("calling persist all: {}", self.event_q.len());
         if self.event_q.is_empty() {
             return Ok(());
         }


### PR DESCRIPTION
During a recent refactor (released in 0.33), prev was incorrectly set to the init_cid in the startup ordering task. This would have caused events to have been "delivered" in a possibly random order, as everything is after the init event. As this was just introduced and we generally have short streams that should be ordered inline, it is extremely unlikely that it caused any problems that merit a clean up migration (i.e. delete the current value, read all events to rewrite the deliverable order and tell js-ceramic to indexing again) so that is not included. 

I also deleted a log statement I accidentally left as info during debugging that shouldn't have landed. It could probably be trace but for now I just removed it as we have prometheus and other metrics around that.