### PR TITLE
chore: remove release event trigger for deb repo action

### DIFF
--- a/.github/workflows/update-deb-repo.yml
+++ b/.github/workflows/update-deb-repo.yml
@@ -2,8 +2,6 @@ name: Update Deb Repo
 
 on:
   workflow_dispatch:
-  release:
-    types: [released]
 
 jobs:
   update-deb-repo:


### PR DESCRIPTION
We don't currently need this action to run on releases (and it's failing), so it's manual only now.