### PR TITLE
fix: use tokio::time::Interval for scheduling anchor batches

### DIFF
--- a/anchor-service/src/anchor_batch.rs
+++ b/anchor-service/src/anchor_batch.rs
@@ -77,7 +77,7 @@ impl AnchorService {
         pin_mut!(shutdown_signal);
 
         info!("anchor service started");
-        let interval = self.build_interval();
+        let mut interval = self.build_interval();
 
         loop {
             let tick = interval.tick();
@@ -96,6 +96,8 @@ impl AnchorService {
         info!("anchor service stopped");
     }
 
+    // Construct an [`Interval`] that will tick just before each anchor interval period.
+    // Missed ticks will skip.
     fn build_interval(&self) -> Interval {
         let period =
             TimeDelta::from_std(self.anchor_interval).expect("anchor interval should be in range");

--- a/anchor-service/src/anchor_batch.rs
+++ b/anchor-service/src/anchor_batch.rs
@@ -79,8 +79,7 @@ impl AnchorService {
         info!("anchor service started");
         let period =
             TimeDelta::from_std(self.anchor_interval).expect("anchor interval should be in range");
-        let buffer = TimeDelta::from_std(self.anchor_interval / 12)
-            .expect("anchor interval fraction should be in range");
+        let buffer = period / 12;
 
         // It is not possible to truncate a tokio::time::Instant as the time is opaque.
         // Therefore we use the `chrono` crate to do the truncate logic and then compute the delay


### PR DESCRIPTION
This leverages the time math of skipping missed ticks etc. We are only left with computing the time when we should start the first tick. For this we use chrono and then rely on Interval for the heavy lifting.