### PR TITLE
fix: Make error message match the js-ceramic version

### DIFF
--- a/validation/src/verifier/cacao_verifier.rs
+++ b/validation/src/verifier/cacao_verifier.rs
@@ -129,7 +129,7 @@ impl Verifier for Capability {
         {
             Ok(())
         } else {
-            bail!("capability does not have appropriate permissions to update this stream");
+            bail!("Capability does not have appropriate permissions to update this stream");
         }
     }
 }


### PR DESCRIPTION
I'm mostly just curious how far the js-ceramic tests will get with event validation turned on with this change.