### PR TITLE
chore: version v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.41.0] - 2024-11-04
+
+### 🚀 Features
+
+- Turn on event validation by default (#562)
+
+### 🐛 Bug Fixes
+
+- Correct path to latest tarball (#566)
+- Size 1 anchor trees (#565)
+
+### 🚜 Refactor
+
+- Modify ethereum rpc trait for hoku support (#550)
+- Make ChainInclusion trait fully generic and change input to the raw AnchorProof (#570)
+
 ## [0.40.0] - 2024-10-17
 
 ### 🚀 Features
@@ -22,6 +38,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Record the per item duration of an insert_many request (#551)
+- Version v0.40.0 (#564)
 
 ## [0.39.0] - 2024-10-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2503,7 +2503,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "ceramic-pipeline",
  "datafusion",
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2616,7 +2616,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "built",
  "project-root",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2820,7 +2820,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-olap"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2854,7 +2854,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "arrow-flight",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2974,7 +2974,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6205,7 +6205,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -6245,7 +6245,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9704,7 +9704,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.40.0"
+version = "0.41.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.40.0
-- Build date: 2024-10-17T18:51:28.818325470Z[Etc/UTC]
+- API version: 0.41.0
+- Build date: 2024-11-04T21:29:52.880610824Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.40.0
+  version: 0.41.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.40.0";
+pub const API_VERSION: &str = "0.41.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.40.0
+  version: 0.41.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.40.0
-- Build date: 2024-10-17T18:51:31.008931216Z[Etc/UTC]
+- API version: 0.41.0
+- Build date: 2024-11-04T21:29:55.002948945Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.40.0
+  version: 0.41.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.40.0";
+pub const API_VERSION: &str = "0.41.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.40.0
+  version: 0.41.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.41.0] - 2024-11-04

### 🚀 Features

- Turn on event validation by default (#562)

### 🐛 Bug Fixes

- Correct path to latest tarball (#566)
- Size 1 anchor trees (#565)

### 🚜 Refactor

- Modify ethereum rpc trait for hoku support (#550)
- Make ChainInclusion trait fully generic and change input to the raw AnchorProof (#570)