### PR TITLE
chore: log current highwater mark when processing events

### DIFF
--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -520,7 +520,7 @@ impl OrderingState {
                     .await?;
                 event_cnt += number_processed;
                 if event_cnt % LOG_EVERY_N_ENTRIES < number_processed {
-                    info!(count=%event_cnt, "Processed undelivered events");
+                    info!(count=%event_cnt, highwater=%new_hw, "Processed undelivered events");
                 }
             }
             if !found_something || found_everything {


### PR DESCRIPTION
This should tell us how far we've made it in addition to how many events we've had to process so far.