### PR TITLE
feat: use cache table to make queries faster and writes to object store batched

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,8 +810,7 @@ dependencies = [
 [[package]]
 name = "arrow-arith"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91f2dfd1a7ec0aca967dfaa616096aec49779adc8eccec005e2f5e4111b1192a"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -825,8 +824,7 @@ dependencies = [
 [[package]]
 name = "arrow-array"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39387ca628be747394890a6e47f138ceac1aa912eab64f02519fed24b637af8"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -835,15 +833,14 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half 2.4.1",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e51e05228852ffe3eb391ce7178a0f97d2cf80cc6ef91d3c4a6b3cb688049ec"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "bytes 1.7.2",
  "half 2.4.1",
@@ -853,8 +850,7 @@ dependencies = [
 [[package]]
 name = "arrow-cast"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09aea56ec9fa267f3f3f6cdab67d8a9974cbba90b3aa38c8fe9d0bb071bd8c1"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -893,8 +889,7 @@ dependencies = [
 [[package]]
 name = "arrow-data"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98ae0af50890b494cebd7d6b04b35e896205c1d1df7b29a6272c5d0d0249ef5"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -905,8 +900,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703620bf755500804893dc4b42982b8a33ee20d7c20c9c3ab3490a1d0f7cf641"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -933,8 +927,7 @@ dependencies = [
 [[package]]
 name = "arrow-ipc"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed91bdeaff5a1c00d28d8f73466bcb64d32bbd7093b5a30156b4b9f4dba3eee"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -968,8 +961,7 @@ dependencies = [
 [[package]]
 name = "arrow-ord"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2883d7035e0b600fb4c30ce1e50e66e53d8656aa729f2bfa4b51d359cf3ded52"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -983,8 +975,7 @@ dependencies = [
 [[package]]
 name = "arrow-row"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552907e8e587a6fde4f8843fd7a27a576a260f65dab6c065741ea79f633fc5be"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -997,14 +988,12 @@ dependencies = [
 [[package]]
 name = "arrow-schema"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "539ada65246b949bd99ffa0881a9a15a4a529448af1a07a9838dd78617dafab1"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 
 [[package]]
 name = "arrow-select"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6259e566b752da6dceab91766ed8b2e67bf6270eb9ad8a6e07a33c1bede2b125"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -1017,8 +1006,7 @@ dependencies = [
 [[package]]
 name = "arrow-string"
 version = "53.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3179ccbd18ebf04277a095ba7321b93fd1f774f18816bd5f6b3ce2f594edb6c"
+source = "git+https://github.com/apache/arrow-rs.git?branch=master#e907bf8e3df5cd8cba8b5f761f9291f2ec0c2730"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2576,7 +2564,9 @@ dependencies = [
  "int-enum",
  "ipld-core",
  "json-patch",
+ "mockall",
  "object_store",
+ "parking_lot",
  "serde",
  "serde_json",
  "test-log",
@@ -3541,7 +3531,7 @@ dependencies = [
 [[package]]
 name = "datafusion-federation"
 version = "0.3.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-federation.git?branch=main#e1084a92f7bc75a07cb1a9840429bca3842bd593"
+source = "git+https://github.com/datafusion-contrib/datafusion-federation.git?branch=main#c5e3149ac6c18fa80a33a6831314e603154ab032"
 dependencies = [
  "arrow-json",
  "async-stream",
@@ -3553,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "datafusion-flight-sql-server"
 version = "0.4.0"
-source = "git+https://github.com/datafusion-contrib/datafusion-federation.git?branch=main#e1084a92f7bc75a07cb1a9840429bca3842bd593"
+source = "git+https://github.com/datafusion-contrib/datafusion-federation.git?branch=main#c5e3149ac6c18fa80a33a6831314e603154ab032"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4990,6 +4980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5252,7 +5248,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8833,8 +8829,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes 1.7.2",
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8880,7 +8876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -10373,7 +10369,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -12504,7 +12500,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,3 +255,18 @@ repository = "https://github.com/3box/rust-ceramic"
 inherits = "release"
 debug = true
 strip = "none"
+
+[patch.crates-io]
+# We need the pre-released code until this fix is part of a release https://github.com/apache/arrow-rs/pull/6645
+arrow-arith = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-array = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-data = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-flight = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-row = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-select = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }
+arrow-string = { git = "https://github.com/apache/arrow-rs.git", branch = "master" }

--- a/flight/tests/server.rs
+++ b/flight/tests/server.rs
@@ -19,9 +19,7 @@ use test_log::test;
 use tokio::net::TcpListener;
 use tonic::{async_trait, transport::Channel};
 
-/// Return a [`Channel`] connected to the TestServer
-#[allow(dead_code)]
-pub async fn channel(addr: &SocketAddr) -> Channel {
+async fn channel(addr: &SocketAddr) -> Channel {
     let url = format!("http://{addr}");
     let uri: Uri = url.parse().expect("Valid URI");
     Channel::builder(uri)
@@ -72,7 +70,7 @@ async fn execute_flight(
         batches.append(&mut endpoint_batches);
     }
 
-    Ok(concat_batches(&schema, &batches)?)
+    Ok(concat_batches(&schema, &batches).context("concat_batches for output")?)
 }
 
 mock! {

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -531,7 +531,7 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
             .s3_bucket
             .ok_or_else(|| anyhow!("s3_bucket option is required when exposing flight sql"))?;
         let ctx = ceramic_pipeline::session_from_config(ceramic_pipeline::Config {
-            conclusion_feed: feed,
+            conclusion_feed: feed.into(),
             object_store: Arc::new(
                 AmazonS3Builder::from_env()
                     .with_bucket_name(&bucket)

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -30,7 +30,9 @@ serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+parking_lot = "0.12.3"
 
 [dev-dependencies]
 test-log = "0.2.16"
 ceramic-arrow-test.workspace = true
+mockall.workspace = true

--- a/pipeline/src/cache_table.rs
+++ b/pipeline/src/cache_table.rs
@@ -1,0 +1,681 @@
+//! [`CacheTable`] for querying `Vec<RecordBatch>` by DataFusion.
+
+// This implentation is copied from the MemTable from datafusion
+// and modified for the specific needs of being a cache table
+// that is periodically cleared.
+// It is likely that we continue to specialize this implentation
+// based on our unique needs.
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt::{self, Debug};
+use std::sync::Arc;
+
+use arrow::array::RecordBatch;
+use arrow_schema::SchemaRef;
+use async_trait::async_trait;
+use datafusion::logical_expr::SortExpr;
+use datafusion::{
+    catalog::Session,
+    common::{plan_err, Constraints, DFSchema, SchemaExt as _},
+    datasource::{TableProvider, TableType},
+    error::Result,
+    execution::TaskContext,
+    logical_expr::Expr,
+    physical_plan::{
+        insert::{DataSink, DataSinkExec},
+        memory::MemoryExec,
+        metrics::MetricsSet,
+        DisplayAs, DisplayFormatType, ExecutionPlan, SendableRecordBatchStream,
+    },
+    physical_planner::create_physical_sort_exprs,
+};
+use futures::StreamExt as _;
+use parking_lot::Mutex;
+use tokio::sync::RwLock;
+use tracing::debug;
+
+/// Type alias for partition data
+pub type PartitionData = Arc<RwLock<Vec<RecordBatch>>>;
+
+/// In-memory data source for presenting a `Vec<RecordBatch>` as a
+/// data source that can be queried by DataFusion. This allows data to
+/// be pre-loaded into memory and then repeatedly queried without
+/// incurring additional file I/O overhead.
+///
+/// The data may also be cleared in order to use this table as a write cache table.
+#[derive(Debug)]
+pub struct CacheTable {
+    schema: SchemaRef,
+    pub(crate) batches: Vec<PartitionData>,
+    constraints: Constraints,
+    column_defaults: HashMap<String, Expr>,
+    /// Optional pre-known sort order(s). Must be `SortExpr`s.
+    /// inserting data into this table removes the order
+    pub sort_order: Arc<Mutex<Vec<Vec<SortExpr>>>>,
+}
+
+impl CacheTable {
+    /// Create a new in-memory table from the provided schema and record batches
+    pub fn try_new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
+        for batches in partitions.iter().flatten() {
+            let batches_schema = batches.schema();
+            if !schema.contains(&batches_schema) {
+                debug!(
+                    ?schema,
+                    ?batches_schema,
+                    "mem table schema does not contain batches schema."
+                );
+                return plan_err!("Mismatch between schema and batches");
+            }
+        }
+
+        Ok(Self {
+            schema,
+            batches: partitions
+                .into_iter()
+                .map(|e| Arc::new(RwLock::new(e)))
+                .collect::<Vec<_>>(),
+            constraints: Constraints::empty(),
+            column_defaults: HashMap::new(),
+            sort_order: Arc::new(Mutex::new(vec![])),
+        })
+    }
+
+    async fn clear(&self) {
+        for arc_inner_vec in self.batches.iter() {
+            arc_inner_vec.write().await.clear();
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for CacheTable {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn constraints(&self) -> Option<&Constraints> {
+        Some(&self.constraints)
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let mut partitions = vec![];
+        for arc_inner_vec in self.batches.iter() {
+            let inner_vec = arc_inner_vec.read().await;
+            partitions.push(inner_vec.clone())
+        }
+
+        // TODO: Do we want to use a specialized CacheExec here that doesn't need a copy of the
+        // data?
+        // Is copying the data once faster than repeated access to the locks?
+        let mut exec = MemoryExec::try_new(&partitions, self.schema(), projection.cloned())?;
+
+        let show_sizes = state.config_options().explain.show_sizes;
+        exec = exec.with_show_sizes(show_sizes);
+
+        // add sort information if present
+        let sort_order = self.sort_order.lock();
+        if !sort_order.is_empty() {
+            let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+
+            let file_sort_order = sort_order
+                .iter()
+                .map(|sort_exprs| {
+                    create_physical_sort_exprs(sort_exprs, &df_schema, state.execution_props())
+                })
+                .collect::<Result<Vec<_>>>()?;
+            exec = exec.with_sort_information(file_sort_order);
+        }
+
+        Ok(Arc::new(exec))
+    }
+
+    /// Returns an ExecutionPlan that inserts the execution results of a given [`ExecutionPlan`] into this [`CacheTable`].
+    ///
+    /// The [`ExecutionPlan`] must have the same schema as this [`CacheTable`].
+    ///
+    /// # Arguments
+    ///
+    /// * `state` - The [`SessionState`] containing the context for executing the plan.
+    /// * `input` - The [`ExecutionPlan`] to execute and insert.
+    ///
+    /// # Returns
+    ///
+    /// * A plan that returns the number of rows written.
+    async fn insert_into(
+        &self,
+        _state: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        overwrite: bool,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // If we are inserting into the table, any sort order may be messed up so reset it here
+        *self.sort_order.lock() = vec![];
+
+        // Create a physical plan from the logical plan.
+        // Check that the schema of the plan matches the schema of this table.
+        if !self
+            .schema()
+            .logically_equivalent_names_and_types(&input.schema())
+        {
+            return plan_err!("Inserting query must have the same schema with the table.");
+        }
+        if overwrite {
+            self.clear().await;
+        }
+        let sink = Arc::new(CacheSink::new(self.batches.clone()));
+        Ok(Arc::new(DataSinkExec::new(
+            input,
+            sink,
+            self.schema.clone(),
+            None,
+        )))
+    }
+
+    fn get_column_default(&self, column: &str) -> Option<&Expr> {
+        self.column_defaults.get(column)
+    }
+}
+
+/// Implements for writing to a [`CacheTable`]
+struct CacheSink {
+    /// Target locations for writing data
+    batches: Vec<PartitionData>,
+}
+
+impl Debug for CacheSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MemSink")
+            .field("num_partitions", &self.batches.len())
+            .finish()
+    }
+}
+
+impl DisplayAs for CacheSink {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                let partition_count = self.batches.len();
+                write!(f, "MemoryTable (partitions={partition_count})")
+            }
+        }
+    }
+}
+
+impl CacheSink {
+    fn new(batches: Vec<PartitionData>) -> Self {
+        Self { batches }
+    }
+}
+
+#[async_trait]
+impl DataSink for CacheSink {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        None
+    }
+
+    async fn write_all(
+        &self,
+        mut data: SendableRecordBatchStream,
+        _context: &Arc<TaskContext>,
+    ) -> Result<u64> {
+        let num_partitions = self.batches.len();
+
+        // buffer up the data round robin style into num_partitions
+
+        let mut new_batches = vec![vec![]; num_partitions];
+        let mut i = 0;
+        let mut row_count = 0;
+        while let Some(batch) = data.next().await.transpose()? {
+            row_count += batch.num_rows();
+            new_batches[i].push(batch);
+            i = (i + 1) % num_partitions;
+        }
+
+        // write the outputs into the batches
+        for (target, mut batches) in self.batches.iter().zip(new_batches.into_iter()) {
+            // Append all the new batches in one go to minimize locking overhead
+            target.write().await.append(&mut batches);
+        }
+
+        Ok(row_count as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use arrow::{
+        array::{AsArray as _, Int32Array},
+        datatypes::UInt64Type,
+    };
+    use arrow_schema::{ArrowError, DataType, Field, Schema};
+    use datafusion::{
+        datasource::provider_as_source, error::DataFusionError, execution::context::SessionContext,
+        logical_expr::LogicalPlanBuilder, physical_plan::collect,
+    };
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_with_projection() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+            Field::new("d", DataType::Int32, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+                Arc::new(Int32Array::from(vec![None, None, Some(9)])),
+            ],
+        )?;
+
+        let provider = CacheTable::try_new(schema, vec![vec![batch]])?;
+
+        // scan with projection
+        let exec = provider
+            .scan(&session_ctx.state(), Some(&vec![2, 1]), &[], None)
+            .await?;
+
+        let mut it = exec.execute(0, task_ctx)?;
+        let batch2 = it.next().await.unwrap()?;
+        assert_eq!(2, batch2.schema().fields().len());
+        assert_eq!("c", batch2.schema().field(0).name());
+        assert_eq!("b", batch2.schema().field(1).name());
+        assert_eq!(2, batch2.num_columns());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_without_projection() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )?;
+
+        let provider = CacheTable::try_new(schema, vec![vec![batch]])?;
+
+        let exec = provider.scan(&session_ctx.state(), None, &[], None).await?;
+        let mut it = exec.execute(0, task_ctx)?;
+        let batch1 = it.next().await.unwrap()?;
+        assert_eq!(3, batch1.schema().fields().len());
+        assert_eq!(3, batch1.num_columns());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_invalid_projection() -> Result<()> {
+        let session_ctx = SessionContext::new();
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )?;
+
+        let provider = CacheTable::try_new(schema, vec![vec![batch]])?;
+
+        let projection: Vec<usize> = vec![0, 4];
+
+        match provider
+            .scan(&session_ctx.state(), Some(&projection), &[], None)
+            .await
+        {
+            Err(DataFusionError::ArrowError(ArrowError::SchemaError(e), _)) => {
+                assert_eq!(
+                    "\"project index 4 out of bounds, max field 3\"",
+                    format!("{e:?}")
+                )
+            }
+            res => panic!("Scan should failed on invalid projection, got {res:?}"),
+        };
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_schema_validation_incompatible_column() -> Result<()> {
+        let schema1 = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let schema2 = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Float64, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema1,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )?;
+
+        let e = CacheTable::try_new(schema2, vec![vec![batch]]).unwrap_err();
+        assert_eq!(
+            "Error during planning: Mismatch between schema and batches",
+            e.strip_backtrace()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_schema_validation_different_column_count() -> Result<()> {
+        let schema1 = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let schema2 = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema1,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![7, 5, 9])),
+            ],
+        )?;
+
+        let e = CacheTable::try_new(schema2, vec![vec![batch]]).unwrap_err();
+        assert_eq!(
+            "Error during planning: Mismatch between schema and batches",
+            e.strip_backtrace()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_merged_schema() -> Result<()> {
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let mut metadata = HashMap::new();
+        metadata.insert("foo".to_string(), "bar".to_string());
+
+        let schema1 = Schema::new_with_metadata(
+            vec![
+                Field::new("a", DataType::Int32, false),
+                Field::new("b", DataType::Int32, false),
+                Field::new("c", DataType::Int32, false),
+            ],
+            // test for comparing metadata
+            metadata,
+        );
+
+        let schema2 = Schema::new(vec![
+            // test for comparing nullability
+            Field::new("a", DataType::Int32, true),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Int32, false),
+        ]);
+
+        let merged_schema = Schema::try_merge(vec![schema1.clone(), schema2.clone()])?;
+
+        let batch1 = RecordBatch::try_new(
+            Arc::new(schema1),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )?;
+
+        let batch2 = RecordBatch::try_new(
+            Arc::new(schema2),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![4, 5, 6])),
+                Arc::new(Int32Array::from(vec![7, 8, 9])),
+            ],
+        )?;
+
+        let provider = CacheTable::try_new(Arc::new(merged_schema), vec![vec![batch1, batch2]])?;
+
+        let exec = provider.scan(&session_ctx.state(), None, &[], None).await?;
+        let mut it = exec.execute(0, task_ctx)?;
+        let batch1 = it.next().await.unwrap()?;
+        assert_eq!(3, batch1.schema().fields().len());
+        assert_eq!(3, batch1.num_columns());
+
+        Ok(())
+    }
+
+    async fn experiment(
+        schema: SchemaRef,
+        initial_data: Vec<Vec<RecordBatch>>,
+        inserted_data: Vec<Vec<RecordBatch>>,
+    ) -> Result<Vec<Vec<RecordBatch>>> {
+        let expected_count: u64 = inserted_data
+            .iter()
+            .flat_map(|batches| batches.iter().map(|batch| batch.num_rows() as u64))
+            .sum();
+
+        // Create a new session context
+        let session_ctx = SessionContext::new();
+        // Create and register the initial table with the provided schema and data
+        let initial_table = Arc::new(CacheTable::try_new(schema.clone(), initial_data)?);
+        session_ctx.register_table("t", initial_table.clone())?;
+        // Create and register the source table with the provided schema and inserted data
+        let source_table = Arc::new(CacheTable::try_new(schema.clone(), inserted_data)?);
+        session_ctx.register_table("source", source_table.clone())?;
+        // Convert the source table into a provider so that it can be used in a query
+        let source = provider_as_source(source_table);
+        // Create a table scan logical plan to read from the source table
+        let scan_plan = LogicalPlanBuilder::scan("source", source, None)?.build()?;
+        // Create an insert plan to insert the source data into the initial table
+        let insert_into_table =
+            LogicalPlanBuilder::insert_into(scan_plan, "t", &schema, false)?.build()?;
+        // Create a physical plan from the insert plan
+        let plan = session_ctx
+            .state()
+            .create_physical_plan(&insert_into_table)
+            .await?;
+
+        // Execute the physical plan and collect the results
+        let res = collect(plan, session_ctx.task_ctx()).await?;
+        assert_eq!(extract_count(res), expected_count);
+
+        // Read the data from the initial table and store it in a vector of partitions
+        let mut partitions = vec![];
+        for partition in initial_table.batches.iter() {
+            let part = partition.read().await.clone();
+            partitions.push(part);
+        }
+        Ok(partitions)
+    }
+
+    /// Returns the value of results. For example, returns 6 given the following
+    ///
+    /// ```text
+    /// +-------+,
+    /// | count |,
+    /// +-------+,
+    /// | 6     |,
+    /// +-------+,
+    /// ```
+    fn extract_count(res: Vec<RecordBatch>) -> u64 {
+        assert_eq!(res.len(), 1, "expected one batch, got {}", res.len());
+        let batch = &res[0];
+        assert_eq!(
+            batch.num_columns(),
+            1,
+            "expected 1 column, got {}",
+            batch.num_columns()
+        );
+        let col = batch.column(0).as_primitive::<UInt64Type>();
+        assert_eq!(col.len(), 1, "expected 1 row, got {}", col.len());
+        let val = col
+            .iter()
+            .next()
+            .expect("had value")
+            .expect("expected non null");
+        val
+    }
+
+    // Test inserting a single batch of data into a single partition
+    #[tokio::test]
+    async fn test_insert_into_single_partition() -> Result<()> {
+        // Create a new schema with one field called "a" of type Int32
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // Create a new batch of data to insert into the table
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        // Run the experiment and obtain the resulting data in the table
+        let resulting_data_in_table =
+            experiment(schema, vec![vec![batch.clone()]], vec![vec![batch.clone()]]).await?;
+        // Ensure that the table now contains two batches of data in the same partition
+        assert_eq!(resulting_data_in_table[0].len(), 2);
+        Ok(())
+    }
+
+    // Test inserting multiple batches of data into a single partition
+    #[tokio::test]
+    async fn test_insert_into_single_partition_with_multi_partition() -> Result<()> {
+        // Create a new schema with one field called "a" of type Int32
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // Create a new batch of data to insert into the table
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        // Run the experiment and obtain the resulting data in the table
+        let resulting_data_in_table = experiment(
+            schema,
+            vec![vec![batch.clone()]],
+            vec![vec![batch.clone()], vec![batch]],
+        )
+        .await?;
+        // Ensure that the table now contains three batches of data in the same partition
+        assert_eq!(resulting_data_in_table[0].len(), 3);
+        Ok(())
+    }
+
+    // Test inserting multiple batches of data into multiple partitions
+    #[tokio::test]
+    async fn test_insert_into_multi_partition_with_multi_partition() -> Result<()> {
+        // Create a new schema with one field called "a" of type Int32
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // Create a new batch of data to insert into the table
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        // Run the experiment and obtain the resulting data in the table
+        let resulting_data_in_table = experiment(
+            schema,
+            vec![vec![batch.clone()], vec![batch.clone()]],
+            vec![
+                vec![batch.clone(), batch.clone()],
+                vec![batch.clone(), batch],
+            ],
+        )
+        .await?;
+        // Ensure that each partition in the table now contains three batches of data
+        assert_eq!(resulting_data_in_table[0].len(), 3);
+        assert_eq!(resulting_data_in_table[1].len(), 3);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_insert_from_empty_table() -> Result<()> {
+        // Create a new schema with one field called "a" of type Int32
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+
+        // Create a new batch of data to insert into the table
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )?;
+        // Run the experiment and obtain the resulting data in the table
+        let resulting_data_in_table = experiment(
+            schema,
+            vec![vec![batch.clone(), batch.clone()]],
+            vec![vec![]],
+        )
+        .await?;
+        // Ensure that the table now contains two batches of data in the same partition
+        assert_eq!(resulting_data_in_table[0].len(), 2);
+        Ok(())
+    }
+}

--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -5,11 +5,31 @@ use object_store::ObjectStore;
 /// Configuration for pipeline session.
 pub struct Config<F> {
     /// Define how the conclusion feed will be accessed.
-    pub conclusion_feed: Arc<F>,
+    pub conclusion_feed: ConclusionFeedSource<F>,
 
     /// Bucket name in which to store objects.
     pub object_store_bucket_name: String,
 
     /// Access to an object store.
     pub object_store: Arc<dyn ObjectStore>,
+}
+
+/// Define the source of the conclusion_feed table
+pub enum ConclusionFeedSource<F> {
+    /// Direct API access to the feed
+    Direct(Arc<F>),
+    /// Memory table
+    #[cfg(test)]
+    InMemory(datafusion::datasource::MemTable),
+}
+
+impl<F> From<F> for ConclusionFeedSource<F> {
+    fn from(value: F) -> Self {
+        Self::Direct(Arc::new(value))
+    }
+}
+impl<F> From<&Arc<F>> for ConclusionFeedSource<F> {
+    fn from(value: &Arc<F>) -> Self {
+        Self::Direct(Arc::clone(value))
+    }
 }

--- a/pipeline/src/schemas.rs
+++ b/pipeline/src/schemas.rs
@@ -3,7 +3,60 @@ use std::sync::{Arc, OnceLock};
 
 use datafusion::arrow::datatypes::{DataType, Field, Fields, SchemaBuilder, SchemaRef};
 
+static CONCLUSION_FEED: OnceLock<SchemaRef> = OnceLock::new();
 static DOC_STATE: OnceLock<SchemaRef> = OnceLock::new();
+
+/// The `conclusion_feed` table contains the raw events annotated with conclcusions about each
+/// event.
+pub fn conclusion_feed() -> SchemaRef {
+    Arc::clone(CONCLUSION_FEED.get_or_init(|| {
+        Arc::new(
+            SchemaBuilder::from(&Fields::from(vec![
+                Field::new("index", DataType::UInt64, false),
+                Field::new("event_type", DataType::UInt8, false),
+                Field::new("stream_cid", DataType::Binary, false),
+                Field::new("stream_type", DataType::UInt8, false),
+                Field::new("controller", DataType::Utf8, false),
+                Field::new(
+                    // NOTE: The entire dimensions map may be null or values for a given key may
+                    // be null. No other aspect of dimensions may be null.
+                    "dimensions",
+                    DataType::Map(
+                        Field::new(
+                            "entries",
+                            DataType::Struct(
+                                vec![
+                                    Field::new("key", DataType::Utf8, false),
+                                    Field::new(
+                                        "value",
+                                        DataType::Dictionary(
+                                            Box::new(DataType::Int32),
+                                            Box::new(DataType::Binary),
+                                        ),
+                                        true,
+                                    ),
+                                ]
+                                .into(),
+                            ),
+                            false,
+                        )
+                        .into(),
+                        false,
+                    ),
+                    true,
+                ),
+                Field::new("event_cid", DataType::Binary, false),
+                Field::new("data", DataType::Binary, true),
+                Field::new(
+                    "previous",
+                    DataType::List(Arc::new(Field::new("item", DataType::Binary, false))),
+                    true,
+                ),
+            ]))
+            .finish(),
+        )
+    }))
+}
 
 /// The `doc_state` table contains the aggregated state for each event for each stream.
 pub fn doc_state() -> SchemaRef {

--- a/pipeline/src/tests.rs
+++ b/pipeline/src/tests.rs
@@ -1,0 +1,17 @@
+use async_trait::async_trait;
+use mockall::mock;
+
+use crate::ConclusionEvent;
+
+mock! {
+    #[derive(Debug)]
+    pub ConclusionFeed {}
+    #[async_trait]
+    impl crate::ConclusionFeed for ConclusionFeed {
+        async fn conclusion_events_since(
+            &self,
+            highwater_mark: i64,
+            limit: i64,
+        ) -> anyhow::Result<Vec<ConclusionEvent>>;
+    }
+}


### PR DESCRIPTION
Prior to this change each small batch of writes into the API would result in a single parquet file being written to object store. This behavior quickly creates many files that are too small to gain any column storage benefits. 

This change instead caches writes locally into an in memory table that once large enough is written as a single file into object store. This has a few consequences:

* Files written to object store are large enough to be valuable. (defaults to 10,000 rows)
* There is always a set of data that lives only in memory.
    * If the process is stopped or crashes this data must be recreated on next startup
    * This data can only be queried if read directly from the node that holds the data
 
 
 