### PR TITLE
feat: use many tasks to order streams and discover undelivered events at startup

### DIFF
--- a/anchor-service/src/anchor_batch.rs
+++ b/anchor-service/src/anchor_batch.rs
@@ -290,13 +290,13 @@ mod tests {
         );
         let (shutdown_signal_tx, mut shutdown_signal) = broadcast::channel::<()>(1);
         // let mut shutdown_signal = shutdown_signal_rx.resubscribe();
-        Some(tokio::spawn(async move {
+        tokio::spawn(async move {
             anchor_service
                 .run(async move {
                     let _ = shutdown_signal.recv().await;
                 })
                 .await
-        }));
+        });
         while event_service.events.lock().unwrap().is_empty() {
             sleep(Duration::from_millis(1)).await;
         }

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -659,7 +659,7 @@ impl OrderingState {
         let mut tasks: tokio::task::JoinSet<Result<()>> = tokio::task::JoinSet::new();
         let (cnt_tx, mut rx) = tokio::sync::mpsc::channel(8);
         for task_id in 0..partition_size {
-            info!("starting task {task_id} of {partition_size} to process undelivered events");
+            debug!("starting task {task_id} of {partition_size} to process undelivered events");
             let tx = tx.clone();
             let cnt_tx = cnt_tx.clone();
             let event_access = event_access.clone();

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -698,7 +698,7 @@ impl OrderingState {
                 if iter_cnt > max_iterations {
                     warn!(%batch_size, iterations=%iter_cnt, %task_id, "Exceeded max iterations for finding undelivered events!");
                 }
-                info!(%task_id, "Finished processing undelivered events");
+                debug!(%task_id, "Finished processing undelivered events");
                 Ok(())
             });
         }

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -24,7 +24,7 @@ const LOG_EVERY_N_ENTRIES: usize = 10_000;
 /// The max number of tasks we'll spawn when ordering events.
 /// Each stask is given a chunk of streams and wil order them
 const MAX_STREAM_PROCESSING_TASKS: usize = 16;
-/// The minimum number of streams each task will process to ensure we don't spawn tasks when we don't have much work. 
+/// The minimum number of streams each task will process to ensure we don't spawn tasks when we don't have much work.
 /// If there are many streams, each batch will be the size of `(num_streams_to_process) / MAX_STREAM_PROCESSING_TASKS`.
 const MIN_NUM_STREAMS_PER_BATCH: usize = 25;
 /// The number of events we initially pull from the channel when doing startup undelivered batch processing.

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -24,8 +24,8 @@ const LOG_EVERY_N_ENTRIES: usize = 10_000;
 /// The max number of tasks we'll spawn when ordering events.
 /// Each stask is given a chunk of streams and wil order them
 const MAX_STREAM_PROCESSING_TASKS: usize = 16;
-/// The minimim number of streams each task will process. If there are many streams, we'll spawn
-/// STREAM_NUM / MAX_STREAM_PROCESSING_TASKS.
+/// The minimum number of streams each task will process to ensure we don't spawn tasks when we don't have much work. 
+/// If there are many streams, each batch will be the size of `(num_streams_to_process) / MAX_STREAM_PROCESSING_TASKS`.
 const MIN_NUM_STREAMS_PER_BATCH: usize = 25;
 /// The number of events we initially pull from the channel when doing startup undelivered batch processing.
 /// Being larger was measured to go faster when processing millions of events, however there's no need to

--- a/event-svc/src/store/sql/access/event.rs
+++ b/event-svc/src/store/sql/access/event.rs
@@ -446,7 +446,10 @@ impl EventAccess {
         &self,
         highwater_mark: i64,
         limit: i64,
+        num_tasks: u32,
+        task_id: u32,
     ) -> Result<(Vec<(Cid, unvalidated::Event<Ipld>)>, i64)> {
+        debug_assert!(task_id < num_tasks, "task_id must be in 0..num_tasks");
         struct UndeliveredEventBlockRow {
             block: ReconEventBlockRaw,
             row_id: i64,
@@ -466,6 +469,8 @@ impl EventAccess {
             sqlx::query_as(EventQuery::undelivered_with_values())
                 .bind(highwater_mark)
                 .bind(limit)
+                .bind(num_tasks)
+                .bind(task_id)
                 .fetch_all(self.pool.reader())
                 .await?;
 

--- a/event-svc/src/store/sql/query.rs
+++ b/event-svc/src/store/sql/query.rs
@@ -84,6 +84,8 @@ impl EventQuery {
     /// Requires binding two parameters:
     ///     $1: limit (i64)
     ///     $2: rowid (i64)
+    ///     $3: number_of_tasks/partitions (i32)
+    ///     $4: task_id (i32)
     pub fn undelivered_with_values() -> &'static str {
         r#"SELECT
                 key.order_key, key.event_cid, eb.codec, eb.root, eb.idx, b.multihash, b.bytes, key.rowid
@@ -94,6 +96,7 @@ impl EventQuery {
                 WHERE
                     EXISTS (SELECT 1 FROM ceramic_one_event_block where event_cid = e.cid)
                     AND e.delivered IS NULL and e.rowid > $1
+                    AND (e.rowid % $3) = $4
                 LIMIT
                     $2
             ) key

--- a/event-svc/src/store/sql/test.rs
+++ b/event-svc/src/store/sql/test.rs
@@ -154,7 +154,7 @@ async fn undelivered_with_values() {
     let event_access = Arc::new(EventAccess::try_new(pool).await.unwrap());
 
     let (res, hw) = event_access
-        .undelivered_with_values(0, 10000)
+        .undelivered_with_values(0, 10000, 1, 0)
         .await
         .unwrap();
     assert_eq!(res.len(), 0);

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -786,7 +786,7 @@ fn events_to_table(conclusion_events: &[ConclusionEvent]) -> String {
                     .join(", ")
             )),
             Cell::new(&event_cid.to_string()),
-            Cell::new(&data),
+            Cell::new(data),
             Cell::new(&previous),
         ]));
     }

--- a/event-svc/src/tests/mod.rs
+++ b/event-svc/src/tests/mod.rs
@@ -58,7 +58,7 @@ pub(crate) fn random_cid() -> Cid {
     Cid::new_v1(0x00, hash)
 }
 pub(crate) fn deterministic_cid(data: &[u8]) -> Cid {
-    let hash = MultihashDigest::digest(&Code::Sha2_256, &data);
+    let hash = MultihashDigest::digest(&Code::Sha2_256, data);
     Cid::new_v1(0x00, hash)
 }
 

--- a/flight/tests/server.rs
+++ b/flight/tests/server.rs
@@ -69,7 +69,7 @@ async fn execute_flight(
         batches.append(&mut endpoint_batches);
     }
 
-    Ok(concat_batches(&schema, &batches).context("concat_batches for output")?)
+    concat_batches(&schema, &batches).context("concat_batches for output")
 }
 
 mock! {


### PR DESCRIPTION
After an IPFS migration, we have to review all the data in the database to make sure we have the complete stream history before we can send events out of the API. We originally kept it simple and would read events and process them, then repeat in a single task. This was taking far too long on large datasets (e.g. 100s of GBs). Now we spawn multiple tasks to read the events from the database, and they send events over a channel to the ordering task (like we do during normal operation). This task was also modified to spawn multiple tasks to process events by stream and order them. Both changes appeared necessary during testing as one side would waiting on the other. This allows us to keep a solid rate of processing going and we've seen a substantial improvement in runtime (~60-100x faster).

On the discovery side: At startup, we spawn 16 tasks to read batches from the database. The number of events read each time was reduced to 250, as 1000 was taking seconds. The values are slightly arbitrary but this seemed like a "fast enough" choice during testing (the goal is simply to keep the channel full). The event data is partitioned using `(rowid % number_tasks) = task_number` so we don't have to do anything clever to split the data into batches up front. Each task starts from the beginning and pick up any events that have been missed. Once it finishes, the subsequent runs are fast, so we spawn the tasks regardless of whether they're needed.

On the ordering side a few changes were made. First, the channel size was reduced to 10000 (the previous value was far too large) and we try to empty it before doing any ordering since we have more tasks to process the set, and any events found may avoid database reads if they're for the same stream. Once events are grouped by stream, we split the streams into batches and spawn 1-16 tasks to process each batch. This processing has cpu bound work, but also requires database reads so multiple tasks have been beneficial. The tasks then send their ordered data back to the manager, which handles writing to the database. During testing, I made a change to remove a RO connection from the pool (and allow it to grow afterward) for each of these tasks. It didn't seem to make an obvious difference, but it may be useful to revisit.
