### PR TITLE
feat: validate time event chain inclusion proofs

### DIFF
--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -478,6 +478,11 @@ pub enum ValidationError {
     RequiresHistory {
         key: EventId,
     },
+    /// A time event proof was invalid for some reason
+    InvalidTimeProof {
+        key: EventId,
+        reason: String,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Default)]
@@ -524,6 +529,9 @@ pub struct ValidationRequirement {
     /// If true, we fail validation if we can't find the init event to validate the signature.
     /// If false: the init event may not yet be known to the node and we'll store it in memory until we discover it.
     pub require_local_init: bool,
+    /// Whether a time event must have a valid inclusion proof to be allowed. For example, we allow storing and syncing
+    /// events discovered over recon even if we don't have a RPC provider for the chain yet.
+    pub require_inclusion_proof: bool,
 }
 
 impl ValidationRequirement {
@@ -532,6 +540,7 @@ impl ValidationRequirement {
         Self {
             check_exp: true,
             require_local_init: true,
+            require_inclusion_proof: true,
         }
     }
 
@@ -540,6 +549,7 @@ impl ValidationRequirement {
         Self {
             check_exp: false,
             require_local_init: false,
+            require_inclusion_proof: false,
         }
     }
 }

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -87,12 +87,14 @@ impl EventService {
         pool: SqlitePool,
         process_undelivered_events: bool,
         validate_events: bool,
+        ethereum_rpc_urls: Option<&[String]>,
     ) -> Result<Self> {
         CeramicOneEvent::init_delivered_order(&pool).await?;
 
         let delivery_task = OrderingTask::run(pool.clone(), PENDING_EVENTS_CHANNEL_DEPTH).await;
 
-        let event_validator = EventValidator::new(pool.clone());
+        let event_validator = EventValidator::try_new(pool.clone(), ethereum_rpc_urls).await?;
+
         let svc = Self {
             pool,
             validate_events,
@@ -111,7 +113,7 @@ impl EventService {
     /// in the next pass.. but it's basically same same but different.
     #[allow(dead_code)]
     pub(crate) async fn new_with_event_validation(pool: SqlitePool) -> Result<Self> {
-        Self::try_new(pool, false, true).await
+        Self::try_new(pool, false, true, None).await
     }
 
     /// Currently, we track events when the [`ValidationRequirement`] allows. Right now, this applies to

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -529,9 +529,6 @@ pub struct ValidationRequirement {
     /// If true, we fail validation if we can't find the init event to validate the signature.
     /// If false: the init event may not yet be known to the node and we'll store it in memory until we discover it.
     pub require_local_init: bool,
-    /// Whether a time event must have a valid inclusion proof to be allowed. For example, we allow storing and syncing
-    /// events discovered over recon even if we don't have a RPC provider for the chain yet.
-    pub require_inclusion_proof: bool,
 }
 
 impl ValidationRequirement {
@@ -540,7 +537,6 @@ impl ValidationRequirement {
         Self {
             check_exp: true,
             require_local_init: true,
-            require_inclusion_proof: true,
         }
     }
 
@@ -549,7 +545,6 @@ impl ValidationRequirement {
         Self {
             check_exp: false,
             require_local_init: false,
-            require_inclusion_proof: false,
         }
     }
 }

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -256,16 +256,13 @@ impl EventValidator {
     ) -> std::result::Result<(), ValidationError> {
         match err {
             ChainInclusionError::TxNotFound { chain_id, tx_hash } => {
-                if require_inclusion_proof {
-                    Err(ValidationError::InvalidTimeProof {
-                        key: order_key.to_owned(),
-                        reason: format!(
-                            "Transaction on chain '{chain_id}' with hash '{tx_hash}' not found."
-                        ),
-                    })
-                } else {
-                    Ok(())
-                }
+                // we have an RPC provider so the transaction missing means it's invalid/unproveable
+                Err(ValidationError::InvalidTimeProof {
+                    key: order_key.to_owned(),
+                    reason: format!(
+                        "Transaction on chain '{chain_id}' with hash '{tx_hash}' not found."
+                    ),
+                })
             }
             ChainInclusionError::TxNotMined { chain_id, tx_hash } => {
                 if require_inclusion_proof {
@@ -274,6 +271,7 @@ impl EventValidator {
                         reason: format!("Transaction on chain '{chain_id}' with hash '{tx_hash}' has not been mined in a block yet."),
                     })
                 } else {
+                    // we may be able to validate it in the future when the block is mined
                     Ok(())
                 }
             }
@@ -290,6 +288,7 @@ impl EventValidator {
                     reason: format!("No RPC provider for chain '{chain_id}'. Transaction for event cannot be verified."),
                 })
                 } else {
+                    // someone with an RPC provider could validate this event so we'll allow it
                     Ok(())
                 }
             }

--- a/event-svc/src/event/validator/mod.rs
+++ b/event-svc/src/event/validator/mod.rs
@@ -1,10 +1,7 @@
 mod event;
 mod grouped;
 mod signed;
-// this is not used yet
-// we should export the following and consume in the event validator
-// pub use time::{BlockchainVerifier, EthRpcProvider, EventTimestamper, Timestamp};
-#[allow(dead_code)]
+
 mod time;
 
 pub use event::{EventValidator, UnvalidatedEvent, ValidatedEvent, ValidatedEvents};

--- a/event-svc/src/event/validator/time.rs
+++ b/event-svc/src/event/validator/time.rs
@@ -53,6 +53,7 @@ pub struct Timestamp(i64);
 
 impl Timestamp {
     /// A unix epoch timestamp
+    #[allow(dead_code)]
     pub fn as_unix_ts(&self) -> i64 {
         self.0
     }
@@ -114,7 +115,7 @@ impl TimeEventValidator {
     }
 
     /// Get the CAIP2 Chain IDs that we can validate
-    pub fn supported_chains(&self) -> Vec<caip2::ChainId> {
+    fn _supported_chains(&self) -> Vec<caip2::ChainId> {
         self.chain_providers.keys().cloned().collect()
     }
 

--- a/event-svc/src/event/validator/time.rs
+++ b/event-svc/src/event/validator/time.rs
@@ -36,32 +36,30 @@ impl Timestamp {
     }
 }
 
-#[async_trait::async_trait]
-pub trait BlockchainVerifier {
-    /// Get the CAIP-2 chains that are supported for validating time events
-    fn supported_chains(&self) -> Vec<caip2::ChainId>;
-
-    /// Verify the time event anchor information
-    async fn validate_chain_inclusion(
-        &self,
-        event: &unvalidated::TimeEvent,
-    ) -> Result<Option<Timestamp>>;
-}
-
 pub type EthRpcProvider = Arc<dyn EthRpc + Send + Sync>;
 
-pub struct EventTimestamper<'a> {
-    // TODO: will be needed to persist transaction and proof information
-    _pool: &'a SqlitePool,
+pub struct TimeEventValidator {
     /// we could support multiple providers for each chain (to get around rate limits)
     /// but we'll just force people to run a light client if they really need the throughput
     chain_providers: HashMap<caip2::ChainId, EthRpcProvider>,
 }
 
-impl<'a> EventTimestamper<'a> {
-    pub async fn try_new(pool: &'a SqlitePool, urls: &[&str]) -> Result<Self> {
-        let mut chain_providers = HashMap::with_capacity(urls.len());
-        for url in urls {
+impl std::fmt::Debug for TimeEventValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EventTimestamper")
+            .field(
+                "chain_providers",
+                &format!("{:?}", &self.chain_providers.keys()),
+            )
+            .finish()
+    }
+}
+
+impl TimeEventValidator {
+    /// Try to construct the validator by looking building the etherum rpc providers from the given URLsƒsw
+    pub async fn try_new(rpc_urls: &[String]) -> Result<Self> {
+        let mut chain_providers = HashMap::with_capacity(rpc_urls.len());
+        for url in rpc_urls {
             match HttpEthRpc::try_new(url).await {
                 Ok(provider) => {
                     // use the first valid rpc client we find rather than replace one
@@ -79,20 +77,71 @@ impl<'a> EventTimestamper<'a> {
         if chain_providers.is_empty() {
             bail!("failed to instantiate any RPC chain providers");
         }
-        Ok(Self {
-            _pool: pool,
-            chain_providers,
-        })
+        Ok(Self { chain_providers })
     }
 
     /// Create from known providers (e.g. inject mocks)
-    pub fn new_with_providers(pool: &'a SqlitePool, providers: Vec<EthRpcProvider>) -> Self {
+    /// Currently used in tests, may switch to this from service if we want to share RPC with anchoring.
+    #[allow(dead_code)]
+    pub fn new_with_providers(providers: Vec<EthRpcProvider>) -> Self {
         Self {
-            _pool: pool,
             chain_providers: HashMap::from_iter(
                 providers.into_iter().map(|p| (p.chain_id().to_owned(), p)),
             ),
         }
+    }
+
+    /// Get the CAIP2 Chain IDs that we can validate
+    pub fn supported_chains(&self) -> Vec<caip2::ChainId> {
+        self.chain_providers.keys().cloned().collect()
+    }
+
+    /// Validate the chain inclusion proof for a time event, returning the block timestamp if found
+    pub async fn validate_chain_inclusion(
+        &self,
+        _pool: &SqlitePool,
+        event: &unvalidated::TimeEvent,
+    ) -> Result<Option<Timestamp>> {
+        let chain_id =
+            caip2::ChainId::from_str(event.proof().chain_id()).context("invalid proof chain ID")?;
+
+        let provider = self
+            .chain_providers
+            .get(&chain_id)
+            .ok_or_else(|| anyhow!("missing rpc verifier for chain ID"))?;
+        let tx_hash = Self::expected_tx_hash(event.proof().tx_hash());
+
+        // TODO: check db or lru cache for transaction.
+        //     if known => return it
+        //     else if new => query it
+        //     else if we've tried before and it's been "long enough" => query it
+        // for now, we just use the rpc endpoint again which has a small internal LRU cache
+        let (root_cid, block) = match self.get_block(provider, &tx_hash, event.proof()).await? {
+            Some(v) => match v.1 {
+                Some(block) => (v.0, block),
+                None => return Ok(None), // block has not been mined yet so time information can't be determined
+            },
+            None => {
+                bail!("transaction {tx_hash} not found");
+            }
+        };
+
+        if root_cid != event.proof().root() {
+            bail!(
+                "the root CID is not in the transaction (root={})",
+                event.proof().root()
+            )
+        }
+
+        if let Some(threshold) = BLOCK_THRESHHOLDS.get(event.proof().chain_id()) {
+            if block.number < *threshold {
+                return Ok(Some(Timestamp(block.timestamp)));
+            } else if event.proof().tx_type() != V1_PROOF_TYPE {
+                bail!("Any anchor proofs created after block {threshold} for chain {} must include the txType field={V1_PROOF_TYPE}. Anchor txn blockNumber: {}", event.proof().chain_id(), block.number);
+            }
+        }
+
+        Ok(Some(Timestamp(block.timestamp)))
     }
 
     /// Input is the data input to the contract for the transaction
@@ -161,59 +210,6 @@ impl<'a> EventTimestamper<'a> {
 
     fn expected_tx_hash(cid: Cid) -> String {
         format!("0x{}", hex::encode(cid.hash().digest()))
-    }
-}
-
-#[async_trait::async_trait]
-impl<'a> BlockchainVerifier for EventTimestamper<'a> {
-    fn supported_chains(&self) -> Vec<caip2::ChainId> {
-        self.chain_providers.keys().cloned().collect()
-    }
-
-    async fn validate_chain_inclusion(
-        &self,
-        event: &unvalidated::TimeEvent,
-    ) -> Result<Option<Timestamp>> {
-        let chain_id =
-            caip2::ChainId::from_str(event.proof().chain_id()).context("invalid proof chain ID")?;
-
-        let provider = self
-            .chain_providers
-            .get(&chain_id)
-            .ok_or_else(|| anyhow!("missing rpc verifier for chain ID"))?;
-        let tx_hash = Self::expected_tx_hash(event.proof().tx_hash());
-
-        // TODO: check db or lru cache for transaction.
-        //     if known => return it
-        //     else if new => query it
-        //     else if we've tried before and it's been "long enough" => query it
-        // for now, we just use the rpc endpoint again which has a small internal LRU cache
-        let (root_cid, block) = match self.get_block(provider, &tx_hash, event.proof()).await? {
-            Some(v) => match v.1 {
-                Some(block) => (v.0, block),
-                None => return Ok(None), // block has not been mined yet so time information can't be determined
-            },
-            None => {
-                bail!("transaction {tx_hash} not found");
-            }
-        };
-
-        if root_cid != event.proof().root() {
-            bail!(
-                "the root CID is not in the transaction (root={})",
-                event.proof().root()
-            )
-        }
-
-        if let Some(threshold) = BLOCK_THRESHHOLDS.get(event.proof().chain_id()) {
-            if block.number < *threshold {
-                return Ok(Some(Timestamp(block.timestamp)));
-            } else if event.proof().tx_type() != V1_PROOF_TYPE {
-                bail!("Any anchor proofs created after block {threshold} for chain {} must include the txType field={V1_PROOF_TYPE}. Anchor txn blockNumber: {}", event.proof().chain_id(), block.number);
-            }
-        }
-
-        Ok(Some(Timestamp(block.timestamp)))
     }
 }
 
@@ -365,11 +361,7 @@ mod test {
         }
     }
 
-    async fn get_mock_provider(
-        pool: &SqlitePool,
-        tx_hash: String,
-        tx_input: String,
-    ) -> EventTimestamper<'_> {
+    async fn get_mock_provider(tx_hash: String, tx_input: String) -> TimeEventValidator {
         let mut mock_provider = MockEthRpcProviderTest::new();
         let chain =
             caip2::ChainId::from_str("eip155:11155111").expect("eip155:11155111 is a valid chain");
@@ -391,8 +383,7 @@ mod test {
                     }),
                 }))
             });
-        let verifier = EventTimestamper::new_with_providers(pool, vec![Arc::new(mock_provider)]);
-        verifier
+        TimeEventValidator::new_with_providers(vec![Arc::new(mock_provider)])
     }
 
     #[test(tokio::test)]
@@ -400,13 +391,9 @@ mod test {
         let event = time_event_single_event_batch();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
 
-        let verifier = get_mock_provider(
-            &pool,
-            SINGLE_TX_HASH.to_string(),
-            SINGLE_TX_HASH_INPUT.into(),
-        )
-        .await;
-        match verifier.validate_chain_inclusion(&event).await {
+        let verifier =
+            get_mock_provider(SINGLE_TX_HASH.to_string(), SINGLE_TX_HASH_INPUT.into()).await;
+        match verifier.validate_chain_inclusion(&pool, &event).await {
             Ok(ts) => {
                 let ts = ts.expect("should have timestamp");
                 assert_eq!(ts.as_unix_ts(), BLOCK_TIMESTAMP);
@@ -420,13 +407,9 @@ mod test {
         let event = time_event_single_event_batch();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
 
-        let verifier = get_mock_provider(
-            &pool,
-            SINGLE_TX_HASH.to_string(),
-            MULTI_TX_HASH_INPUT.to_string(),
-        )
-        .await;
-        match verifier.validate_chain_inclusion(&event).await {
+        let verifier =
+            get_mock_provider(SINGLE_TX_HASH.to_string(), MULTI_TX_HASH_INPUT.to_string()).await;
+        match verifier.validate_chain_inclusion(&pool, &event).await {
             Ok(v) => {
                 panic!("should have failed: {:?}", v)
             }
@@ -444,13 +427,9 @@ mod test {
         let event = time_event_multi_event_batch();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
 
-        let verifier = get_mock_provider(
-            &pool,
-            MULTI_TX_HASH.to_string(),
-            MULTI_TX_HASH_INPUT.to_string(),
-        )
-        .await;
-        match verifier.validate_chain_inclusion(&event).await {
+        let verifier =
+            get_mock_provider(MULTI_TX_HASH.to_string(), MULTI_TX_HASH_INPUT.to_string()).await;
+        match verifier.validate_chain_inclusion(&pool, &event).await {
             Ok(ts) => {
                 let ts = ts.expect("should have timestamp");
                 assert_eq!(ts.as_unix_ts(), BLOCK_TIMESTAMP);
@@ -464,13 +443,9 @@ mod test {
         let event = time_event_multi_event_batch();
         let pool = SqlitePool::connect_in_memory().await.unwrap();
 
-        let verifier = get_mock_provider(
-            &pool,
-            MULTI_TX_HASH.to_string(),
-            SINGLE_TX_HASH_INPUT.to_string(),
-        )
-        .await;
-        match verifier.validate_chain_inclusion(&event).await {
+        let verifier =
+            get_mock_provider(MULTI_TX_HASH.to_string(), SINGLE_TX_HASH_INPUT.to_string()).await;
+        match verifier.validate_chain_inclusion(&pool, &event).await {
             Ok(v) => {
                 panic!("should have failed: {:?}", v)
             }
@@ -487,7 +462,7 @@ mod test {
     fn parse_tx_input_data_v1() {
         assert_eq!(
             Cid::from_str("bafyreigs2yqh2olnwzrsykyt6gvgsabk7hu5e7gtmjrkobq25af5x3y7be").unwrap(),
-            EventTimestamper::get_root_cid_from_input(
+            TimeEventValidator::get_root_cid_from_input(
                 "0x97ad09ebd2d6207d396db6632c2b13f1aa69002af9e9d27cd36262a7061ae80bdbef1f09",
                 V1_PROOF_TYPE,
             )
@@ -499,7 +474,7 @@ mod test {
     fn parse_tx_input_data_v0() {
         assert_eq!(
             Cid::from_str("bafyreigs2yqh2olnwzrsykyt6gvgsabk7hu5e7gtmjrkobq25af5x3y7be").unwrap(),
-            EventTimestamper::get_root_cid_from_input(
+            TimeEventValidator::get_root_cid_from_input(
                 "0x01711220d2d6207d396db6632c2b13f1aa69002af9e9d27cd36262a7061ae80bdbef1f09",
                 V0_PROOF_TYPE,
             )

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -25,7 +25,7 @@ macro_rules! test_with_sqlite {
             async fn [<$test_name _sqlite>]() {
 
                 let conn = $crate::store::SqlitePool::connect_in_memory().await.unwrap();
-                let store = $crate::EventService::try_new(conn, true, true).await.unwrap();
+                let store = $crate::EventService::try_new(conn, true, true, None).await.unwrap();
                 $(
                     for stmt in $sql_stmts {
                         store.pool.run_statement(stmt).await.unwrap();
@@ -607,7 +607,7 @@ where
 #[tokio::test]
 async fn test_conclusion_events_since() -> Result<(), Box<dyn std::error::Error>> {
     let pool = SqlitePool::connect_in_memory().await?;
-    let service = EventService::try_new(pool, false, false).await?;
+    let service = EventService::try_new(pool, false, false, None).await?;
     let test_events = generate_chained_events().await;
 
     for event in test_events {

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -264,8 +264,9 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
 
     // Construct services from pool
     let interest_svc = Arc::new(InterestService::new(sqlite_pool.clone()));
-    let event_svc =
-        Arc::new(EventService::try_new(sqlite_pool.clone(), true, opts.event_validation).await?);
+    let event_svc = Arc::new(
+        EventService::try_new(sqlite_pool.clone(), true, opts.event_validation, None).await?,
+    );
 
     let network = opts.network.to_network(&opts.local_network_id)?;
 

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -99,7 +99,7 @@ async fn from_ipfs(opts: FromIpfsOpts) -> Result<()> {
     let db_opts: DBOpts = (&opts).into();
     let sqlite_pool = db_opts.get_sqlite_pool().await?;
     // TODO: feature flags here? or just remove this entirely when enabling
-    let event_svc = Arc::new(EventService::try_new(sqlite_pool, false, false).await?);
+    let event_svc = Arc::new(EventService::try_new(sqlite_pool, false, false, None).await?);
     let blocks = FSBlockStore {
         input_ipfs_path: opts.input_ipfs_path,
         sharded_paths: !opts.non_sharded_paths,

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1387,7 +1387,7 @@ mod tests {
             let sql_pool = SqlitePool::connect_in_memory().await.unwrap();
 
             let metrics = Metrics::register(&mut prometheus_client::registry::Registry::default());
-            let store = Arc::new(EventService::try_new(sql_pool, true, true).await?);
+            let store = Arc::new(EventService::try_new(sql_pool, true, true, None).await?);
             let mut p2p = Node::new(
                 network_config,
                 rpc_server_addr,


### PR DESCRIPTION
The validation service now sets up and interacts with the ethereum RPC providers in order to validate time event inclusion proofs. I refactored some things a bit, like removing a trait in the service crate that isn't necessary currently as we already have one at the RPC provider level. 

The `ValidationRequirement` struct now has a `require_inclusion_proof` option that allows us to store and sync time events over recon even if we can't prove that their valid (e.g. we don't have an RPC provider for the chain). If we can prove they are invalid, we will reject them still. I also made an error enum that is specific to the chain inclusion result to make it easier to process different errors. It doesn't yet handle transient errors very well, which I plan to address in the RPC provider level when I switch the http client to use the alloy crate rather than a simple reqwest wrapper.