### PR TITLE
refactor: return reference to inserted item from event store and reduce unnecessary ordering work 

### DIFF
--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -640,13 +640,25 @@ mod test {
             .unwrap();
 
         assert_eq!(9, new.inserted.len());
-        assert_eq!(0, new.inserted.iter().filter(|e| e.deliverable).count());
+        assert_eq!(
+            0,
+            new.inserted
+                .iter()
+                .filter(|e| e.inserted.deliverable())
+                .count()
+        );
 
         let new = CeramicOneEvent::insert_many(pool, [&init].into_iter())
             .await
             .unwrap();
         assert_eq!(1, new.inserted.len());
-        assert_eq!(1, new.inserted.iter().filter(|e| e.deliverable).count());
+        assert_eq!(
+            1,
+            new.inserted
+                .iter()
+                .filter(|e| e.inserted.deliverable())
+                .count()
+        );
         insertable
     }
 

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::{Arc, Mutex, MutexGuard},
 };
 
@@ -16,6 +16,7 @@ use ceramic_sql::sqlite::SqlitePool;
 use cid::Cid;
 use futures::stream::BoxStream;
 use ipld_core::ipld::Ipld;
+use itertools::Itertools;
 use recon::ReconItem;
 use tracing::{trace, warn};
 
@@ -268,14 +269,8 @@ impl EventService {
             self.track_pending(unvalidated);
         }
 
-        let store_result = self
-            .persist_events(to_insert, deliverable_req, &mut invalid)
-            .await?;
-
-        Ok(InsertResult {
-            store_result,
-            rejected: invalid,
-        })
+        self.persist_events(to_insert, deliverable_req, invalid)
+            .await
     }
 
     /// Persists events to disk and notifies the background ordering task when appropriate
@@ -283,8 +278,8 @@ impl EventService {
         &self,
         to_insert: Vec<EventInsertable>,
         deliverable_req: DeliverableRequirement,
-        invalid: &mut Vec<ValidationError>,
-    ) -> Result<crate::store::InsertResult> {
+        mut invalid: Vec<ValidationError>,
+    ) -> Result<InsertResult> {
         match deliverable_req {
             DeliverableRequirement::Immediate => {
                 let ordered =
@@ -295,7 +290,8 @@ impl EventService {
                         key: e.order_key().clone(),
                     }
                 }));
-                Ok(CeramicOneEvent::insert_many(&self.pool, to_insert).await?)
+                let store_result = CeramicOneEvent::insert_many(&self.pool, to_insert).await?;
+                Ok(InsertResult::new_from_store(invalid, store_result))
             }
             DeliverableRequirement::Asap => {
                 let ordered = OrderEvents::find_deliverable_in_memory(to_insert).await?;
@@ -306,15 +302,15 @@ impl EventService {
 
                 let store_result = CeramicOneEvent::insert_many(&self.pool, to_insert).await?;
 
-                self.notify_ordering_task(&ordered, &store_result).await?;
+                self.notify_ordering_task(&store_result).await?;
 
-                Ok(store_result)
+                Ok(InsertResult::new_from_store(invalid, store_result))
             }
             DeliverableRequirement::Lazy => {
                 let store_result =
                     CeramicOneEvent::insert_many(&self.pool, to_insert.iter()).await?;
 
-                Ok(store_result)
+                Ok(InsertResult::new_from_store(invalid, store_result))
             }
         }
     }
@@ -424,29 +420,16 @@ impl EventService {
 
     async fn notify_ordering_task(
         &self,
-        ordered: &OrderEvents,
-        store_result: &crate::store::InsertResult,
+        store_result: &crate::store::InsertResult<'_>,
     ) -> Result<()> {
-        let new = store_result
-            .inserted
-            .iter()
-            .filter_map(|i| if i.new_key { i.order_key.cid() } else { None })
-            .collect::<HashSet<_>>();
-        // TODO : Update discovered event to not have cid as an optional field
-        for ev in ordered
-            .deliverable()
-            .iter()
-            .chain(ordered.missing_history().iter())
-        {
-            if new.contains(ev.cid()) {
-                self.send_discovered_event(DiscoveredEvent {
-                    cid: *ev.cid(),
-                    prev: ev.event().prev().copied(),
-                    id: *ev.event().id(),
-                    known_deliverable: ev.deliverable(),
-                })
-                .await?;
-            }
+        for ev in store_result.inserted.iter() {
+            self.send_discovered_event(DiscoveredEvent {
+                cid: *ev.inserted.cid(),
+                prev: ev.inserted.event().prev().copied(),
+                id: *ev.inserted.event().id(),
+                known_deliverable: ev.inserted.deliverable(),
+            })
+            .await?;
         }
 
         Ok(())
@@ -480,10 +463,31 @@ pub enum ValidationError {
     },
 }
 
-#[derive(Debug, PartialEq, Eq, Default)]
+#[derive(Debug, PartialEq, Default)]
 pub struct InsertResult {
     pub rejected: Vec<ValidationError>,
-    pub(crate) store_result: crate::store::InsertResult,
+    pub new: Vec<EventId>,
+    pub existed: Vec<EventId>,
+}
+
+impl InsertResult {
+    pub fn new_from_store(
+        rejected: Vec<ValidationError>,
+        store: crate::store::InsertResult,
+    ) -> Self {
+        let (new, existed) = store.inserted.into_iter().partition_map(|e| {
+            if e.new_key {
+                itertools::Either::Left(e.order_key.clone())
+            } else {
+                itertools::Either::Right(e.order_key.clone())
+            }
+        });
+        Self {
+            rejected,
+            new,
+            existed,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -476,10 +476,11 @@ impl InsertResult {
         store: crate::store::InsertResult,
     ) -> Self {
         let (new, existed) = store.inserted.into_iter().partition_map(|e| {
+            let key = e.inserted.order_key().clone();
             if e.new_key {
-                itertools::Either::Left(e.order_key.clone())
+                itertools::Either::Left(key)
             } else {
-                itertools::Either::Right(e.order_key.clone())
+                itertools::Either::Right(key)
             }
         });
         Self {

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -463,7 +463,7 @@ pub enum ValidationError {
     },
 }
 
-#[derive(Debug, PartialEq, Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub struct InsertResult {
     pub rejected: Vec<ValidationError>,
     pub new: Vec<EventId>,

--- a/event-svc/src/event/store.rs
+++ b/event-svc/src/event/store.rs
@@ -32,7 +32,7 @@ impl From<InsertResult> for recon::InsertResult<EventId> {
                 ValidationError::RequiresHistory { .. } => pending += 1,
             };
         }
-        recon::InsertResult::new_err(value.store_result.count_new_keys(), invalid, pending)
+        recon::InsertResult::new_err(value.new.len(), invalid, pending)
     }
 }
 
@@ -143,9 +143,9 @@ impl iroh_bitswap::Store for EventService {
 
 impl From<InsertResult> for Vec<ceramic_api::EventInsertResult> {
     fn from(res: InsertResult) -> Self {
-        let mut api_res = Vec::with_capacity(res.store_result.inserted.len() + res.rejected.len());
-        for ev in res.store_result.inserted {
-            api_res.push(ceramic_api::EventInsertResult::new_ok(ev.order_key));
+        let mut api_res = Vec::with_capacity(res.new.len() + res.rejected.len());
+        for ev in res.new.into_iter().chain(res.existed.into_iter()) {
+            api_res.push(ceramic_api::EventInsertResult::new_ok(ev));
         }
 
         for ev in res.rejected {

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -38,8 +38,14 @@ pub struct ValidatedEvent {
 impl ValidatedEvent {
     /// Convert this ValidatedEvent into an EventInsertable
     pub fn into_insertable(value: Self, informant: Option<NodeId>) -> EventInsertable {
-        EventInsertable::new(value.key, value.cid, value.event, informant, false)
-            .expect("validated events must be insertable")
+        EventInsertable::new(
+            value.key,
+            value.cid,
+            value.event.is_init(),
+            value.event,
+            informant,
+        )
+        .expect("validated events must be insertable")
     }
 
     /// The way to convert into a validated event. Normally `unchecked` has a "memory unsafety" implication typically,

--- a/event-svc/src/store/sql/access/event.rs
+++ b/event-svc/src/store/sql/access/event.rs
@@ -24,44 +24,42 @@ use crate::store::{
 
 static GLOBAL_COUNTER: AtomicI64 = AtomicI64::new(0);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug)]
 /// An event that was inserted into the database
-pub struct InsertedEvent {
+pub struct InsertedEvent<'a> {
     /// The event order key that was inserted
-    pub order_key: EventId,
-    /// Whether the event was marked as deliverable
-    pub deliverable: bool,
+    pub order_key: &'a EventId,
+    /// The event that was inserted
+    pub inserted: &'a EventInsertable,
     /// Whether the event was a new key
     pub new_key: bool,
 }
 
-impl InsertedEvent {
+impl<'a> InsertedEvent<'a> {
     /// Create a new delivered event
-    fn new(order_key: EventId, new_key: bool, deliverable: bool) -> Self {
+    fn new(order_key: &'a EventId, new_key: bool, inserted: &'a EventInsertable) -> Self {
         Self {
             order_key,
-            deliverable,
+            inserted,
             new_key,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Default)]
 /// The result of inserting events into the database
-pub struct InsertResult {
+pub struct InsertResult<'a> {
     /// The events that were marked as delivered in this batch
-    pub inserted: Vec<InsertedEvent>,
+    pub inserted: Vec<InsertedEvent<'a>>,
 }
 
-impl InsertResult {
+impl<'a> InsertResult<'a> {
     /// The count of new keys added in this batch
     pub fn count_new_keys(&self) -> usize {
         self.inserted.iter().filter(|e| e.new_key).count()
     }
-}
 
-impl InsertResult {
-    fn new(inserted: Vec<InsertedEvent>) -> Self {
+    fn new(inserted: Vec<InsertedEvent<'a>>) -> Self {
         Self { inserted }
     }
 }
@@ -175,7 +173,7 @@ impl CeramicOneEvent {
     ///     That is, events will be processed in the order they are given so earlier events are given a lower global ordering
     ///     and will be returned earlier in the feed. Events can be intereaved with different streams, but if two events
     ///     depend on each other, the `prev` must come first in the list to ensure the correct order for indexers and consumers.
-    pub async fn insert_many<'a, I>(pool: &SqlitePool, to_add: I) -> Result<InsertResult>
+    pub async fn insert_many<'a, I>(pool: &SqlitePool, to_add: I) -> Result<InsertResult<'a>>
     where
         I: Iterator<Item = &'a EventInsertable>,
     {
@@ -191,11 +189,7 @@ impl CeramicOneEvent {
                 item.deliverable(),
             )
             .await?;
-            inserted.push(InsertedEvent::new(
-                item.order_key().clone(),
-                new_key,
-                item.deliverable(),
-            ));
+            inserted.push(InsertedEvent::new(item.order_key(), new_key, item));
             if new_key {
                 for block in item.get_raw_blocks().await?.iter() {
                     CeramicOneBlock::insert(&mut tx, block.multihash.inner(), &block.bytes).await?;

--- a/event-svc/src/store/sql/access/event.rs
+++ b/event-svc/src/store/sql/access/event.rs
@@ -27,8 +27,6 @@ static GLOBAL_COUNTER: AtomicI64 = AtomicI64::new(0);
 #[derive(Debug)]
 /// An event that was inserted into the database
 pub struct InsertedEvent<'a> {
-    /// The event order key that was inserted
-    pub order_key: &'a EventId,
     /// The event that was inserted
     pub inserted: &'a EventInsertable,
     /// Whether the event was a new key
@@ -37,12 +35,8 @@ pub struct InsertedEvent<'a> {
 
 impl<'a> InsertedEvent<'a> {
     /// Create a new delivered event
-    fn new(order_key: &'a EventId, new_key: bool, inserted: &'a EventInsertable) -> Self {
-        Self {
-            order_key,
-            inserted,
-            new_key,
-        }
+    fn new(new_key: bool, inserted: &'a EventInsertable) -> Self {
+        Self { inserted, new_key }
     }
 }
 
@@ -189,7 +183,7 @@ impl CeramicOneEvent {
                 item.deliverable(),
             )
             .await?;
-            inserted.push(InsertedEvent::new(item.order_key(), new_key, item));
+            inserted.push(InsertedEvent::new(new_key, item));
             if new_key {
                 for block in item.get_raw_blocks().await?.iter() {
                     CeramicOneBlock::insert(&mut tx, block.multihash.inner(), &block.bytes).await?;

--- a/event-svc/src/store/sql/entities/event.rs
+++ b/event-svc/src/store/sql/entities/event.rs
@@ -60,9 +60,9 @@ impl EventInsertable {
     pub fn new(
         order_key: EventId,
         event_cid: Cid,
+        deliverable: bool,
         event: Arc<unvalidated::Event<Ipld>>,
         informant: Option<NodeId>,
-        deliverable: bool,
     ) -> Result<Self> {
         let cid = order_key.cid().ok_or_else(|| {
             Error::new_app(anyhow::anyhow!(

--- a/event-svc/src/store/sql/test.rs
+++ b/event-svc/src/store/sql/test.rs
@@ -50,7 +50,7 @@ fn random_events(num: usize) -> Vec<EventInsertable> {
         let order_key = event_id_builder().with_event(&cid).build();
         let event = Box::new(init::Event::new(payload)).into();
 
-        events.push(EventInsertable::new(order_key, cid, Arc::new(event), None, true).unwrap())
+        events.push(EventInsertable::new(order_key, cid, true, Arc::new(event), None).unwrap())
     }
 
     events

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -617,8 +617,9 @@ async fn test_conclusion_events_since() -> Result<(), Box<dyn std::error::Error>
     let service = EventService::try_new(pool, false, false).await?;
     let test_events = generate_chained_events().await;
 
-    for event in &test_events {
-        recon::Store::insert_many(&service, &[event.clone()], NodeId::random().unwrap().0).await?;
+    for event in test_events {
+        ceramic_api::EventService::insert_many(&service, vec![event], NodeId::random().unwrap().0)
+            .await?;
     }
 
     // Fetch conclusion events

--- a/event-svc/src/tests/mod.rs
+++ b/event-svc/src/tests/mod.rs
@@ -4,6 +4,7 @@ mod ordering;
 
 use std::str::FromStr;
 
+use ceramic_api::ApiItem;
 use ceramic_core::{DidDocument, EventId, Network, StreamId};
 use ceramic_event::unvalidated::{self, signed};
 use cid::Cid;
@@ -242,8 +243,8 @@ pub(crate) async fn get_n_events(number: usize) -> Vec<ReconItem<EventId>> {
 /// let chained_events = generate_chained_events().await;
 /// assert_eq!(chained_events.len(), 5);
 /// ```
-pub(crate) async fn generate_chained_events() -> Vec<ReconItem<EventId>> {
-    let mut events: Vec<ReconItem<EventId>> = Vec::with_capacity(5);
+pub(crate) async fn generate_chained_events() -> Vec<ApiItem> {
+    let mut events: Vec<ApiItem> = Vec::with_capacity(5);
 
     let signer = Box::new(signer().await);
     let stream_id_1 = create_deterministic_stream_id_model(&[0x01]);
@@ -308,11 +309,11 @@ pub(crate) async fn generate_chained_events() -> Vec<ReconItem<EventId>> {
     );
 
     // push the events in the order they should be inserted
-    events.push(ReconItem::new(event_id_1, car_1));
-    events.push(ReconItem::new(data_1_id, data_1_car));
-    events.push(ReconItem::new(data_2_id, data_2_car));
-    events.push(ReconItem::new(event_id_2, car_2));
-    events.push(ReconItem::new(data_3_id, data_3_car));
+    events.push(ApiItem::new(event_id_1, car_1));
+    events.push(ApiItem::new(data_1_id, data_1_car));
+    events.push(ApiItem::new(data_2_id, data_2_car));
+    events.push(ApiItem::new(event_id_2, car_2));
+    events.push(ApiItem::new(data_3_id, data_3_car));
 
     events
 }


### PR DESCRIPTION
This PR refactors some of the code for the event service and store to do less cloning/copying of data, and do less database IO when we don't actually care. The commits should all pass tests independently, so we don't have to take all of them (or if any of the later commits are more contentious, I can move them to a separate PR).

Now when creating `EventInsertable` objects during validation, we mark the event as deliverable if it's an init event. This was one of the responsibilities of the first pass of "ordering" that has been obviated. Next, the first pass of ordering was modified to support only ordering against the in memory set as a "best effort" or using the database to ensure the complete history exists. For recon and migrations, this means we can do less work. 

Previously, we would attempt to find an events history in memory and in the database to see if we should mark it ready for the feed during writes. For recon, anything that couldn't be ordered would be sent to the ordering task while the migration writes wouldn't. Now we only check the in memory set for recon and let the ordering task deal with all IO, while for migrations we don't attempt to do any ordering. 

I based this on #503, as I thought more about it related to the deliverable/validation options (and in the context of needing to speed migrations up). It could probably be extracted but it will have conflicts. I'm considering those PRs more important so opening for review but it's not the most urgent IMO.