### PR TITLE
fix: handle double write of same data

### DIFF
--- a/core/src/event_id.rs
+++ b/core/src/event_id.rs
@@ -31,7 +31,7 @@ use crate::network::Network;
 const MIN_BYTES: [u8; 0] = [];
 const MAX_BYTES: [u8; 1] = [0xFF];
 
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 /// EventId is the event data as a recon key
 pub struct EventId(#[serde(with = "serde_bytes")] Vec<u8>);
 


### PR DESCRIPTION
Prior to this change a write of the same data (keyed by the event id) would cause an error the batching logic of the write path. It was assumed that double writes would not happen and so the channel to report the insert result was dropped, causing an error.

Now all channels are preserved and the result is sent to all.