### PR TITLE
feat: store doc_state table in object storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,7 +1414,7 @@ dependencies = [
  "expect-test",
  "hex",
  "multihash-codetable",
- "reqwest",
+ "reqwest 0.11.27",
  "ring 0.17.8",
  "serde",
  "serde_ipld_dagcbor",
@@ -1778,7 +1778,7 @@ dependencies = [
  "opentelemetry_sdk",
  "paste",
  "prometheus-client",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "tokio",
  "tracing",
@@ -1812,6 +1812,7 @@ dependencies = [
  "multihash-codetable",
  "multihash-derive 0.9.0",
  "names",
+ "object_store",
  "prometheus-client",
  "serde_json",
  "signal-hook",
@@ -1820,6 +1821,7 @@ dependencies = [
  "tokio",
  "tonic 0.12.2",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1940,7 +1942,7 @@ dependencies = [
  "multihash-codetable",
  "once_cell",
  "p256 0.13.2",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_ipld_dagcbor",
  "serde_json",
@@ -4564,6 +4566,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4827,7 +4847,7 @@ dependencies = [
  "socket2 0.5.7",
  "widestring",
  "windows-sys 0.48.0",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -5913,7 +5933,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "parking_lot",
- "quinn",
+ "quinn 0.10.2",
  "rand 0.8.5",
  "ring 0.16.20",
  "rustls 0.21.12",
@@ -6879,13 +6899,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a0c4b3a0e31f8b66f71ad8064521efa773910196e2cde791436f13409f3b45"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "bytes 1.7.1",
  "chrono",
  "futures",
  "humantime 2.1.0",
+ "hyper 1.4.1",
  "itertools 0.13.0",
+ "md-5",
  "parking_lot",
  "percent-encoding 2.3.1",
+ "quick-xml",
+ "rand 0.8.5",
+ "reqwest 0.12.5",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
  "snafu",
  "tokio",
  "tracing",
@@ -7883,6 +7912,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7902,10 +7941,28 @@ dependencies = [
  "bytes 1.7.1",
  "futures-io",
  "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
+ "quinn-proto 0.10.6",
+ "quinn-udp 0.4.1",
+ "rustc-hash 1.1.0",
  "rustls 0.21.12",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes 1.7.1",
+ "pin-project-lite",
+ "quinn-proto 0.11.8",
+ "quinn-udp 0.5.4",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
+ "socket2 0.5.7",
  "thiserror",
  "tokio",
  "tracing",
@@ -7920,8 +7977,25 @@ dependencies = [
  "bytes 1.7.1",
  "rand 0.8.5",
  "ring 0.16.20",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.21.12",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes 1.7.1",
+ "rand 0.8.5",
+ "ring 0.17.8",
+ "rustc-hash 2.0.0",
+ "rustls 0.23.13",
  "slab",
  "thiserror",
  "tinyvec",
@@ -7939,6 +8013,19 @@ dependencies = [
  "socket2 0.5.7",
  "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8209,7 +8296,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -8232,7 +8319,52 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.50.0",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.7.1",
+ "futures-core",
+ "futures-util",
+ "h2 0.4.6",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding 2.3.1",
+ "pin-project-lite",
+ "quinn 0.11.5",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.7.3",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -8406,6 +8538,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8464,17 +8602,43 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -8514,9 +8678,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -9791,7 +9955,7 @@ dependencies = [
  "iref",
  "libipld",
  "multihash 0.16.3",
- "reqwest",
+ "reqwest 0.11.27",
  "serde",
  "serde_json",
  "serde_with 2.3.3",
@@ -10420,7 +10584,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
@@ -11101,6 +11265,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11355,6 +11532,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/flight/src/server.rs
+++ b/flight/src/server.rs
@@ -97,6 +97,8 @@ impl<T> FeedTable<T> {
                 Field::new("stream_type", DataType::UInt8, false),
                 Field::new("controller", DataType::Utf8, false),
                 Field::new(
+                    // NOTE: The entire dimensions map may be null or values for a given key may
+                    // be null. No other aspect of dimensions may be null.
                     "dimensions",
                     DataType::Map(
                         Field::new(
@@ -110,7 +112,7 @@ impl<T> FeedTable<T> {
                                             Box::new(DataType::Int32),
                                             Box::new(DataType::Binary),
                                         ),
-                                        false,
+                                        true,
                                     ),
                                 ]
                                 .into(),

--- a/olap/Cargo.toml
+++ b/olap/Cargo.toml
@@ -27,6 +27,7 @@ multihash.workspace = true
 multihash-codetable = { version = "0.1.3", features = ["sha2"] }
 multihash-derive = "0.9.0"
 names.workspace = true
+object_store = { version = "0.11", features = ["aws"] }
 prometheus-client.workspace = true
 serde_json.workspace = true
 signal-hook = "0.3.17"
@@ -34,6 +35,7 @@ signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread"] }
 tonic.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/olap/src/aggregator/ceramic_patch.rs
+++ b/olap/src/aggregator/ceramic_patch.rs
@@ -137,6 +137,7 @@ impl PartitionEvaluator for CeramicPatchEvaluator {
                     }
                 } else {
                     // Unreachable when data is well formed.
+                    // Appending null means well formed documents can continue to be aggregated.
                     new_states.append_null();
                 }
             } else {

--- a/olap/src/aggregator/mod.rs
+++ b/olap/src/aggregator/mod.rs
@@ -12,7 +12,7 @@ use arrow_flight::sql::client::FlightSqlServiceClient;
 use ceramic_patch::CeramicPatch;
 use datafusion::{
     catalog::{CatalogProvider, SchemaProvider},
-    common::{Column, JoinType},
+    common::JoinType,
     dataframe::{DataFrame, DataFrameWriteOptions},
     datasource::{file_format::parquet::ParquetFormat, listing::ListingOptions},
     error::DataFusionError,
@@ -25,10 +25,13 @@ use datafusion::{
 };
 use datafusion_federation::sql::{SQLFederationProvider, SQLSchemaProvider};
 use datafusion_flight_sql_table_provider::FlightSQLExecutor;
+use object_store::aws::AmazonS3Builder;
 use tonic::transport::Endpoint;
+use url::Url;
 
 pub struct Config {
     pub flight_sql_endpoint: String,
+    pub aws_bucket: String,
 }
 
 pub async fn run(
@@ -36,6 +39,7 @@ pub async fn run(
     shutdown_signal: impl Future<Output = ()>,
 ) -> Result<()> {
     let config = config.into();
+
     // Create federated datafusion state
     let state = datafusion_federation::default_session_state();
     let client = new_client(config.flight_sql_endpoint.clone()).await?;
@@ -48,6 +52,14 @@ pub async fn run(
     // Create datafusion context
     let ctx = SessionContext::new_with_state(state);
 
+    // Register s3 object store
+    let s3 = AmazonS3Builder::from_env()
+        .with_bucket_name(&config.aws_bucket)
+        .build()?;
+    let mut url = Url::parse("s3://")?;
+    url.set_host(Some(&config.aws_bucket))?;
+    ctx.register_object_store(&url, Arc::new(s3));
+
     // Register federated catalog
     ctx.register_catalog("ceramic", Arc::new(SQLCatalog { schema_provider }));
 
@@ -56,10 +68,11 @@ pub async fn run(
     let listing_options =
         ListingOptions::new(Arc::new(file_format)).with_file_extension(".parquet");
 
-    // TODO place this table in object store, see AES-284
+    // Set the path within the bucket for the doc_state table
+    url.set_path("/ceramic/v0/doc_state/");
     ctx.register_listing_table(
         "doc_state",
-        "./db/doc_state",
+        url.to_string(),
         listing_options,
         Some(Arc::new(
             SchemaBuilder::from(&Fields::from([
@@ -94,7 +107,7 @@ pub async fn run(
                     true,
                 )),
                 Arc::new(Field::new("event_cid", DataType::Binary, false)),
-                Arc::new(Field::new("state", DataType::Utf8, false)),
+                Arc::new(Field::new("state", DataType::Utf8, true)),
             ]))
             .finish(),
         )),
@@ -104,16 +117,7 @@ pub async fn run(
 
     let conclusion_feed = ctx
         .table(TableReference::full("ceramic", "v0", "conclusion_feed"))
-        .await?
-        .select(vec![
-            col("index"),
-            col("event_type"),
-            col("stream_cid"),
-            col("controller"),
-            col("event_cid"),
-            Expr::Cast(Cast::new(Box::new(col("data")), DataType::Utf8)).alias("data"),
-            col("previous"),
-        ])?;
+        .await?;
 
     // TODO call this in a loop, see AES-291
     process_feed_batch(ctx, conclusion_feed).await?;
@@ -144,14 +148,11 @@ fn tx_error_to_df(err: tonic::transport::Error) -> DataFusionError {
 //  current conclusion_feed batch,
 //  * be valid JSON patch data documents.
 async fn process_feed_batch(ctx: SessionContext, conclusion_feed: DataFrame) -> Result<()> {
-    let doc_state = ctx.table("doc_state").await?.select_columns(&[
-        "stream_cid",
-        "index",
-        "event_type",
-        "controller",
-        "event_cid",
-        "state",
-    ])?;
+    let doc_state = ctx
+        .table("doc_state")
+        .await?
+        .select_columns(&["stream_cid", "event_cid", "state"])
+        .context("reading doc_state")?;
 
     conclusion_feed
         // MID only ever use the first previous, so we can optimize the join by selecting the
@@ -173,36 +174,12 @@ async fn process_feed_batch(ctx: SessionContext, conclusion_feed: DataFrame) -> 
         )?
         // Project joined columns to just the ones we need
         .select(vec![
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "index".to_string(),
-            })
-            .alias("index"),
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "event_type".to_string(),
-            })
-            .alias("event_type"),
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "stream_cid".to_string(),
-            })
-            .alias("stream_cid"),
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "controller".to_string(),
-            })
-            .alias("controller"),
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "dimensions".to_string(),
-            })
-            .alias("dimensions"),
-            col(Column {
-                relation: Some(TableReference::from("?table?")),
-                name: "event_cid".to_string(),
-            })
-            .alias("event_cid"),
+            col("conclusion_feed.index").alias("index"),
+            col("conclusion_feed.event_type").alias("event_type"),
+            col("conclusion_feed.stream_cid").alias("stream_cid"),
+            col("conclusion_feed.controller").alias("controller"),
+            col("conclusion_feed.dimensions").alias("dimensions"),
+            col("conclusion_feed.event_cid").alias("event_cid"),
             col("previous"),
             col("doc_state.state").alias("previous_state"),
             col("data"),

--- a/olap/src/aggregator/mod.rs
+++ b/olap/src/aggregator/mod.rs
@@ -69,7 +69,8 @@ pub async fn run(
         ListingOptions::new(Arc::new(file_format)).with_file_extension(".parquet");
 
     // Set the path within the bucket for the doc_state table
-    url.set_path("/ceramic/v0/doc_state/");
+    const DOC_STATE_OBJECT_STORE_PATH: &str = "/ceramic/v0/doc_state/";
+    url.set_path(DOC_STATE_OBJECT_STORE_PATH);
     ctx.register_listing_table(
         "doc_state",
         url.to_string(),

--- a/olap/src/lib.rs
+++ b/olap/src/lib.rs
@@ -35,7 +35,7 @@ struct DaemonOpts {
     #[arg(
         short,
         long,
-        default_value = "127.0.0.1:5102",
+        default_value = "http://127.0.0.1:5102",
         env = "CERAMIC_OLAP_FLIGHT_SQL_ENDPOINT"
     )]
     flight_sql_endpoint: String,
@@ -56,6 +56,21 @@ struct DaemonOpts {
     /// When true traces will be exported
     #[arg(long, default_value_t = false, env = "CERAMIC_OLAP_TRACING")]
     tracing: bool,
+
+    /// AWS S3 bucket name.
+    /// When configured the aggregator will support storing data in S3 compatible object stores.
+    ///
+    /// Credentials are read from the environment:
+    ///
+    ///     AWS_ACCESS_KEY_ID -> access_key_id
+    ///     AWS_SECRET_ACCESS_KEY -> secret_access_key
+    ///     AWS_DEFAULT_REGION -> region
+    ///     AWS_ENDPOINT -> endpoint
+    ///     AWS_SESSION_TOKEN -> token
+    ///     AWS_ALLOW_HTTP -> set to “true” to permit HTTP connections without TLS
+    ///
+    #[arg(long, env = "CERAMIC_OLAP_AWS_BUCKET")]
+    aws_bucket: String,
 
     #[command(flatten)]
     log_opts: LogOpts,
@@ -94,6 +109,7 @@ impl From<&DaemonOpts> for aggregator::Config {
     fn from(value: &DaemonOpts) -> Self {
         Self {
             flight_sql_endpoint: value.flight_sql_endpoint.clone(),
+            aws_bucket: value.aws_bucket.clone(),
         }
     }
 }

--- a/olap/src/lib.rs
+++ b/olap/src/lib.rs
@@ -62,12 +62,12 @@ struct DaemonOpts {
     ///
     /// Credentials are read from the environment:
     ///
-    ///     AWS_ACCESS_KEY_ID -> access_key_id
-    ///     AWS_SECRET_ACCESS_KEY -> secret_access_key
-    ///     AWS_DEFAULT_REGION -> region
-    ///     AWS_ENDPOINT -> endpoint
-    ///     AWS_SESSION_TOKEN -> token
-    ///     AWS_ALLOW_HTTP -> set to “true” to permit HTTP connections without TLS
+    ///   * AWS_ACCESS_KEY_ID -> access_key_id
+    ///   * AWS_SECRET_ACCESS_KEY -> secret_access_key
+    ///   * AWS_DEFAULT_REGION -> region
+    ///   * AWS_ENDPOINT -> endpoint
+    ///   * AWS_SESSION_TOKEN -> token
+    ///   * AWS_ALLOW_HTTP -> set to "true" to permit HTTP connections without TLS
     ///
     #[arg(long, env = "CERAMIC_OLAP_AWS_BUCKET")]
     aws_bucket: String,


### PR DESCRIPTION
With this change the doc_state table is backed by an object store instead of the local filesystem.

We assume an S3 compatible API and credentials.

Fixes AES-284