### PR TITLE
refactor: teach event validator some more and store a copy on the service

### DIFF
--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -255,31 +255,28 @@ impl EventService {
             .map(|e| ValidatedEvent::into_insertable(e, informant))
             .collect();
 
-        // we consider these "invalid" to tell the caller what happened.
-        // it may be okay and we'll track them below and try to find events we need in the future,
-        // but if this isn't allowed, we won't track them and just error
-        unvalidated.iter().for_each(|p| {
-            invalid.push(ValidationError::RequiresHistory {
-                key: p.order_key().to_owned(),
-            })
-        });
-
-        // if we're not validating, there's no need to pend anything
-        if validation_req.map_or(false, |v| v.allow_pending) {
+        let pending_count = unvalidated.len();
+        // validation should have converted things to errors/unvalidated appropriately
+        // so we can always track pending if anything was returned
+        if !unvalidated.is_empty() {
             self.track_pending(unvalidated);
         }
 
-        self.persist_events(to_insert, deliverable_req, invalid)
-            .await
+        let (new, existed) = self
+            .persist_events(to_insert, deliverable_req, &mut invalid)
+            .await?;
+
+        Ok(InsertResult::new(new, existed, invalid, pending_count))
     }
 
     /// Persists events to disk and notifies the background ordering task when appropriate
+    /// Returns two vectors of Event IDs representing (new, existed)
     async fn persist_events(
         &self,
         to_insert: Vec<EventInsertable>,
         deliverable_req: DeliverableRequirement,
-        mut invalid: Vec<ValidationError>,
-    ) -> Result<InsertResult> {
+        invalid: &mut Vec<ValidationError>,
+    ) -> Result<(Vec<EventId>, Vec<EventId>)> {
         match deliverable_req {
             DeliverableRequirement::Immediate => {
                 let ordered =
@@ -291,7 +288,7 @@ impl EventService {
                     }
                 }));
                 let store_result = CeramicOneEvent::insert_many(&self.pool, to_insert).await?;
-                Ok(InsertResult::new_from_store(invalid, store_result))
+                Ok(Self::partition_store_result(store_result))
             }
             DeliverableRequirement::Asap => {
                 let ordered = OrderEvents::find_deliverable_in_memory(to_insert).await?;
@@ -304,15 +301,27 @@ impl EventService {
 
                 self.notify_ordering_task(&store_result).await?;
 
-                Ok(InsertResult::new_from_store(invalid, store_result))
+                Ok(Self::partition_store_result(store_result))
             }
             DeliverableRequirement::Lazy => {
                 let store_result =
                     CeramicOneEvent::insert_many(&self.pool, to_insert.iter()).await?;
 
-                Ok(InsertResult::new_from_store(invalid, store_result))
+                Ok(Self::partition_store_result(store_result))
             }
         }
+    }
+
+    /// Returns two vectors of Event IDs representing (new, existed)
+    fn partition_store_result(store: crate::store::InsertResult) -> (Vec<EventId>, Vec<EventId>) {
+        store.inserted.into_iter().partition_map(|e| {
+            let key = e.inserted.order_key().clone();
+            if e.new_key {
+                itertools::Either::Left(key)
+            } else {
+                itertools::Either::Right(key)
+            }
+        })
     }
 
     pub(crate) async fn transform_raw_events_to_conclusion_events(
@@ -469,25 +478,21 @@ pub struct InsertResult {
     pub rejected: Vec<ValidationError>,
     pub new: Vec<EventId>,
     pub existed: Vec<EventId>,
+    pub pending_count: usize,
 }
 
 impl InsertResult {
-    pub fn new_from_store(
+    pub fn new(
+        new: Vec<EventId>,
+        existed: Vec<EventId>,
         rejected: Vec<ValidationError>,
-        store: crate::store::InsertResult,
+        pending_count: usize,
     ) -> Self {
-        let (new, existed) = store.inserted.into_iter().partition_map(|e| {
-            let key = e.inserted.order_key().clone();
-            if e.new_key {
-                itertools::Either::Left(key)
-            } else {
-                itertools::Either::Right(key)
-            }
-        });
         Self {
             rejected,
             new,
             existed,
+            pending_count,
         }
     }
 }
@@ -508,10 +513,10 @@ pub(crate) struct DiscoveredEvent {
 pub struct ValidationRequirement {
     /// Whether we should check the signature is currently valid or simply whether it was once valid
     pub check_exp: bool,
-    /// Whether validation must succeed or events can be "pended" until init events are discovered.
-    /// If true: the init event may not yet be known to the node and we'll store it in memory until we discover it.
-    /// If false, we fail validation if we can't find the init event to validate the signature.
-    pub allow_pending: bool,
+    /// Whether events without a known init event should be considered invalid or may be "pended" until init events are discovered.
+    /// If true, we fail validation if we can't find the init event to validate the signature.
+    /// If false: the init event may not yet be known to the node and we'll store it in memory until we discover it.
+    pub require_local_init: bool,
 }
 
 impl ValidationRequirement {
@@ -519,7 +524,7 @@ impl ValidationRequirement {
     pub fn new_local() -> Self {
         Self {
             check_exp: true,
-            allow_pending: false,
+            require_local_init: true,
         }
     }
 
@@ -527,7 +532,7 @@ impl ValidationRequirement {
     pub fn new_recon() -> Self {
         Self {
             check_exp: false,
-            allow_pending: true,
+            require_local_init: false,
         }
     }
 }


### PR DESCRIPTION
The pending/invalid logic didn't fit very nicely as implemented in #503. With #530 (this one's target), the return types of some of these signatures have been adjusted and it made the change to have the validator know whether a missing init event should be an error or pending/unvalidated easier. This feels like a more appropriate place to understand this, and simplifies the service logic a bit. 

It also adjusts how the event validator is constructed by the service so that we create one that we reuse, which will make it easier to construct at start up with the eth RPC providers to actually do the time event chain inclusion validation. 