### PR TITLE
refactor: make ChainInclusion trait fully generic and change input to the raw AnchorProof

### DIFF
--- a/anchor-remote/src/cas_remote.rs
+++ b/anchor-remote/src/cas_remote.rs
@@ -18,7 +18,7 @@ use ceramic_anchor_service::{
 };
 use ceramic_car::CarReader;
 use ceramic_core::{Cid, NodeId, StreamId};
-use ceramic_event::unvalidated::Proof;
+use ceramic_event::unvalidated::AnchorProof;
 
 pub const AGENT_VERSION: &str = concat!("ceramic-one/", env!("CARGO_PKG_VERSION"));
 
@@ -200,11 +200,11 @@ async fn parse_anchor_response(anchor_response: String) -> Result<CasResponsePar
     let mut car_reader = CarReader::new(witness_car_bytes.as_ref()).await?;
     let mut remote_merkle_nodes = MerkleNodes::default();
     let mut detached_time_event: Option<DetachedTimeEvent> = None;
-    let mut proof: Option<Proof> = None;
+    let mut proof: Option<AnchorProof> = None;
     while let Some((cid, block)) = car_reader.next_block().await? {
         if let Ok(block) = serde_ipld_dagcbor::from_slice::<DetachedTimeEvent>(&block) {
             detached_time_event = Some(block);
-        } else if let Ok(block) = serde_ipld_dagcbor::from_slice::<Proof>(&block) {
+        } else if let Ok(block) = serde_ipld_dagcbor::from_slice::<AnchorProof>(&block) {
             proof = Some(block);
         } else if let Ok(block) = serde_ipld_dagcbor::from_slice::<MerkleNode>(&block) {
             remote_merkle_nodes.insert(cid, block);

--- a/anchor-service/src/anchor.rs
+++ b/anchor-service/src/anchor.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 use tracing::info;
 
 use ceramic_core::{EventId, SerializeExt};
-use ceramic_event::unvalidated::{Proof, ProofEdge, RawTimeEvent, TimeEvent};
+use ceramic_event::unvalidated::{AnchorProof, ProofEdge, RawTimeEvent, TimeEvent};
 
 /// AnchorRequest for a Data Event on a Stream
 #[derive(Clone, PartialEq, Eq, Serialize)]
@@ -98,7 +98,7 @@ pub struct TimeEventBatch {
     /// The intermediate Merkle Tree Nodes
     pub merkle_nodes: MerkleNodes,
     /// The anchor proof
-    pub proof: Proof,
+    pub proof: AnchorProof,
     /// The Time Events
     pub raw_time_events: RawTimeEvents,
 }
@@ -138,7 +138,7 @@ impl TimeEventBatch {
 
     /// Build a TimeEventInsertable from a RawTimeEvent and AnchorRequest
     fn build_time_event_insertable(
-        proof: &Proof,
+        proof: &AnchorProof,
         merkle_nodes: &MerkleNodes,
         time_event: RawTimeEvent,
         anchor_request: AnchorRequest,

--- a/anchor-service/src/cas_mock.rs
+++ b/anchor-service/src/cas_mock.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use multihash_codetable::{Code, MultihashDigest};
 
 use ceramic_core::{Cid, EventId, NodeId, SerializeExt};
-use ceramic_event::unvalidated::Proof;
+use ceramic_event::unvalidated::AnchorProof;
 
 use crate::{
     AnchorRequest, DetachedTimeEvent, RootTimeEvent, Store, TimeEventInsertable, TransactionManager,
@@ -17,7 +17,7 @@ pub struct MockCas;
 #[async_trait]
 impl TransactionManager for MockCas {
     async fn anchor_root(&self, root_cid: Cid) -> Result<RootTimeEvent> {
-        let mock_proof = Proof::new(
+        let mock_proof = AnchorProof::new(
             "mock chain id".to_string(),
             root_cid,
             root_cid,

--- a/anchor-service/src/transaction_manager.rs
+++ b/anchor-service/src/transaction_manager.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use ceramic_core::Cid;
-use ceramic_event::unvalidated::Proof;
+use ceramic_event::unvalidated::AnchorProof;
 
 use crate::anchor::MerkleNodes;
 
@@ -11,7 +11,7 @@ use crate::anchor::MerkleNodes;
 /// corresponding Merkle tree nodes.
 pub struct RootTimeEvent {
     /// the proof data from the remote anchoring service
-    pub proof: Proof,
+    pub proof: AnchorProof,
     /// the path through the remote Merkle tree
     pub detached_time_event: DetachedTimeEvent,
     /// the Merkle tree nodes from the remote anchoring service

--- a/event-svc/src/event/migration.rs
+++ b/event-svc/src/event/migration.rs
@@ -390,7 +390,7 @@ impl<'a, S: BlockStore> Migrator<'a, S> {
             .await
             .context("finding proof block")
             .with_model_context(&model)?;
-        let proof: unvalidated::Proof = serde_ipld_dagcbor::from_slice(&data)
+        let proof: unvalidated::AnchorProof = serde_ipld_dagcbor::from_slice(&data)
             .context("decoding proof block")
             .with_model_context(&model)?;
         let mut curr = proof.root();

--- a/event-svc/src/event/mod.rs
+++ b/event-svc/src/event/mod.rs
@@ -7,4 +7,4 @@ mod store;
 mod validator;
 
 pub use service::{BlockStore, DeliverableRequirement, EventService};
-pub use validator::EthRpcProvider;
+pub use validator::ChainInclusionProvider;

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use recon::ReconItem;
 use tracing::{trace, warn};
 
-use crate::event::validator::EthRpcProvider;
+use crate::event::validator::ChainInclusionProvider;
 use crate::store::{EventAccess, EventInsertable, EventRowDelivered};
 use crate::{Error, Result};
 
@@ -89,7 +89,7 @@ impl EventService {
         pool: SqlitePool,
         process_undelivered_events: bool,
         validate_events: bool,
-        ethereum_rpc_providers: Vec<EthRpcProvider>,
+        ethereum_rpc_providers: Vec<ChainInclusionProvider>,
     ) -> Result<Self> {
         let event_access = Arc::new(EventAccess::try_new(pool.clone()).await?);
 

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -7,7 +7,7 @@ use ipld_core::ipld::Ipld;
 use recon::ReconItem;
 use tokio::try_join;
 
-use crate::event::validator::EthRpcProvider;
+use crate::event::validator::ChainInclusionProvider;
 use crate::store::EventAccess;
 use crate::{
     event::{
@@ -131,7 +131,7 @@ impl EventValidator {
     /// Create a new event validator
     pub async fn try_new(
         event_access: Arc<EventAccess>,
-        ethereum_rpc_providers: Vec<EthRpcProvider>,
+        ethereum_rpc_providers: Vec<ChainInclusionProvider>,
     ) -> Result<Self> {
         let time_event_verifier = TimeEventValidator::new_with_providers(ethereum_rpc_providers);
 
@@ -226,7 +226,7 @@ impl EventValidator {
         Ok(validated_events)
     }
 
-    /// Transforms the [`ChainInclusionError`] into a [`ValidationError`] with an appropriate message
+    /// Transforms the [`eth_rpc::Error`] into a [`ValidationError`] with an appropriate message
     fn convert_inclusion_error(err: eth_rpc::Error, order_key: &EventId) -> ValidationError {
         match err {
             eth_rpc::Error::TxNotFound { chain_id, tx_hash } => {

--- a/event-svc/src/event/validator/mod.rs
+++ b/event-svc/src/event/validator/mod.rs
@@ -4,6 +4,6 @@ mod signed;
 
 mod time;
 
-pub use time::EthRpcProvider;
+pub use time::ChainInclusionProvider;
 
 pub use event::{EventValidator, UnvalidatedEvent, ValidatedEvent, ValidatedEvents};

--- a/event-svc/src/lib.rs
+++ b/event-svc/src/lib.rs
@@ -9,7 +9,7 @@ mod tests;
 
 pub use ceramic_validation::eth_rpc;
 pub use error::Error;
-pub use event::EthRpcProvider;
+pub use event::ChainInclusionProvider;
 pub use event::{BlockStore, EventService};
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/event/src/unvalidated/builder.rs
+++ b/event/src/unvalidated/builder.rs
@@ -316,7 +316,7 @@ impl TimeBuilderState for TimeBuilderWithPrev {}
 impl TimeBuilder<TimeBuilderWithPrev> {
     /// Build the [`unvalidated::TimeEvent`].
     pub fn build(self) -> anyhow::Result<unvalidated::TimeEvent> {
-        let proof = unvalidated::Proof::new(
+        let proof = unvalidated::AnchorProof::new(
             self.state.chain_id,
             self.state.prev,
             self.state.tx_hash,
@@ -381,7 +381,7 @@ impl TimeBuilder<TimeBuilderWithRoot> {
             Ipld::Link(prev) => *prev,
             _ => bail!("leaf indexed value should always be a Cid"),
         };
-        let proof = unvalidated::Proof::new(
+        let proof = unvalidated::AnchorProof::new(
             self.state.chain_id,
             root.to_cid()?,
             self.state.tx_hash,

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -9,7 +9,7 @@ use ceramic_anchor_remote::RemoteCas;
 use ceramic_anchor_service::AnchorService;
 use ceramic_core::NodeId;
 use ceramic_event_svc::eth_rpc::HttpEthRpc;
-use ceramic_event_svc::{EthRpcProvider, EventService};
+use ceramic_event_svc::{ChainInclusionProvider, EventService};
 use ceramic_interest_svc::InterestService;
 use ceramic_kubo_rpc::Multiaddr;
 use ceramic_metrics::{config::Config as MetricsConfig, MetricsHandle};
@@ -245,7 +245,7 @@ pub struct DaemonOpts {
 async fn get_eth_rpc_providers(
     ethereum_rpc_urls: Vec<String>,
     network: &Network,
-) -> Result<Vec<EthRpcProvider>> {
+) -> Result<Vec<ChainInclusionProvider>> {
     let ethereum_rpc_urls = if ethereum_rpc_urls.is_empty() {
         network.default_rpc_urls()?
     } else {
@@ -266,7 +266,7 @@ async fn get_eth_rpc_providers(
                         provider.chain_id(),
                         provider.url()
                     );
-                    let provider: EthRpcProvider = Arc::new(provider);
+                    let provider: ChainInclusionProvider = Arc::new(provider);
                     providers.push(provider);
                 } else {
                     warn!("Eth RPC provider {} uses chainid {} which isn't supported by Ceramic network {:?}", url, provider_chain,network);

--- a/validation/src/blockchain/eth_rpc/mod.rs
+++ b/validation/src/blockchain/eth_rpc/mod.rs
@@ -2,6 +2,4 @@ mod http;
 mod types;
 
 pub use http::HttpEthRpc;
-pub use types::{
-    BlockHash, ChainInclusion, Error, EthProofType, EthTxProofInput, TimeProof, TxHash,
-};
+pub use types::{BlockHash, ChainInclusion, ChainInclusionProof, Error, EthProofType, TxHash};


### PR DESCRIPTION
builds on https://github.com/ceramicnetwork/rust-ceramic/pull/550 making things more fully generic and preparing for the addition of an "adm" implementation of the `ChainProvider` trait.