### PR TITLE
chore: version v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.35.0] - 2024-09-09
+
+### 🚀 Features
+
+- Aes 287 create conclusion event type (#499)
+- Trait for generating cbor bytes and cids (#477)
+- Groundwork for event validation and some clean up (#505)
+- Anchor service (part 2) (#476)
+- Remote anchor transaction manager (part 3) (#478)
+
+### 🐛 Bug Fixes
+
+- Updates detection of tile docs and doesn't log them by default (#514)
+- Start up ordering task bug (#516)
+
+### 🚜 Refactor
+
+- Remove recon client/server and send empty ranges when we don't need anything (#509)
+- Create explicit event and interest services with separate stores. (#513)
+- Simplify daemon logic (#515)
+
+### ⚙️ Miscellaneous Tasks
+
+- Update console-subscriber package version (#507)
+
 ## [0.34.0] - 2024-08-26
 
 ### 🚀 Features
@@ -18,6 +43,7 @@ All notable changes to this project will be documented in this file.
 
 - Add logic to dispatch validation based on event type (#493)
 - Modify cacao, unvalidated module, jwk to add functionality needed for event validation (#492)
+- Version v0.34.0 (#506)
 
 ## [0.33.0] - 2024-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1431,7 +1431,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1476,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1554,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1621,7 +1621,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1706,7 +1706,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1733,7 +1733,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "built",
  "project-root",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1763,7 +1763,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-olap"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "ceramic-metrics",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4706,7 +4706,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4746,7 +4746,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.1",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -7868,7 +7868,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.34.0
-- Build date: 2024-08-26T21:42:47.754879189Z[Etc/UTC]
+- API version: 0.35.0
+- Build date: 2024-09-09T16:04:11.911682803Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.34.0
+  version: 0.35.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.34.0";
+pub const API_VERSION: &str = "0.35.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.34.0
+  version: 0.35.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.34.0"
+version = "0.35.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.34.0
-- Build date: 2024-08-26T21:42:49.846750291Z[Etc/UTC]
+- API version: 0.35.0
+- Build date: 2024-09-09T16:04:14.489447244Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.34.0
+  version: 0.35.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.34.0";
+pub const API_VERSION: &str = "0.35.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.34.0
+  version: 0.35.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.35.0] - 2024-09-09

### 🚀 Features

- Aes 287 create conclusion event type (#499)
- Trait for generating cbor bytes and cids (#477)
- Groundwork for event validation and some clean up (#505)
- Anchor service (part 2) (#476)
- Remote anchor transaction manager (part 3) (#478)

### 🐛 Bug Fixes

- Updates detection of tile docs and doesn't log them by default (#514)
- Start up ordering task bug (#516)

### 🚜 Refactor

- Remove recon client/server and send empty ranges when we don't need anything (#509)
- Create explicit event and interest services with separate stores. (#513)
- Simplify daemon logic (#515)

### ⚙️ Miscellaneous Tasks

- Update console-subscriber package version (#507)