### PR TITLE
chore: version v0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.40.0] - 2024-10-17
+
+### 🚀 Features
+
+- Protect FlightSQL server with sql options. (#544)
+- Aes 291 continuous queries in olap aggregator (#538)
+- Migrate from file list (#501)
+- Use data container wrapper for mutable metadata (#559)
+- Add query command to ceramic-one (#545)
+
+### 🐛 Bug Fixes
+
+- Only write out error counts on errors (#560)
+- Use correct index for the conclusion feed. (#561)
+- Use tokio::time::Interval for scheduling anchor batches (#563)
+- Subscribe to server shutdown signal in insert task (#553)
+
+### ⚙️ Miscellaneous Tasks
+
+- Record the per item duration of an insert_many request (#551)
+
 ## [0.39.0] - 2024-10-07
 
 ### 🐛 Bug Fixes
@@ -11,6 +32,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Always log options at startup (#554)
+- Version v0.39.0 (#557)
 
 ## [0.38.0] - 2024-10-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "ceramic-pipeline",
  "datafusion",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2727,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2791,7 +2791,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "built",
  "project-root",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-olap"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2912,7 +2912,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2975,7 +2975,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -6279,7 +6279,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9705,7 +9705,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.39.0
-- Build date: 2024-10-07T22:15:07.398424168Z[Etc/UTC]
+- API version: 0.40.0
+- Build date: 2024-10-17T18:51:28.818325470Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.39.0
+  version: 0.40.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.39.0";
+pub const API_VERSION: &str = "0.40.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.39.0
+  version: 0.40.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.39.0"
+version = "0.40.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.39.0
-- Build date: 2024-10-07T22:15:09.633328921Z[Etc/UTC]
+- API version: 0.40.0
+- Build date: 2024-10-17T18:51:31.008931216Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.39.0
+  version: 0.40.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.39.0";
+pub const API_VERSION: &str = "0.40.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.39.0
+  version: 0.40.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.40.0] - 2024-10-17

### 🚀 Features

- Protect FlightSQL server with sql options. (#544)
- Aes 291 continuous queries in olap aggregator (#538)
- Migrate from file list (#501)
- Use data container wrapper for mutable metadata (#559)
- Add query command to ceramic-one (#545)

### 🐛 Bug Fixes

- Only write out error counts on errors (#560)
- Use correct index for the conclusion feed. (#561)
- Use tokio::time::Interval for scheduling anchor batches (#563)
- Subscribe to server shutdown signal in insert task (#553)

### ⚙️ Miscellaneous Tasks

- Record the per item duration of an insert_many request (#551)