### PR TITLE
chore: version v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.38.0] - 2024-10-07
+
+### 🚀 Features
+
+- Validate signed events (#503)
+- Self-anchoring (part 5) (#488)
+- Support non sharded IPFS block paths (#541)
+- Store doc_state table in object storage (#540)
+- Add logic to migration to count errors by model (#542)
+- Validate time event chain inclusion proofs (#539)
+- Process batches on the interval (#548)
+- Ethereum RPC provider configuration (#547)
+
+### 🐛 Bug Fixes
+
+- Make self-anchoring config experimental (#546)
+
+### 🚜 Refactor
+
+- Return reference to inserted item from event store and reduce unnecessary ordering work  (#530)
+- Teach event validator some more and store a copy on the service (#536)
+- Use alloy as ethereum RPC provider (#543)
+
+### ⚙️ Miscellaneous Tasks
+
+- Update ca-certificates so eth rpc connections (#549)
+
 ## [0.37.0] - 2024-09-23
 
 ### 🚀 Features
@@ -16,6 +43,10 @@ All notable changes to this project will be documented in this file.
 ### 🚜 Refactor
 
 - Small logic change for readability (#534)
+
+### ⚙️ Miscellaneous Tasks
+
+- Version v0.37.0 (#537)
 
 ## [0.36.0] - 2024-09-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2097,7 +2097,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "arrow",
  "cid 0.11.1",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2237,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2410,7 +2410,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2437,7 +2437,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "built",
  "project-root",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-olap"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2505,7 +2505,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -5775,7 +5775,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9094,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,7 +240,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.37.0"
+version = "0.38.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.37.0
-- Build date: 2024-09-23T13:32:03.704584605Z[Etc/UTC]
+- API version: 0.38.0
+- Build date: 2024-10-07T17:48:54.387481342Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.37.0
+  version: 0.38.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.37.0";
+pub const API_VERSION: &str = "0.38.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.37.0
+  version: 0.38.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.37.0"
+version = "0.38.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.37.0
-- Build date: 2024-09-23T13:32:05.968701797Z[Etc/UTC]
+- API version: 0.38.0
+- Build date: 2024-10-07T17:48:56.491997062Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.37.0
+  version: 0.38.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.37.0";
+pub const API_VERSION: &str = "0.38.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.37.0
+  version: 0.38.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.38.0] - 2024-10-07

### 🚀 Features

- Validate signed events (#503)
- Self-anchoring (part 5) (#488)
- Support non sharded IPFS block paths (#541)
- Store doc_state table in object storage (#540)
- Add logic to migration to count errors by model (#542)
- Validate time event chain inclusion proofs (#539)
- Process batches on the interval (#548)
- Ethereum RPC provider configuration (#547)

### 🐛 Bug Fixes

- Make self-anchoring config experimental (#546)

### 🚜 Refactor

- Return reference to inserted item from event store and reduce unnecessary ordering work  (#530)
- Teach event validator some more and store a copy on the service (#536)
- Use alloy as ethereum RPC provider (#543)

### ⚙️ Miscellaneous Tasks

- Update ca-certificates so eth rpc connections (#549)