### PR TITLE
chore: version v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.36.0] - 2024-09-18
+
+### 🚀 Features
+
+- Make feature flags top level with experimental features requiring the experimental-features flag to be set (#521)
+- Api to transform events to conclusion events (#508)
+- Add flight sql server to expose conclusion feed. (#523)
+- Anchor service (#484)
+- Add metamodel stream id constant (#529)
+- Infer stream type from raw event model and add it to conclusion event + tests (#525)
+- Rpc client for eth blockchains (#520)
+- Verify time event proofs from eth rpc client and calculate time (#522)
+
+### 🐛 Bug Fixes
+
+- Disable debian repo release workflow (#519)
+- Use build.rs to rebuild sql crate on migrations change (#531)
+
+### 🚜 Refactor
+
+- More prep for signed event validation (#526)
+
 ## [0.35.0] - 2024-09-09
 
 ### 🚀 Features
@@ -26,6 +48,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Update console-subscriber package version (#507)
+- Version v0.35.0 (#517)
 
 ## [0.34.0] - 2024-08-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1426,7 +1426,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "arrow",
  "cid 0.11.1",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -1524,7 +1524,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1694,7 +1694,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "built",
  "project-root",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-olap"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "ceramic-metrics",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -1909,7 +1909,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4838,7 +4838,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4856,7 +4856,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.1",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -8016,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,7 +233,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.35.0"
+version = "0.36.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.35.0
-- Build date: 2024-09-09T16:04:11.911682803Z[Etc/UTC]
+- API version: 0.36.0
+- Build date: 2024-09-18T14:01:49.272724974Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.35.0
+  version: 0.36.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.35.0";
+pub const API_VERSION: &str = "0.36.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.35.0
+  version: 0.36.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.35.0
-- Build date: 2024-09-09T16:04:14.489447244Z[Etc/UTC]
+- API version: 0.36.0
+- Build date: 2024-09-18T14:01:51.504107673Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.35.0
+  version: 0.36.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.35.0";
+pub const API_VERSION: &str = "0.36.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.35.0
+  version: 0.36.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.36.0] - 2024-09-18

### 🚀 Features

- Make feature flags top level with experimental features requiring the experimental-features flag to be set (#521)
- Api to transform events to conclusion events (#508)
- Add flight sql server to expose conclusion feed. (#523)
- Anchor service (#484)
- Add metamodel stream id constant (#529)
- Infer stream type from raw event model and add it to conclusion event + tests (#525)
- Rpc client for eth blockchains (#520)
- Verify time event proofs from eth rpc client and calculate time (#522)

### 🐛 Bug Fixes

- Disable debian repo release workflow (#519)
- Use build.rs to rebuild sql crate on migrations change (#531)

### 🚜 Refactor

- More prep for signed event validation (#526)