### PR TITLE
chore: version v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,478 +2,497 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.45.0] - 2024-11-25
+
+### 🚀 Features
+
+- Add api to get stream state ([#586](https://github.com/ceramicnetwork/rust-ceramic/issues/586))
+
+### 🐛 Bug Fixes
+
+- Expose various db errors when storing events ([#601](https://github.com/ceramicnetwork/rust-ceramic/issues/601))
+- Handle double write of same data ([#613](https://github.com/ceramicnetwork/rust-ceramic/issues/613))
+
+### ⚙️ Miscellaneous Tasks
+
+- Automatically select release level ([#612](https://github.com/ceramicnetwork/rust-ceramic/issues/612))
+
 ## [0.44.0] - 2024-11-18
 
 ### 🚀 Features
 
-- Backoff recon synchronization to peers with bad data (#597)
+- Backoff recon synchronization to peers with bad data ([#597](https://github.com/ceramicnetwork/rust-ceramic/issues/597))
 
 ### 🚜 Refactor
 
-- Consistent pipeline table names and schemas (#587)
+- Consistent pipeline table names and schemas ([#587](https://github.com/ceramicnetwork/rust-ceramic/issues/587))
+
+### ⚙️ Miscellaneous Tasks
+
+- Version v0.44.0 ([#598](https://github.com/ceramicnetwork/rust-ceramic/issues/598))
 
 ## [0.43.0] - 2024-11-14
 
 ### 🚀 Features
 
-- Use cache table to make queries faster and writes to object store (#576)
+- Use cache table to make queries faster and writes to object store ([#576](https://github.com/ceramicnetwork/rust-ceramic/issues/576))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Update ci env to dev-qa cluster (#584)
-- Version v0.43.0 (#585)
+- Update ci env to dev-qa cluster ([#584](https://github.com/ceramicnetwork/rust-ceramic/issues/584))
+- Version v0.43.0 ([#585](https://github.com/ceramicnetwork/rust-ceramic/issues/585))
 
 ## [0.42.0] - 2024-11-07
 
 ### 🚀 Features
 
-- Expose all tables via flight sql (#571)
+- Expose all tables via flight sql ([#571](https://github.com/ceramicnetwork/rust-ceramic/issues/571))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Use larger github runner for image builds (#577)
-- Version v0.42.0 (#579)
+- Use larger github runner for image builds ([#577](https://github.com/ceramicnetwork/rust-ceramic/issues/577))
+- Version v0.42.0 ([#579](https://github.com/ceramicnetwork/rust-ceramic/issues/579))
 
 ## [0.41.1] - 2024-11-06
 
 ### 🐛 Bug Fixes
 
-- Remove superflous $ in cacao model auth check (#573)
-- Make error message match the js-ceramic version (#574)
+- Remove superflous $ in cacao model auth check ([#573](https://github.com/ceramicnetwork/rust-ceramic/issues/573))
+- Make error message match the js-ceramic version ([#574](https://github.com/ceramicnetwork/rust-ceramic/issues/574))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.41.1 (#575)
+- Version v0.41.1 ([#575](https://github.com/ceramicnetwork/rust-ceramic/issues/575))
 
 ## [0.41.0] - 2024-11-04
 
 ### 🚀 Features
 
-- Turn on event validation by default (#562)
+- Turn on event validation by default ([#562](https://github.com/ceramicnetwork/rust-ceramic/issues/562))
 
 ### 🐛 Bug Fixes
 
-- Correct path to latest tarball (#566)
-- Size 1 anchor trees (#565)
+- Correct path to latest tarball ([#566](https://github.com/ceramicnetwork/rust-ceramic/issues/566))
+- Size 1 anchor trees ([#565](https://github.com/ceramicnetwork/rust-ceramic/issues/565))
 
 ### 🚜 Refactor
 
-- Modify ethereum rpc trait for hoku support (#550)
-- Make ChainInclusion trait fully generic and change input to the raw AnchorProof (#570)
+- Modify ethereum rpc trait for hoku support ([#550](https://github.com/ceramicnetwork/rust-ceramic/issues/550))
+- Make ChainInclusion trait fully generic and change input to the raw AnchorProof ([#570](https://github.com/ceramicnetwork/rust-ceramic/issues/570))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.41.0 (#572)
+- Version v0.41.0 ([#572](https://github.com/ceramicnetwork/rust-ceramic/issues/572))
 
 ## [0.40.0] - 2024-10-17
 
 ### 🚀 Features
 
-- Protect FlightSQL server with sql options. (#544)
-- Aes 291 continuous queries in olap aggregator (#538)
-- Migrate from file list (#501)
-- Use data container wrapper for mutable metadata (#559)
-- Add query command to ceramic-one (#545)
+- Protect FlightSQL server with sql options. ([#544](https://github.com/ceramicnetwork/rust-ceramic/issues/544))
+- Aes 291 continuous queries in olap aggregator ([#538](https://github.com/ceramicnetwork/rust-ceramic/issues/538))
+- Migrate from file list ([#501](https://github.com/ceramicnetwork/rust-ceramic/issues/501))
+- Use data container wrapper for mutable metadata ([#559](https://github.com/ceramicnetwork/rust-ceramic/issues/559))
+- Add query command to ceramic-one ([#545](https://github.com/ceramicnetwork/rust-ceramic/issues/545))
 
 ### 🐛 Bug Fixes
 
-- Only write out error counts on errors (#560)
-- Use correct index for the conclusion feed. (#561)
-- Use tokio::time::Interval for scheduling anchor batches (#563)
-- Subscribe to server shutdown signal in insert task (#553)
+- Only write out error counts on errors ([#560](https://github.com/ceramicnetwork/rust-ceramic/issues/560))
+- Use correct index for the conclusion feed. ([#561](https://github.com/ceramicnetwork/rust-ceramic/issues/561))
+- Use tokio::time::Interval for scheduling anchor batches ([#563](https://github.com/ceramicnetwork/rust-ceramic/issues/563))
+- Subscribe to server shutdown signal in insert task ([#553](https://github.com/ceramicnetwork/rust-ceramic/issues/553))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Record the per item duration of an insert_many request (#551)
-- Version v0.40.0 (#564)
+- Record the per item duration of an insert_many request ([#551](https://github.com/ceramicnetwork/rust-ceramic/issues/551))
+- Version v0.40.0 ([#564](https://github.com/ceramicnetwork/rust-ceramic/issues/564))
 
 ## [0.39.0] - 2024-10-07
 
 ### 🐛 Bug Fixes
 
-- Allow local and inmemory networks to start up without an eth rpc url (#555)
+- Allow local and inmemory networks to start up without an eth rpc url ([#555](https://github.com/ceramicnetwork/rust-ceramic/issues/555))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Always log options at startup (#554)
-- Version v0.39.0 (#557)
+- Always log options at startup ([#554](https://github.com/ceramicnetwork/rust-ceramic/issues/554))
+- Version v0.39.0 ([#557](https://github.com/ceramicnetwork/rust-ceramic/issues/557))
 
 ## [0.38.0] - 2024-10-07
 
 ### 🚀 Features
 
-- Validate signed events (#503)
-- Self-anchoring (part 5) (#488)
-- Support non sharded IPFS block paths (#541)
-- Store doc_state table in object storage (#540)
-- Add logic to migration to count errors by model (#542)
-- Validate time event chain inclusion proofs (#539)
-- Process batches on the interval (#548)
-- Ethereum RPC provider configuration (#547)
+- Validate signed events ([#503](https://github.com/ceramicnetwork/rust-ceramic/issues/503))
+- Self-anchoring (part 5) ([#488](https://github.com/ceramicnetwork/rust-ceramic/issues/488))
+- Support non sharded IPFS block paths ([#541](https://github.com/ceramicnetwork/rust-ceramic/issues/541))
+- Store doc_state table in object storage ([#540](https://github.com/ceramicnetwork/rust-ceramic/issues/540))
+- Add logic to migration to count errors by model ([#542](https://github.com/ceramicnetwork/rust-ceramic/issues/542))
+- Validate time event chain inclusion proofs ([#539](https://github.com/ceramicnetwork/rust-ceramic/issues/539))
+- Process batches on the interval ([#548](https://github.com/ceramicnetwork/rust-ceramic/issues/548))
+- Ethereum RPC provider configuration ([#547](https://github.com/ceramicnetwork/rust-ceramic/issues/547))
 
 ### 🐛 Bug Fixes
 
-- Make self-anchoring config experimental (#546)
+- Make self-anchoring config experimental ([#546](https://github.com/ceramicnetwork/rust-ceramic/issues/546))
 
 ### 🚜 Refactor
 
-- Return reference to inserted item from event store and reduce unnecessary ordering work  (#530)
-- Teach event validator some more and store a copy on the service (#536)
-- Use alloy as ethereum RPC provider (#543)
+- Return reference to inserted item from event store and reduce unnecessary ordering work  ([#530](https://github.com/ceramicnetwork/rust-ceramic/issues/530))
+- Teach event validator some more and store a copy on the service ([#536](https://github.com/ceramicnetwork/rust-ceramic/issues/536))
+- Use alloy as ethereum RPC provider ([#543](https://github.com/ceramicnetwork/rust-ceramic/issues/543))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Update ca-certificates so eth rpc connections (#549)
-- Version v0.38.0 (#552)
+- Update ca-certificates so eth rpc connections ([#549](https://github.com/ceramicnetwork/rust-ceramic/issues/549))
+- Version v0.38.0 ([#552](https://github.com/ceramicnetwork/rust-ceramic/issues/552))
 
 ## [0.37.0] - 2024-09-23
 
 ### 🚀 Features
 
-- Add webauthn signature validation (#511)
-- Support dimensions in conclusion feed (#535)
+- Add webauthn signature validation ([#511](https://github.com/ceramicnetwork/rust-ceramic/issues/511))
+- Support dimensions in conclusion feed ([#535](https://github.com/ceramicnetwork/rust-ceramic/issues/535))
 
 ### 🐛 Bug Fixes
 
-- Spawn std task instead of tokio to avoid blocking runtime (#532)
+- Spawn std task instead of tokio to avoid blocking runtime ([#532](https://github.com/ceramicnetwork/rust-ceramic/issues/532))
 
 ### 🚜 Refactor
 
-- Small logic change for readability (#534)
+- Small logic change for readability ([#534](https://github.com/ceramicnetwork/rust-ceramic/issues/534))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.37.0 (#537)
+- Version v0.37.0 ([#537](https://github.com/ceramicnetwork/rust-ceramic/issues/537))
 
 ## [0.36.0] - 2024-09-18
 
 ### 🚀 Features
 
-- Make feature flags top level with experimental features requiring the experimental-features flag to be set (#521)
-- Api to transform events to conclusion events (#508)
-- Add flight sql server to expose conclusion feed. (#523)
-- Anchor service (#484)
-- Add metamodel stream id constant (#529)
-- Infer stream type from raw event model and add it to conclusion event + tests (#525)
-- Rpc client for eth blockchains (#520)
-- Verify time event proofs from eth rpc client and calculate time (#522)
-- Add olap aggregation function (#527)
+- Make feature flags top level with experimental features requiring the experimental-features flag to be set ([#521](https://github.com/ceramicnetwork/rust-ceramic/issues/521))
+- Api to transform events to conclusion events ([#508](https://github.com/ceramicnetwork/rust-ceramic/issues/508))
+- Add flight sql server to expose conclusion feed. ([#523](https://github.com/ceramicnetwork/rust-ceramic/issues/523))
+- Anchor service ([#484](https://github.com/ceramicnetwork/rust-ceramic/issues/484))
+- Add metamodel stream id constant ([#529](https://github.com/ceramicnetwork/rust-ceramic/issues/529))
+- Infer stream type from raw event model and add it to conclusion event + tests ([#525](https://github.com/ceramicnetwork/rust-ceramic/issues/525))
+- Rpc client for eth blockchains ([#520](https://github.com/ceramicnetwork/rust-ceramic/issues/520))
+- Verify time event proofs from eth rpc client and calculate time ([#522](https://github.com/ceramicnetwork/rust-ceramic/issues/522))
+- Add olap aggregation function ([#527](https://github.com/ceramicnetwork/rust-ceramic/issues/527))
 
 ### 🐛 Bug Fixes
 
-- Disable debian repo release workflow (#519)
-- Use build.rs to rebuild sql crate on migrations change (#531)
+- Disable debian repo release workflow ([#519](https://github.com/ceramicnetwork/rust-ceramic/issues/519))
+- Use build.rs to rebuild sql crate on migrations change ([#531](https://github.com/ceramicnetwork/rust-ceramic/issues/531))
 
 ### 🚜 Refactor
 
-- More prep for signed event validation (#526)
+- More prep for signed event validation ([#526](https://github.com/ceramicnetwork/rust-ceramic/issues/526))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.36.0 (#533)
+- Version v0.36.0 ([#533](https://github.com/ceramicnetwork/rust-ceramic/issues/533))
 
 ## [0.35.0] - 2024-09-09
 
 ### 🚀 Features
 
-- Aes 287 create conclusion event type (#499)
-- Trait for generating cbor bytes and cids (#477)
-- Groundwork for event validation and some clean up (#505)
-- Anchor service (part 2) (#476)
-- Remote anchor transaction manager (part 3) (#478)
+- Aes 287 create conclusion event type ([#499](https://github.com/ceramicnetwork/rust-ceramic/issues/499))
+- Trait for generating cbor bytes and cids ([#477](https://github.com/ceramicnetwork/rust-ceramic/issues/477))
+- Groundwork for event validation and some clean up ([#505](https://github.com/ceramicnetwork/rust-ceramic/issues/505))
+- Anchor service (part 2) ([#476](https://github.com/ceramicnetwork/rust-ceramic/issues/476))
+- Remote anchor transaction manager (part 3) ([#478](https://github.com/ceramicnetwork/rust-ceramic/issues/478))
 
 ### 🐛 Bug Fixes
 
-- Updates detection of tile docs and doesn't log them by default (#514)
-- Start up ordering task bug (#516)
+- Updates detection of tile docs and doesn't log them by default ([#514](https://github.com/ceramicnetwork/rust-ceramic/issues/514))
+- Start up ordering task bug ([#516](https://github.com/ceramicnetwork/rust-ceramic/issues/516))
 
 ### 🚜 Refactor
 
-- Remove recon client/server and send empty ranges when we don't need anything (#509)
-- Create explicit event and interest services with separate stores. (#513)
-- Simplify daemon logic (#515)
+- Remove recon client/server and send empty ranges when we don't need anything ([#509](https://github.com/ceramicnetwork/rust-ceramic/issues/509))
+- Create explicit event and interest services with separate stores. ([#513](https://github.com/ceramicnetwork/rust-ceramic/issues/513))
+- Simplify daemon logic ([#515](https://github.com/ceramicnetwork/rust-ceramic/issues/515))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Update console-subscriber package version (#507)
-- Version v0.35.0 (#517)
+- Update console-subscriber package version ([#507](https://github.com/ceramicnetwork/rust-ceramic/issues/507))
+- Version v0.35.0 ([#517](https://github.com/ceramicnetwork/rust-ceramic/issues/517))
 
 ## [0.34.0] - 2024-08-26
 
 ### 🚀 Features
 
-- Eth and sol pkh cacao validation (#496)
-- Jws signature validation (#498)
-- Check cacao resources against stream information (#502)
+- Eth and sol pkh cacao validation ([#496](https://github.com/ceramicnetwork/rust-ceramic/issues/496))
+- Jws signature validation ([#498](https://github.com/ceramicnetwork/rust-ceramic/issues/498))
+- Check cacao resources against stream information ([#502](https://github.com/ceramicnetwork/rust-ceramic/issues/502))
 
 ### 🐛 Bug Fixes
 
-- Use cacao timestamp strings and parse (#504)
+- Use cacao timestamp strings and parse ([#504](https://github.com/ceramicnetwork/rust-ceramic/issues/504))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Add logic to dispatch validation based on event type (#493)
-- Modify cacao, unvalidated module, jwk to add functionality needed for event validation (#492)
-- Version v0.34.0 (#506)
+- Add logic to dispatch validation based on event type ([#493](https://github.com/ceramicnetwork/rust-ceramic/issues/493))
+- Modify cacao, unvalidated module, jwk to add functionality needed for event validation ([#492](https://github.com/ceramicnetwork/rust-ceramic/issues/492))
+- Version v0.34.0 ([#506](https://github.com/ceramicnetwork/rust-ceramic/issues/506))
 
 ## [0.33.0] - 2024-08-19
 
 ### 🚀 Features
 
-- Recon event insert batching (#470)
-- Modify recon store to support event validation concepts (#473)
-- Add noop ceramic-olap binary (#482)
+- Recon event insert batching ([#470](https://github.com/ceramicnetwork/rust-ceramic/issues/470))
+- Modify recon store to support event validation concepts ([#473](https://github.com/ceramicnetwork/rust-ceramic/issues/473))
+- Add noop ceramic-olap binary ([#482](https://github.com/ceramicnetwork/rust-ceramic/issues/482))
 
 ### 🐛 Bug Fixes
 
-- Add better TileDocument detection (#475)
-- Fix bug in TimeEvent witness blocks parsing logic (#486)
+- Add better TileDocument detection ([#475](https://github.com/ceramicnetwork/rust-ceramic/issues/475))
+- Fix bug in TimeEvent witness blocks parsing logic ([#486](https://github.com/ceramicnetwork/rust-ceramic/issues/486))
 
 ### 🚜 Refactor
 
-- Create sync car crate (#485)
+- Create sync car crate ([#485](https://github.com/ceramicnetwork/rust-ceramic/issues/485))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Flatten EventInsertable type (#480)
-- Remove Clone from EventInsertable (#481)
-- Change EventInsertable to store the parsed Event object instead of its raw blocks (#487)
-- Remove an iteration pass in OrderEvents::try_new (#489)
-- Add TODO comment (#491)
-- Remove EventMetadata type (#490)
-- Version v0.33.0 (#494)
+- Flatten EventInsertable type ([#480](https://github.com/ceramicnetwork/rust-ceramic/issues/480))
+- Remove Clone from EventInsertable ([#481](https://github.com/ceramicnetwork/rust-ceramic/issues/481))
+- Change EventInsertable to store the parsed Event object instead of its raw blocks ([#487](https://github.com/ceramicnetwork/rust-ceramic/issues/487))
+- Remove an iteration pass in OrderEvents::try_new ([#489](https://github.com/ceramicnetwork/rust-ceramic/issues/489))
+- Add TODO comment ([#491](https://github.com/ceramicnetwork/rust-ceramic/issues/491))
+- Remove EventMetadata type ([#490](https://github.com/ceramicnetwork/rust-ceramic/issues/490))
+- Version v0.33.0 ([#494](https://github.com/ceramicnetwork/rust-ceramic/issues/494))
 
 ## [0.32.0] - 2024-08-07
 
 ### 🚀 Features
 
-- Feature and experimental feature flags (#448)
-- Change default dir back to shared home location (#471)
+- Feature and experimental feature flags ([#448](https://github.com/ceramicnetwork/rust-ceramic/issues/448))
+- Change default dir back to shared home location ([#471](https://github.com/ceramicnetwork/rust-ceramic/issues/471))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.32.0 (#472)
+- Version v0.32.0 ([#472](https://github.com/ceramicnetwork/rust-ceramic/issues/472))
 
 ## [0.31.0] - 2024-08-02
 
 ### 🚀 Features
 
-- Don't deploy js-ceramic when deploying ceramic-one (#451)
-- Add query parameter to return event data on feed endpoint (#398)
-- Add peer id filter to interests (#456)
+- Don't deploy js-ceramic when deploying ceramic-one ([#451](https://github.com/ceramicnetwork/rust-ceramic/issues/451))
+- Add query parameter to return event data on feed endpoint ([#398](https://github.com/ceramicnetwork/rust-ceramic/issues/398))
+- Add peer id filter to interests ([#456](https://github.com/ceramicnetwork/rust-ceramic/issues/456))
 
 ### 🐛 Bug Fixes
 
-- Fix benchmark (#410)
-- Create release prs via bot (#454)
-- Revert to using pat for release prs (╯°□°)╯︵ ┻━┻ (#458)
+- Fix benchmark ([#410](https://github.com/ceramicnetwork/rust-ceramic/issues/410))
+- Create release prs via bot ([#454](https://github.com/ceramicnetwork/rust-ceramic/issues/454))
+- Revert to using pat for release prs (╯°□°)╯︵ ┻━┻ ([#458](https://github.com/ceramicnetwork/rust-ceramic/issues/458))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Rust 1.80 lints (#450)
-- Version v0.31.0 (#464)
+- Rust 1.80 lints ([#450](https://github.com/ceramicnetwork/rust-ceramic/issues/450))
+- Version v0.31.0 ([#464](https://github.com/ceramicnetwork/rust-ceramic/issues/464))
 
 ## [0.30.0] - 2024-07-29
 
 ### 🚀 Features
 
-- Log bind address at startup (#446)
-- Expose current ceramic network via api (#441)
-- Track version history in database (#409)
+- Log bind address at startup ([#446](https://github.com/ceramicnetwork/rust-ceramic/issues/446))
+- Expose current ceramic network via api ([#441](https://github.com/ceramicnetwork/rust-ceramic/issues/441))
+- Track version history in database ([#409](https://github.com/ceramicnetwork/rust-ceramic/issues/409))
 
 ### 🐛 Bug Fixes
 
-- Disable libp2p tcp port reuse (#440)
-- Use default (google) dns servers if system resolv.conf is invalid (#447)
+- Disable libp2p tcp port reuse ([#440](https://github.com/ceramicnetwork/rust-ceramic/issues/440))
+- Use default (google) dns servers if system resolv.conf is invalid ([#447](https://github.com/ceramicnetwork/rust-ceramic/issues/447))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.30.0 (#449)
+- Version v0.30.0 ([#449](https://github.com/ceramicnetwork/rust-ceramic/issues/449))
 
 ## [0.29.0] - 2024-07-22
 
 ### 🚀 Features
 
-- Support cors via cli flag (#425)
-- Workflow update deb repo (#437)
-- Add option for external swarm addresses (#439)
+- Support cors via cli flag ([#425](https://github.com/ceramicnetwork/rust-ceramic/issues/425))
+- Workflow update deb repo ([#437](https://github.com/ceramicnetwork/rust-ceramic/issues/437))
+- Add option for external swarm addresses ([#439](https://github.com/ceramicnetwork/rust-ceramic/issues/439))
 
 ### 🐛 Bug Fixes
 
-- Add context to p2p key dir errors (#438)
+- Add context to p2p key dir errors ([#438](https://github.com/ceramicnetwork/rust-ceramic/issues/438))
 
 ### 📚 Documentation
 
-- Adds UPGRADE.md docs (#402)
+- Adds UPGRADE.md docs ([#402](https://github.com/ceramicnetwork/rust-ceramic/issues/402))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Add CODEOWNERS file (#443)
-- Version v0.29.0 (#445)
+- Add CODEOWNERS file ([#443](https://github.com/ceramicnetwork/rust-ceramic/issues/443))
+- Version v0.29.0 ([#445](https://github.com/ceramicnetwork/rust-ceramic/issues/445))
 
 ## [0.28.1] - 2024-07-15
 
 ### 🚀 Features
 
-- Add debug to all event types (#432)
+- Add debug to all event types ([#432](https://github.com/ceramicnetwork/rust-ceramic/issues/432))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release archive with linux binary (#422)
-- Update selector for post-deployment tests (#435)
-- Version v0.28.1 (#436)
+- Release archive with linux binary ([#422](https://github.com/ceramicnetwork/rust-ceramic/issues/422))
+- Update selector for post-deployment tests ([#435](https://github.com/ceramicnetwork/rust-ceramic/issues/435))
+- Version v0.28.1 ([#436](https://github.com/ceramicnetwork/rust-ceramic/issues/436))
 
 ## [0.28.0] - 2024-07-12
 
 ### 🚀 Features
 
-- Add devqa bootstrap peers (#430)
-- [**breaking**] Change default dir to current directory (#431)
+- Add devqa bootstrap peers ([#430](https://github.com/ceramicnetwork/rust-ceramic/issues/430))
+- [**breaking**] Change default dir to current directory ([#431](https://github.com/ceramicnetwork/rust-ceramic/issues/431))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.28.0 (#433)
+- Version v0.28.0 ([#433](https://github.com/ceramicnetwork/rust-ceramic/issues/433))
 
 ## [0.27.0] - 2024-07-10
 
 ### 🚀 Features
 
-- Add explicit checking for tile documents for specific errors (#417)
-- Add log-format option to migrations command (#420)
-- Change default ports used for swarm and rpc endpoint (#411)
-- Make private key dir configurable (#426)
-- Add new mainnet and tnet bootstrap peers (#428)
+- Add explicit checking for tile documents for specific errors ([#417](https://github.com/ceramicnetwork/rust-ceramic/issues/417))
+- Add log-format option to migrations command ([#420](https://github.com/ceramicnetwork/rust-ceramic/issues/420))
+- Change default ports used for swarm and rpc endpoint ([#411](https://github.com/ceramicnetwork/rust-ceramic/issues/411))
+- Make private key dir configurable ([#426](https://github.com/ceramicnetwork/rust-ceramic/issues/426))
+- Add new mainnet and tnet bootstrap peers ([#428](https://github.com/ceramicnetwork/rust-ceramic/issues/428))
 
 ### 🐛 Bug Fixes
 
-- Update homebrew-tap push token (#418)
-- Schedule post-deployment tests 15 min after deployment (#419)
-- Optimize migrations logic for less memory (#424)
+- Update homebrew-tap push token ([#418](https://github.com/ceramicnetwork/rust-ceramic/issues/418))
+- Schedule post-deployment tests 15 min after deployment ([#419](https://github.com/ceramicnetwork/rust-ceramic/issues/419))
+- Optimize migrations logic for less memory ([#424](https://github.com/ceramicnetwork/rust-ceramic/issues/424))
 
 ### 🚜 Refactor
 
-- Allow skipping ordering all events on start up and skip tracking during migration (#423)
+- Allow skipping ordering all events on start up and skip tracking during migration ([#423](https://github.com/ceramicnetwork/rust-ceramic/issues/423))
 
 ### 📚 Documentation
 
-- Add cargo testing docs (#394)
+- Add cargo testing docs ([#394](https://github.com/ceramicnetwork/rust-ceramic/issues/394))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.27.0 (#429)
+- Version v0.27.0 ([#429](https://github.com/ceramicnetwork/rust-ceramic/issues/429))
 
 ## [0.26.0] - 2024-07-02
 
 ### 🐛 Bug Fixes
 
-- IOD long streams could remain undelivered (#387)
-- Address edge cases in from-ipfs time events (#395)
-- Make sure the store directory exists and create it if needed (#401)
-- Default missing sep to model (#404)
-- Update correctness test selector (#406)
-- Use event service rather than store to enforce deliverability/or… (#403)
-- Homebrew support (#412)
-- Update homebrew workflow (#413)
-- Use pat for homebrew workflow (#415)
+- IOD long streams could remain undelivered ([#387](https://github.com/ceramicnetwork/rust-ceramic/issues/387))
+- Address edge cases in from-ipfs time events ([#395](https://github.com/ceramicnetwork/rust-ceramic/issues/395))
+- Make sure the store directory exists and create it if needed ([#401](https://github.com/ceramicnetwork/rust-ceramic/issues/401))
+- Default missing sep to model ([#404](https://github.com/ceramicnetwork/rust-ceramic/issues/404))
+- Update correctness test selector ([#406](https://github.com/ceramicnetwork/rust-ceramic/issues/406))
+- Use event service rather than store to enforce deliverability/or… ([#403](https://github.com/ceramicnetwork/rust-ceramic/issues/403))
+- Homebrew support ([#412](https://github.com/ceramicnetwork/rust-ceramic/issues/412))
+- Update homebrew workflow ([#413](https://github.com/ceramicnetwork/rust-ceramic/issues/413))
+- Use pat for homebrew workflow ([#415](https://github.com/ceramicnetwork/rust-ceramic/issues/415))
 
 ### 🚜 Refactor
 
-- Use an Iterator for insert_many and other clean up (#399)
+- Use an Iterator for insert_many and other clean up ([#399](https://github.com/ceramicnetwork/rust-ceramic/issues/399))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Mzk/readme installation (#397)
-- Homebrew support (#407)
-- Version v0.26.0 (#416)
+- Mzk/readme installation ([#397](https://github.com/ceramicnetwork/rust-ceramic/issues/397))
+- Homebrew support ([#407](https://github.com/ceramicnetwork/rust-ceramic/issues/407))
+- Version v0.26.0 ([#416](https://github.com/ceramicnetwork/rust-ceramic/issues/416))
 
 ## [0.25.0] - 2024-06-24
 
 ### 🚀 Features
 
-- Adds migration logic from IPFS (#326)
+- Adds migration logic from IPFS ([#326](https://github.com/ceramicnetwork/rust-ceramic/issues/326))
 
 ### 🐛 Bug Fixes
 
-- Adjust API insert contract and avoid failing entire batch if any one is invalid (#388)
+- Adjust API insert contract and avoid failing entire batch if any one is invalid ([#388](https://github.com/ceramicnetwork/rust-ceramic/issues/388))
 
 ### 🚜 Refactor
 
-- Modify store API and rename some things  (#390)
+- Modify store API and rename some things  ([#390](https://github.com/ceramicnetwork/rust-ceramic/issues/390))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Replace tracing_test with test-log and don't init tracing manually (#391)
-- Rename prometheus registry and metrics for better consistency (#373)
-- Version v0.25.0 (#396)
+- Replace tracing_test with test-log and don't init tracing manually ([#391](https://github.com/ceramicnetwork/rust-ceramic/issues/391))
+- Rename prometheus registry and metrics for better consistency ([#373](https://github.com/ceramicnetwork/rust-ceramic/issues/373))
+- Version v0.25.0 ([#396](https://github.com/ceramicnetwork/rust-ceramic/issues/396))
 
 ## [0.24.0] - 2024-06-18
 
 ### 🐛 Bug Fixes
 
-- Remove redundant db url cli arg (#384)
-- TimeEvents from single-write anchor batches don't have a separate root block (#386)
+- Remove redundant db url cli arg ([#384](https://github.com/ceramicnetwork/rust-ceramic/issues/384))
+- TimeEvents from single-write anchor batches don't have a separate root block ([#386](https://github.com/ceramicnetwork/rust-ceramic/issues/386))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.24.0 (#389)
+- Version v0.24.0 ([#389](https://github.com/ceramicnetwork/rust-ceramic/issues/389))
 
 ## [0.23.0] - 2024-06-17
 
 ### 🚀 Features
 
-- Cd to dev (#376)
-- Add builder for time events (#378)
-- Add cacao serde to unvalidated::Events (#380)
+- Cd to dev ([#376](https://github.com/ceramicnetwork/rust-ceramic/issues/376))
+- Add builder for time events ([#378](https://github.com/ceramicnetwork/rust-ceramic/issues/378))
+- Add cacao serde to unvalidated::Events ([#380](https://github.com/ceramicnetwork/rust-ceramic/issues/380))
 
 ### 🚜 Refactor
 
-- Consolidate car serde logic into event crate (#379)
+- Consolidate car serde logic into event crate ([#379](https://github.com/ceramicnetwork/rust-ceramic/issues/379))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Run clippy fix (#377)
-- Minor clean up and derive more behavior on events (#381)
-- Version v0.23.0 (#383)
+- Run clippy fix ([#377](https://github.com/ceramicnetwork/rust-ceramic/issues/377))
+- Minor clean up and derive more behavior on events ([#381](https://github.com/ceramicnetwork/rust-ceramic/issues/381))
+- Version v0.23.0 ([#383](https://github.com/ceramicnetwork/rust-ceramic/issues/383))
 
 ## [0.22.0] - 2024-06-10
 
 ### 🚀 Features
 
-- Get feed highwater mark to start from "now" (#370)
+- Get feed highwater mark to start from "now" ([#370](https://github.com/ceramicnetwork/rust-ceramic/issues/370))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Fix prom cardinality for test path (#372)
-- Version v0.22.0 (#374)
+- Fix prom cardinality for test path ([#372](https://github.com/ceramicnetwork/rust-ceramic/issues/372))
+- Version v0.22.0 ([#374](https://github.com/ceramicnetwork/rust-ceramic/issues/374))
 
 ## [0.21.0] - 2024-06-03
 
 ### 🚀 Features
 
-- Adjust prom metrics to capture path info and status codes  (#364)
-- Disallow events with unexpected fields via the http api (#363)
+- Adjust prom metrics to capture path info and status codes  ([#364](https://github.com/ceramicnetwork/rust-ceramic/issues/364))
+- Disallow events with unexpected fields via the http api ([#363](https://github.com/ceramicnetwork/rust-ceramic/issues/363))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Rename store traits to InterestStore and EventStore (#365)
-- Deserialize CAR into Event before extracting EventID. (#362)
-- Version v0.21.0 (#371)
+- Rename store traits to InterestStore and EventStore ([#365](https://github.com/ceramicnetwork/rust-ceramic/issues/365))
+- Deserialize CAR into Event before extracting EventID. ([#362](https://github.com/ceramicnetwork/rust-ceramic/issues/362))
+- Version v0.21.0 ([#371](https://github.com/ceramicnetwork/rust-ceramic/issues/371))
 
 ## [0.20.0] - 2024-05-24
 
 ### 🚀 Features
 
-- Add interests endpoint for inspecting interests of a node (#353)
+- Add interests endpoint for inspecting interests of a node ([#353](https://github.com/ceramicnetwork/rust-ceramic/issues/353))
 
 ### 🐛 Bug Fixes
 
-- Add context to init event header (#360)
-- Events incorrectly left undelivered (#366)
-- Recon protocol stall with no shared interests (#367)
+- Add context to init event header ([#360](https://github.com/ceramicnetwork/rust-ceramic/issues/360))
+- Events incorrectly left undelivered ([#366](https://github.com/ceramicnetwork/rust-ceramic/issues/366))
+- Recon protocol stall with no shared interests ([#367](https://github.com/ceramicnetwork/rust-ceramic/issues/367))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.20.0 (#368)
+- Version v0.20.0 ([#368](https://github.com/ceramicnetwork/rust-ceramic/issues/368))
 
 ## [0.19.0] - 2024-05-20
 
@@ -481,8 +500,8 @@ All notable changes to this project will be documented in this file.
 
 - Adjust recon bounds to be lower inclusive and always store value
 - Use builder pattern to create unvalidated and validated events
-- Update event types and builder APIs to prevent building events that dont align with the protocol spec (#357)
-- In order delivery of ceramic events (#344)
+- Update event types and builder APIs to prevent building events that dont align with the protocol spec ([#357](https://github.com/ceramicnetwork/rust-ceramic/issues/357))
+- In order delivery of ceramic events ([#344](https://github.com/ceramicnetwork/rust-ceramic/issues/344))
 
 ### 🐛 Bug Fixes
 
@@ -490,7 +509,7 @@ All notable changes to this project will be documented in this file.
 - Lower correctness test network ttl
 - Move network ttl to hermetic driver command
 - Tests
-- Recon protocol hang with large diffs (#356)
+- Recon protocol hang with large diffs ([#356](https://github.com/ceramicnetwork/rust-ceramic/issues/356))
 
 ### 🚜 Refactor
 
@@ -498,17 +517,17 @@ All notable changes to this project will be documented in this file.
 - Remove value parsing from recon tests
 - Optimize remote missing edge cases
 - Remove keys_with_missing_values from all traits
-- Add service crate (#354)
+- Add service crate ([#354](https://github.com/ceramicnetwork/rust-ceramic/issues/354))
 
 ### ⚙️ Miscellaneous Tasks
 
 - Address review feedback
-- PR review comments (#346)
+- PR review comments ([#346](https://github.com/ceramicnetwork/rust-ceramic/issues/346))
 - Clippy
 - Review and test fixes
 - Unused deps
-- Make event struct fields private (#359)
-- Version v0.19.0 (#361)
+- Make event struct fields private ([#359](https://github.com/ceramicnetwork/rust-ceramic/issues/359))
+- Version v0.19.0 ([#361](https://github.com/ceramicnetwork/rust-ceramic/issues/361))
 
 ## [0.18.0] - 2024-05-13
 
@@ -522,16 +541,16 @@ All notable changes to this project will be documented in this file.
 
 - Update events GET API to return event CID instead of EventID
 - Return event root cid instead of EventID from feed
-- Update experimental API for getting a range of events to return event root CID, not EventID (#337)
+- Update experimental API for getting a range of events to return event root CID, not EventID ([#337](https://github.com/ceramicnetwork/rust-ceramic/issues/337))
 - Simplify event id
 - Add serde methods for Events
-- Make event creation endpoint infer EventID from event CAR file data (#341)
-- Remove id argument from events POST endpoint (#347)
+- Make event creation endpoint infer EventID from event CAR file data ([#341](https://github.com/ceramicnetwork/rust-ceramic/issues/341))
+- Remove id argument from events POST endpoint ([#347](https://github.com/ceramicnetwork/rust-ceramic/issues/347))
 
 ### 🐛 Bug Fixes
 
 - Parse unsigned init events
-- Handle data events with unsigned init events (#348)
+- Handle data events with unsigned init events ([#348](https://github.com/ceramicnetwork/rust-ceramic/issues/348))
 
 ### 🚜 Refactor
 
@@ -540,7 +559,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - SQL queries for event blocks dont need order_key
-- Update comment for Event type in API (#338)
+- Update comment for Event type in API ([#338](https://github.com/ceramicnetwork/rust-ceramic/issues/338))
 - Make gen-api-server
 - Version v0.17.0
 
@@ -548,230 +567,230 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
-- Remove deprecated http API for getting events for a single interest (#332)
+- Remove deprecated http API for getting events for a single interest ([#332](https://github.com/ceramicnetwork/rust-ceramic/issues/332))
 
 ### 🐛 Bug Fixes
 
-- Changes to improve sync and ingest performance (#324)
-- Fix clippy (#334)
+- Changes to improve sync and ingest performance ([#324](https://github.com/ceramicnetwork/rust-ceramic/issues/324))
+- Fix clippy ([#334](https://github.com/ceramicnetwork/rust-ceramic/issues/334))
 
 ### 🚜 Refactor
 
-- Update deps cid, multihash, and ipld (#309)
-- Update recon word list test to make it easier to debug (#342)
+- Update deps cid, multihash, and ipld ([#309](https://github.com/ceramicnetwork/rust-ceramic/issues/309))
+- Update recon word list test to make it easier to debug ([#342](https://github.com/ceramicnetwork/rust-ceramic/issues/342))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Add bad request response to get events API (#329)
-- Run build/test/check CI on all PRs (#333)
-- Version v0.16.0 (#336)
+- Add bad request response to get events API ([#329](https://github.com/ceramicnetwork/rust-ceramic/issues/329))
+- Run build/test/check CI on all PRs ([#333](https://github.com/ceramicnetwork/rust-ceramic/issues/333))
+- Version v0.16.0 ([#336](https://github.com/ceramicnetwork/rust-ceramic/issues/336))
 
 ## [0.15.0] - 2024-04-29
 
 ### 🚀 Features
 
-- Validate time events (#289)
+- Validate time events ([#289](https://github.com/ceramicnetwork/rust-ceramic/issues/289))
 - Add workflow for custom images
-- Migrations with new table format to de-dup blocks and support out of order delivery (#292)
-- Don't mark peers failed when we error during sync (#300)
-- Jemalloc (#319)
-- Store bench (#303)
-- Disable mdns,bitswap,kad,relay,dcutr protocols (#323)
+- Migrations with new table format to de-dup blocks and support out of order delivery ([#292](https://github.com/ceramicnetwork/rust-ceramic/issues/292))
+- Don't mark peers failed when we error during sync ([#300](https://github.com/ceramicnetwork/rust-ceramic/issues/300))
+- Jemalloc ([#319](https://github.com/ceramicnetwork/rust-ceramic/issues/319))
+- Store bench ([#303](https://github.com/ceramicnetwork/rust-ceramic/issues/303))
+- Disable mdns,bitswap,kad,relay,dcutr protocols ([#323](https://github.com/ceramicnetwork/rust-ceramic/issues/323))
 
 ### 🐛 Bug Fixes
 
-- Use TAG_LATEST (#294)
-- Set the js-ceramic image when scheduling k8 deploy (#298)
+- Use TAG_LATEST ([#294](https://github.com/ceramicnetwork/rust-ceramic/issues/294))
+- Set the js-ceramic image when scheduling k8 deploy ([#298](https://github.com/ceramicnetwork/rust-ceramic/issues/298))
 - Gh workflow syntax
-- Cd-to-infra workflow quote fix (#314)
-- Tokio vs std thread is okay (#318)
-- Rust-jemalloc-pprof is only supported on linux (#321)
+- Cd-to-infra workflow quote fix ([#314](https://github.com/ceramicnetwork/rust-ceramic/issues/314))
+- Tokio vs std thread is okay ([#318](https://github.com/ceramicnetwork/rust-ceramic/issues/318))
+- Rust-jemalloc-pprof is only supported on linux ([#321](https://github.com/ceramicnetwork/rust-ceramic/issues/321))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Remove mut from store traits (#305)
-- Adjust types to allow dynamic usage (#306)
-- Don't hang the executor (#307)
-- Recon libp2p e2e tests (#310)
-- Add debug image builds (#311)
-- Update debug tags when not releasing (#313)
-- Fix docker build for debug mode (#315)
-- Add a release build with debug symbols and tokio console (#316)
-- Update open telemetry and tokio-console dependencies (#322)
-- Refactor to to lay groundwork for postgres support (#320)
-- Add variants for error handling (#317)
-- Version v0.15.0 (#325)
+- Remove mut from store traits ([#305](https://github.com/ceramicnetwork/rust-ceramic/issues/305))
+- Adjust types to allow dynamic usage ([#306](https://github.com/ceramicnetwork/rust-ceramic/issues/306))
+- Don't hang the executor ([#307](https://github.com/ceramicnetwork/rust-ceramic/issues/307))
+- Recon libp2p e2e tests ([#310](https://github.com/ceramicnetwork/rust-ceramic/issues/310))
+- Add debug image builds ([#311](https://github.com/ceramicnetwork/rust-ceramic/issues/311))
+- Update debug tags when not releasing ([#313](https://github.com/ceramicnetwork/rust-ceramic/issues/313))
+- Fix docker build for debug mode ([#315](https://github.com/ceramicnetwork/rust-ceramic/issues/315))
+- Add a release build with debug symbols and tokio console ([#316](https://github.com/ceramicnetwork/rust-ceramic/issues/316))
+- Update open telemetry and tokio-console dependencies ([#322](https://github.com/ceramicnetwork/rust-ceramic/issues/322))
+- Refactor to to lay groundwork for postgres support ([#320](https://github.com/ceramicnetwork/rust-ceramic/issues/320))
+- Add variants for error handling ([#317](https://github.com/ceramicnetwork/rust-ceramic/issues/317))
+- Version v0.15.0 ([#325](https://github.com/ceramicnetwork/rust-ceramic/issues/325))
 
 ## [0.14.0] - 2024-03-26
 
 ### 🚀 Features
 
-- Standard 500 error response body (ws1-1518) (#284)
-- Add POST interests route that accepts body instead of path/query parameters (#285)
-- Move GET events by interest route under experimental (#286)
+- Standard 500 error response body (ws1-1518) ([#284](https://github.com/ceramicnetwork/rust-ceramic/issues/284))
+- Add POST interests route that accepts body instead of path/query parameters ([#285](https://github.com/ceramicnetwork/rust-ceramic/issues/285))
+- Move GET events by interest route under experimental ([#286](https://github.com/ceramicnetwork/rust-ceramic/issues/286))
 
 ### 🐛 Bug Fixes
 
-- Moved api tests to a separate file (#268)
+- Moved api tests to a separate file ([#268](https://github.com/ceramicnetwork/rust-ceramic/issues/268))
 
 ### 📚 Documentation
 
-- Added explicit deps to build steps (#291)
+- Added explicit deps to build steps ([#291](https://github.com/ceramicnetwork/rust-ceramic/issues/291))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.14.0 (#297)
+- Version v0.14.0 ([#297](https://github.com/ceramicnetwork/rust-ceramic/issues/297))
 
 ## [0.13.0] - 2024-03-19
 
 ### 🚀 Features
 
-- Add rust-ceramic clay bootstrap nodes (#288)
+- Add rust-ceramic clay bootstrap nodes ([#288](https://github.com/ceramicnetwork/rust-ceramic/issues/288))
 
 ### 🐛 Bug Fixes
 
-- Pass job labels to designate notification channels (#281)
-- Remove loud warn from Recon (#287)
+- Pass job labels to designate notification channels ([#281](https://github.com/ceramicnetwork/rust-ceramic/issues/281))
+- Remove loud warn from Recon ([#287](https://github.com/ceramicnetwork/rust-ceramic/issues/287))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Delete subscribe endpoint (#277)
-- Only lint single commit or PR title (#279)
-- Remove support for old event payload during creation (#272)
-- Version v0.13.0 (#290)
+- Delete subscribe endpoint ([#277](https://github.com/ceramicnetwork/rust-ceramic/issues/277))
+- Only lint single commit or PR title ([#279](https://github.com/ceramicnetwork/rust-ceramic/issues/279))
+- Remove support for old event payload during creation ([#272](https://github.com/ceramicnetwork/rust-ceramic/issues/272))
+- Version v0.13.0 ([#290](https://github.com/ceramicnetwork/rust-ceramic/issues/290))
 
 ## [0.12.0] - 2024-02-22
 
 ### 🚀 Features
 
-- Create GET endpoint to return events for an interest range (#276)
+- Create GET endpoint to return events for an interest range ([#276](https://github.com/ceramicnetwork/rust-ceramic/issues/276))
 
 ### 🐛 Bug Fixes
 
-- Use PAT for create-release-pr workflow (#275)
-- Honor PENDING_RANGES_LIMIT for initial ranges (#271)
+- Use PAT for create-release-pr workflow ([#275](https://github.com/ceramicnetwork/rust-ceramic/issues/275))
+- Honor PENDING_RANGES_LIMIT for initial ranges ([#271](https://github.com/ceramicnetwork/rust-ceramic/issues/271))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.12.0 (#278)
+- Version v0.12.0 ([#278](https://github.com/ceramicnetwork/rust-ceramic/issues/278))
 
 ## [0.11.0] - 2024-02-12
 
 ### 🚀 Features
 
-- Enable recon by default (#270)
-- Support new id/data event payload for event creation (POST /events) (#269)
+- Enable recon by default ([#270](https://github.com/ceramicnetwork/rust-ceramic/issues/270))
+- Support new id/data event payload for event creation (POST /events) ([#269](https://github.com/ceramicnetwork/rust-ceramic/issues/269))
 
 ### 🐛 Bug Fixes
 
-- Store metrics under own registry (not recon) (#266)
+- Store metrics under own registry (not recon) ([#266](https://github.com/ceramicnetwork/rust-ceramic/issues/266))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.11.0 (#274)
+- Version v0.11.0 ([#274](https://github.com/ceramicnetwork/rust-ceramic/issues/274))
 
 ## [0.10.1] - 2024-02-08
 
 ### 🐛 Bug Fixes
 
-- Allow double insert of key/value pairs in Recon (#264)
-- Use try_from on recon keys (#263)
-- Resume token should return previous (not 0) when nothing found (#265)
+- Allow double insert of key/value pairs in Recon ([#264](https://github.com/ceramicnetwork/rust-ceramic/issues/264))
+- Use try_from on recon keys ([#263](https://github.com/ceramicnetwork/rust-ceramic/issues/263))
+- Resume token should return previous (not 0) when nothing found ([#265](https://github.com/ceramicnetwork/rust-ceramic/issues/265))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Version v0.10.1 (#267)
+- Version v0.10.1 ([#267](https://github.com/ceramicnetwork/rust-ceramic/issues/267))
 
 ## [0.10.0] - 2024-02-06
 
 ### 🚀 Features
 
-- Continously publish provider records (#175)
-- Add publisher batch metrics (#187)
-- Add config for republish_max_concurrent (#192)
-- Add peering support (#194)
-- Add tokio metrics (#206)
-- Merge migration script with ceramic-one (#190)
-- Add metrics to api and recon (#208)
-- Schedule_k8s_deploy github action (#213)
-- Recon-over-http (#168)
-- Remove all usage of gossipsub (#209)
-- Stop publishing CIDs to DHT on write (#211)
-- On tag publish deploy to envs (#220)
-- Add sqlite read/write pool split (#218)
-- Add recon store metrics (#221)
-- Add value support to Recon (#217)
-- Post-deployment tests (#242)
-- Updated release workflow (#241)
-- Modify recon storage tables, trait and sqlite config to improve throughput (#243)
-- Synchronize value for synchronized ranges (#238)
-- Workflow_dispatch build job (#249)
-- Add unified recon block store implementation (#245)
-- Interest registration endpoint (#246)
-- Added correctness test (#248)
-- Support for set type documents (#259)
-- Add API to fetch eventData from event String (#258)
-- Add feed endpoint to propagate event data to js-ceramic (#255)
+- Continously publish provider records ([#175](https://github.com/ceramicnetwork/rust-ceramic/issues/175))
+- Add publisher batch metrics ([#187](https://github.com/ceramicnetwork/rust-ceramic/issues/187))
+- Add config for republish_max_concurrent ([#192](https://github.com/ceramicnetwork/rust-ceramic/issues/192))
+- Add peering support ([#194](https://github.com/ceramicnetwork/rust-ceramic/issues/194))
+- Add tokio metrics ([#206](https://github.com/ceramicnetwork/rust-ceramic/issues/206))
+- Merge migration script with ceramic-one ([#190](https://github.com/ceramicnetwork/rust-ceramic/issues/190))
+- Add metrics to api and recon ([#208](https://github.com/ceramicnetwork/rust-ceramic/issues/208))
+- Schedule_k8s_deploy github action ([#213](https://github.com/ceramicnetwork/rust-ceramic/issues/213))
+- Recon-over-http ([#168](https://github.com/ceramicnetwork/rust-ceramic/issues/168))
+- Remove all usage of gossipsub ([#209](https://github.com/ceramicnetwork/rust-ceramic/issues/209))
+- Stop publishing CIDs to DHT on write ([#211](https://github.com/ceramicnetwork/rust-ceramic/issues/211))
+- On tag publish deploy to envs ([#220](https://github.com/ceramicnetwork/rust-ceramic/issues/220))
+- Add sqlite read/write pool split ([#218](https://github.com/ceramicnetwork/rust-ceramic/issues/218))
+- Add recon store metrics ([#221](https://github.com/ceramicnetwork/rust-ceramic/issues/221))
+- Add value support to Recon ([#217](https://github.com/ceramicnetwork/rust-ceramic/issues/217))
+- Post-deployment tests ([#242](https://github.com/ceramicnetwork/rust-ceramic/issues/242))
+- Updated release workflow ([#241](https://github.com/ceramicnetwork/rust-ceramic/issues/241))
+- Modify recon storage tables, trait and sqlite config to improve throughput ([#243](https://github.com/ceramicnetwork/rust-ceramic/issues/243))
+- Synchronize value for synchronized ranges ([#238](https://github.com/ceramicnetwork/rust-ceramic/issues/238))
+- Workflow_dispatch build job ([#249](https://github.com/ceramicnetwork/rust-ceramic/issues/249))
+- Add unified recon block store implementation ([#245](https://github.com/ceramicnetwork/rust-ceramic/issues/245))
+- Interest registration endpoint ([#246](https://github.com/ceramicnetwork/rust-ceramic/issues/246))
+- Added correctness test ([#248](https://github.com/ceramicnetwork/rust-ceramic/issues/248))
+- Support for set type documents ([#259](https://github.com/ceramicnetwork/rust-ceramic/issues/259))
+- Add API to fetch eventData from event String ([#258](https://github.com/ceramicnetwork/rust-ceramic/issues/258))
+- Add feed endpoint to propagate event data to js-ceramic ([#255](https://github.com/ceramicnetwork/rust-ceramic/issues/255))
 
 ### 🐛 Bug Fixes
 
-- Check limits first before other behaviours (#183)
-- Panic with divide by zero duration math (#184)
-- Fix JSON log format errors (#185)
-- Update comment to pass clippy (#189)
-- Run publisher in its own task (#188)
-- Trickle publisher keys to swarm (#191)
-- Use AIMD for publisher batch size (#195)
-- Do not use bootstrap list with kademlia (#199)
-- Simplify the publisher (#200)
-- Always collect metrics (#202)
-- Typo (#203)
-- Upgrade to libp2p 0.53 (#205)
-- Clippy accessing first element with first (#212)
-- Update deploy workflows for k8s (#216)
-- Rename workflows (#223)
-- Add a BUILD tag if it's not a PR merge (#256)
-- Refactor recon storage and remove sqlx dependency from recon and core crates (#254)
+- Check limits first before other behaviours ([#183](https://github.com/ceramicnetwork/rust-ceramic/issues/183))
+- Panic with divide by zero duration math ([#184](https://github.com/ceramicnetwork/rust-ceramic/issues/184))
+- Fix JSON log format errors ([#185](https://github.com/ceramicnetwork/rust-ceramic/issues/185))
+- Update comment to pass clippy ([#189](https://github.com/ceramicnetwork/rust-ceramic/issues/189))
+- Run publisher in its own task ([#188](https://github.com/ceramicnetwork/rust-ceramic/issues/188))
+- Trickle publisher keys to swarm ([#191](https://github.com/ceramicnetwork/rust-ceramic/issues/191))
+- Use AIMD for publisher batch size ([#195](https://github.com/ceramicnetwork/rust-ceramic/issues/195))
+- Do not use bootstrap list with kademlia ([#199](https://github.com/ceramicnetwork/rust-ceramic/issues/199))
+- Simplify the publisher ([#200](https://github.com/ceramicnetwork/rust-ceramic/issues/200))
+- Always collect metrics ([#202](https://github.com/ceramicnetwork/rust-ceramic/issues/202))
+- Typo ([#203](https://github.com/ceramicnetwork/rust-ceramic/issues/203))
+- Upgrade to libp2p 0.53 ([#205](https://github.com/ceramicnetwork/rust-ceramic/issues/205))
+- Clippy accessing first element with first ([#212](https://github.com/ceramicnetwork/rust-ceramic/issues/212))
+- Update deploy workflows for k8s ([#216](https://github.com/ceramicnetwork/rust-ceramic/issues/216))
+- Rename workflows ([#223](https://github.com/ceramicnetwork/rust-ceramic/issues/223))
+- Add a BUILD tag if it's not a PR merge ([#256](https://github.com/ceramicnetwork/rust-ceramic/issues/256))
+- Refactor recon storage and remove sqlx dependency from recon and core crates ([#254](https://github.com/ceramicnetwork/rust-ceramic/issues/254))
 - Update git config for release pr workflow
 
 ### 🚜 Refactor
 
-- Update bitswap logs to use structured logging (#193)
+- Update bitswap logs to use structured logging ([#193](https://github.com/ceramicnetwork/rust-ceramic/issues/193))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Use latest stable openapi-generator-cli (#222)
-- Use docker root user (#251)
-- Adding ci for cargo machete (#252)
-- Run fast post-deployment tests for all envs (#257)
-- Fix false positive in checking generated servers (#260)
-- Version v0.10.0 (#261)
+- Use latest stable openapi-generator-cli ([#222](https://github.com/ceramicnetwork/rust-ceramic/issues/222))
+- Use docker root user ([#251](https://github.com/ceramicnetwork/rust-ceramic/issues/251))
+- Adding ci for cargo machete ([#252](https://github.com/ceramicnetwork/rust-ceramic/issues/252))
+- Run fast post-deployment tests for all envs ([#257](https://github.com/ceramicnetwork/rust-ceramic/issues/257))
+- Fix false positive in checking generated servers ([#260](https://github.com/ceramicnetwork/rust-ceramic/issues/260))
+- Version v0.10.0 ([#261](https://github.com/ceramicnetwork/rust-ceramic/issues/261))
 
 ## [0.9.0] - 2023-11-13
 
 ### 🚀 Features
 
-- Add control over autonat (#176)
+- Add control over autonat ([#176](https://github.com/ceramicnetwork/rust-ceramic/issues/176))
 
 ### 🐛 Bug Fixes
 
-- Rename iroh to ceramic-one in agent (#181)
+- Rename iroh to ceramic-one in agent ([#181](https://github.com/ceramicnetwork/rust-ceramic/issues/181))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Pass manual flag through in deployment job (#180)
-- Release version v0.9.0 (#182)
+- Pass manual flag through in deployment job ([#180](https://github.com/ceramicnetwork/rust-ceramic/issues/180))
+- Release version v0.9.0 ([#182](https://github.com/ceramicnetwork/rust-ceramic/issues/182))
 
 ## [0.8.3] - 2023-11-09
 
 ### 🐛 Bug Fixes
 
-- Call correct api method for removing block from pin store (#178)
-- Be explicit about release deployments (#177)
+- Call correct api method for removing block from pin store ([#178](https://github.com/ceramicnetwork/rust-ceramic/issues/178))
+- Be explicit about release deployments ([#177](https://github.com/ceramicnetwork/rust-ceramic/issues/177))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release version v0.8.3 (#179)
+- Release version v0.8.3 ([#179](https://github.com/ceramicnetwork/rust-ceramic/issues/179))
 
 ## [0.8.2] - 2023-11-08
 
@@ -786,7 +805,7 @@ All notable changes to this project will be documented in this file.
 - Add cli opts for connection limits
 - Add ipfs metrics
 - Expose basic kademlia config
-- Cd (#172)
+- Cd ([#172](https://github.com/ceramicnetwork/rust-ceramic/issues/172))
 
 ### 🐛 Bug Fixes
 
@@ -794,7 +813,7 @@ All notable changes to this project will be documented in this file.
 - Remove Ceramic peer discovery
 - Readd main.rs after move
 - Only provide records on the DHT when they are new
-- Work around github's dumb syntax for conditionals (#173)
+- Work around github's dumb syntax for conditionals ([#173](https://github.com/ceramicnetwork/rust-ceramic/issues/173))
 
 ### 🚜 Refactor
 
@@ -803,7 +822,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release version v0.8.2 (#174)
+- Release version v0.8.2 ([#174](https://github.com/ceramicnetwork/rust-ceramic/issues/174))
 
 ## [0.8.1] - 2023-10-26
 
@@ -862,14 +881,14 @@ All notable changes to this project will be documented in this file.
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release (#130)
-- Release (#131)
+- Release ([#130](https://github.com/ceramicnetwork/rust-ceramic/issues/130))
+- Release ([#131](https://github.com/ceramicnetwork/rust-ceramic/issues/131))
 
 ## [0.4.0] - 2023-09-20
 
 ### 🚀 Features
 
-- Add liveness endpoint (#127)
+- Add liveness endpoint ([#127](https://github.com/ceramicnetwork/rust-ceramic/issues/127))
 
 ### 🐛 Bug Fixes
 
@@ -879,7 +898,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚙️ Miscellaneous Tasks
 
-- Release (#128)
+- Release ([#128](https://github.com/ceramicnetwork/rust-ceramic/issues/128))
 
 ## [0.3.0] - 2023-09-19
 
@@ -918,8 +937,8 @@ All notable changes to this project will be documented in this file.
 - Add switch to disable/enable Recon
 - Release workflow
 - Msg-size
-- Perform release (#121)
-- Release by creating a PR to create a tag, that when merged triggers a release (#123)
+- Perform release ([#121](https://github.com/ceramicnetwork/rust-ceramic/issues/121))
+- Release by creating a PR to create a tag, that when merged triggers a release ([#123](https://github.com/ceramicnetwork/rust-ceramic/issues/123))
 - Merge-from-sqlite
 
 ### 🐛 Bug Fixes
@@ -961,16 +980,16 @@ All notable changes to this project will be documented in this file.
 - Debug info for packaging
 - Remove cycle in debug output
 - Reduce build size
-- Usage of args should correctly parse and apply now (#110)
+- Usage of args should correctly parse and apply now ([#110](https://github.com/ceramicnetwork/rust-ceramic/issues/110))
 - Change bitswap dial behavior
 - Args are hard
 - Return None instead of error if block is missing
 - Release
 - Move cliff correctly
 - Cleanup tmp files so they don't show dirty in release
-- Just use star for cleanup (#119)
+- Just use star for cleanup ([#119](https://github.com/ceramicnetwork/rust-ceramic/issues/119))
 - Return v1 cid when fetching blocks
-- Slash (#122)
+- Slash ([#122](https://github.com/ceramicnetwork/rust-ceramic/issues/122))
 - Rename workflows and use different action
 - Release all not detected
 - Make versions match
@@ -987,6 +1006,13 @@ All notable changes to this project will be documented in this file.
 - Try a pat
 - Can only use tgz files
 - Should listen to copilot
+
+### 💼 Other
+
+- Got actix web tests working
+- Test % put are passing
+- All tests passing
+- Remove println
 
 ### 🚜 Refactor
 
@@ -1028,14 +1054,7 @@ All notable changes to this project will be documented in this file.
 - Add check-api-server make target
 - Update beetle dep to point as main
 - Use sccache for better Rust caches
-- Release (#125)
-- Release (#126)
-
-### Wip
-
-- Got actix web tests working
-- Test % put are passing
-- All tests passing
-- Remove println
+- Release ([#125](https://github.com/ceramicnetwork/rust-ceramic/issues/125))
+- Release ([#126](https://github.com/ceramicnetwork/rust-ceramic/issues/126))
 
 <!-- generated by git-cliff -->

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ceramic-pipeline",
  "datafusion",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2326,7 +2326,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2395,7 +2395,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2422,7 +2422,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "built",
  "project-root",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arrow-cast",
@@ -2511,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2550,7 +2550,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2590,7 +2590,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5703,7 +5703,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5761,7 +5761,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -5776,7 +5776,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9172,7 +9172,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,7 +238,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.44.0"
+version = "0.45.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.44.0
-- Build date: 2024-11-18T15:45:12.874418932-07:00[America/Denver]
+- API version: 0.45.0
+- Build date: 2024-11-25T18:44:34.261235426Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.44.0
+  version: 0.45.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.44.0";
+pub const API_VERSION: &str = "0.45.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.44.0
+  version: 0.45.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.44.0"
+version = "0.45.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.44.0
-- Build date: 2024-11-18T18:58:40.226896417Z[Etc/UTC]
+- API version: 0.45.0
+- Build date: 2024-11-25T18:44:36.536427437Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.44.0
+  version: 0.45.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.44.0";
+pub const API_VERSION: &str = "0.45.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.44.0
+  version: 0.45.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.45.0] - 2024-11-25

### 🚀 Features

- Add api to get stream state ([#586](https://github.com/ceramicnetwork/rust-ceramic/issues/586))

### 🐛 Bug Fixes

- Expose various db errors when storing events ([#601](https://github.com/ceramicnetwork/rust-ceramic/issues/601))
- Handle double write of same data ([#613](https://github.com/ceramicnetwork/rust-ceramic/issues/613))

### ⚙️ Miscellaneous Tasks

- Automatically select release level ([#612](https://github.com/ceramicnetwork/rust-ceramic/issues/612))