### PR TITLE
fix: spawn std task to avoid blocking runtime

### DIFF
--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -109,18 +109,17 @@ where
 {
     let keypair = keypair.clone();
     let config = config.clone();
-    tokio::task::block_in_place(|| {
-        let handle = tokio::runtime::Handle::current();
-        handle.block_on(async move {
-            NodeBehaviour::new(
-                &keypair,
-                &config,
-                relay_client,
-                recons,
-                block_store,
-                metrics,
-            )
-            .await
-        })
+    let handle = tokio::runtime::Handle::current();
+    std::thread::spawn(move || {
+        handle.block_on(NodeBehaviour::new(
+            &keypair,
+            &config,
+            relay_client,
+            recons,
+            block_store,
+            metrics,
+        ))
     })
+    .join()
+    .unwrap()
 }


### PR DESCRIPTION
Spawn a std thread instead of using a tokio block_on. Basically reverting a change I made a while ago that was a mistake. This non std version causes a task to be "busy" indefinitely, which may be the reason we were seeing things lock up on really small machines. 