### PR TITLE
fix: sqlite optimize during connect could timeout and allow specifying db options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ checksum = "6b96ce28d2fde09abb6135f410c41fad670a3a770b6776869bd852f1df102e6f"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
- "heck",
+ "heck 0.5.0",
  "indexmap 2.5.0",
  "proc-macro-error2",
  "proc-macro2",
@@ -495,7 +495,7 @@ checksum = "906746396a8296537745711630d9185746c0b50c033d5e9d18b0a6eba3d53f90"
 dependencies = [
  "const-hex",
  "dunce",
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -2795,7 +2795,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4263,7 +4263,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -4991,9 +4991,9 @@ checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -5009,6 +5009,15 @@ dependencies = [
  "flate2",
  "nom",
  "num-traits",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -6897,7 +6906,7 @@ version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5daceb9dd908417b6dfcfe8e94098bc4aac54500c282e78120b885dadc09b999"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -7042,9 +7051,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "cf4e226dcd58b4be396f7bd3c20da8fdee2911400705297ba7d2d7cc2c30f716"
 dependencies = [
  "cc",
  "pkg-config",
@@ -8177,7 +8186,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "prost 0.13.3",
  "prost-types",
@@ -8824,7 +8833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes 1.7.2",
- "heck",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "log",
  "multimap",
@@ -10331,9 +10340,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smol"
@@ -10367,7 +10373,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.79",
@@ -10509,9 +10515,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+checksum = "c9a2ccff1a000a5a59cd33da541d9f2fdcd9e6e8229cc200565942bff36d0aaa"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -10522,10 +10528,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+checksum = "24ba59a9342a3d9bab6c56c118be528b27c9b60e490080e9711a04dccac83ef6"
 dependencies = [
+ "ahash 0.8.11",
  "atoi",
  "byteorder",
  "bytes 1.7.2",
@@ -10533,13 +10540,12 @@ dependencies = [
  "crc",
  "crossbeam-queue",
  "either",
- "event-listener 5.3.1",
+ "event-listener 2.5.3",
  "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
  "hashlink",
  "hex",
  "indexmap 2.5.0",
@@ -10562,26 +10568,26 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+checksum = "4ea40e2345eb2faa9e1e5e326db8c34711317d2b5e08d0d5741619048a803127"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.79",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+checksum = "5833ef53aaa16d860e92123292f1f6a3d53c34ba8b1969f152ef1a7bb803f3c8"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.4.1",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -10593,7 +10599,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.79",
+ "syn 1.0.109",
  "tempfile",
  "tokio",
  "url",
@@ -10601,12 +10607,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+checksum = "1ed31390216d20e538e447a7a9b959e06ed9fc51c37b514b46eb758016ecd418"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitflags 2.6.0",
  "byteorder",
  "bytes 1.7.2",
@@ -10644,12 +10650,12 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+checksum = "7c824eb80b894f926f89a0b9da0c7f435d27cdd35b8c655b114e58223918577e"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitflags 2.6.0",
  "byteorder",
  "chrono",
@@ -10683,9 +10689,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+checksum = "b244ef0a8414da0bed4bb1910426e890b19e5e9bccc27ada6b797d05c55ae0aa"
 dependencies = [
  "atoi",
  "chrono",
@@ -10699,10 +10705,10 @@ dependencies = [
  "log",
  "percent-encoding 2.3.1",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -11146,7 +11152,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -11159,7 +11165,7 @@ version = "0.41.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a3bf05f1d7a3fd7a97790d410f6e859b3a98dcde05e7a3fc00b31b0f60fe7cb"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "pbjson",
  "pbjson-build",
  "pbjson-types",
@@ -12006,7 +12012,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93bbb24e990654aff858d80fee8114f4322f7d7a1b1ecb45129e2fcb0d0ad5ae"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "log",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,8 @@ serde_with = "2.1"
 sha2 = { version = "0.10", default-features = false }
 sha3 = "0.10"
 smallvec = "1.10"
-sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio", "chrono"] }
+# pragma optimize hangs forver on 0.8, possibly due to libsqlite-sys upgrade
+sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio", "chrono"] }
 ssh-key = { version = "0.5.1", default-features = false }
 ssi = { version = "0.7", features = ["ed25519"] }
 swagger = { version = "6.1", features = [

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -66,13 +66,15 @@ impl OrderingTask {
                 trace!(?recon_events, "new events discovered!");
                 state.add_inserted_events(recon_events);
 
-                if state
+                if let Err(should_exit) = state
                     .process_streams(Arc::clone(&event_access))
                     .await
                     .map_err(Self::log_error)
-                    .is_err()
                 {
-                    return;
+                    if should_exit {
+                        error!("Ordering task exiting due to fatal error");
+                        return;
+                    }
                 }
             }
         }
@@ -83,20 +85,20 @@ impl OrderingTask {
             .map_err(Self::log_error);
     }
 
-    /// Log an error and return a result that can be used to stop the task if it was fatal
-    fn log_error(err: Error) -> std::result::Result<(), ()> {
+    /// Log an error and return a true if it was fatal
+    fn log_error(err: Error) -> bool {
         match err {
             Error::Application { error } => {
                 warn!("Encountered application error: {:?}", error);
-                Ok(())
+                false
             }
             Error::Fatal { error } => {
                 error!("Encountered fatal error: {:?}", error);
-                Err(())
+                true
             }
             Error::Transient { error } | Error::InvalidArgument { error } => {
                 info!("Encountered error: {:?}", error);
-                Ok(())
+                false
             }
         }
     }

--- a/event-svc/src/event/ordering_task.rs
+++ b/event-svc/src/event/ordering_task.rs
@@ -97,7 +97,7 @@ impl OrderingTask {
                 true
             }
             Error::Transient { error } | Error::InvalidArgument { error } => {
-                info!("Encountered error: {:?}", error);
+                warn!("Encountered error: {:?}", error);
                 false
             }
         }

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -182,7 +182,7 @@ pub struct DaemonOpts {
     )]
     flight_sql_bind_address: Option<String>,
 
-    /// Remote anchor service URL
+    /// Remote anchor service URL. Requires using the experimental-features flag
     #[arg(
         long,
         env = "CERAMIC_ONE_REMOTE_ANCHOR_SERVICE_URL",
@@ -193,6 +193,7 @@ pub struct DaemonOpts {
     /// Ceramic One anchor interval in seconds
     ///
     /// The interval between building a tree for all unanchored events and sending to a CAS
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value_t = 3600,
@@ -202,6 +203,7 @@ pub struct DaemonOpts {
     anchor_interval: u64,
 
     /// Ceramic One anchor batch size
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value_t = 1_000_000,
@@ -214,6 +216,7 @@ pub struct DaemonOpts {
     /// Ceramic One anchor polling interval in seconds
     ///
     /// The interval between requests to cas to determine if the chain transaction is completed.
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value_t = 300,
@@ -224,6 +227,7 @@ pub struct DaemonOpts {
     anchor_poll_interval: u64,
 
     /// Ceramic One anchor polling retry count
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value_t = 12,

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -329,13 +329,11 @@ fn spawn_database_optimizer(
         let mut duration = std::time::Duration::from_secs(60 * 60 * 24); // once daily
         loop {
             // recreate interval in case it's been shortened due to error
-            let mut interval = tokio::time::interval(duration);
-            interval.tick().await; // first tick is immediate
             tokio::select! {
                 _ = shutdown.recv() => {
                     break;
                 }
-                _ = interval.tick() => {
+                _ = tokio::time::sleep(duration) => {
                     // optimize and start the loop over
                 }
             }

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -193,7 +193,16 @@ struct DBOpts {
     /// Path to storage directory.
     #[arg(short, long, default_value=default_directory().into_os_string(), env = "CERAMIC_ONE_STORE_DIR")]
     store_dir: PathBuf,
-    #[arg(long, env = "CERAMIC_ONE_DB_CACHE_SIZE")]
+}
+
+#[derive(Args, Debug)]
+/// Experimental options related to tuning database performance
+struct DBOptsExperimental {
+    #[arg(
+        long,
+        env = "CERAMIC_ONE_DB_CACHE_SIZE",
+        requires = "experimental_features"
+    )]
     /// Value to use for the sqlite cache_size pragma
     /// Use the negative version, which represents Kib e.g. -20000 = 20 Mb
     /// Or the postive version, representing pages
@@ -203,21 +212,64 @@ struct DBOpts {
     /// 10737418240: 10 GB of memory mapped IO
     /// if this is slightly bigger than your db file it can improve read performance
     /// Set to 0 to disable. None is the default
-    #[arg(long, env = "CERAMIC_ONE_DB_MMAP_SIZE")]
+    #[arg(
+        long,
+        env = "CERAMIC_ONE_DB_MMAP_SIZE",
+        requires = "experimental_features"
+    )]
     db_mmap_size: Option<u64>,
     /// The maximum number of read only connections in the pool
-    #[arg(long, default_value = "8", env = "CERAMIC_ONE_DB_MAX_CONNECTIONS")]
+    #[arg(
+        long,
+        default_value = "8",
+        env = "CERAMIC_ONE_DB_MAX_CONNECTIONS",
+        requires = "experimental_features"
+    )]
     db_max_connections: u32,
     /// The sqlite temp_store value to use
-    #[arg(long, env = "CERAMIC_ONE_DB_TEMP_STORE")]
+    #[arg(
+        long,
+        env = "CERAMIC_ONE_DB_TEMP_STORE",
+        requires = "experimental_features"
+    )]
     db_temp_store: Option<SqliteTempStore>,
-    /// The sqlite analysis_limit to use for optimize. If <0, optimize is not run.
-    /// If it's set, optimize is run immediately and daily in the background.
+    /// The sqlite analysis_limit to use for optimize.
     /// Values between 100 and 1000 are recommended, with lower values doing less work.
     /// Or, to disable the analysis limit, causing ANALYZE to do a complete scan of each index, set the analysis limit to 0.
     /// This MAY take extemely long (minutes to hours) on very large databases.
-    #[arg(long, default_value = "1000", env = "CERAMIC_ONE_DB_ANALYSIS_LIMIT")]
-    db_analysis_limit: i32,
+    #[arg(
+        long,
+        default_value = "1000",
+        env = "CERAMIC_ONE_DB_ANALYSIS_LIMIT",
+        requires = "experimental_features"
+    )]
+    db_analysis_limit: u32,
+
+    /// Whether or not `pragma optimize` should be run.
+    /// If it's set, optimize is run immediately and daily in the background.
+    /// Will use the `analysis_limit` to control how much work is done.
+    /// It shouldn't, but it's possible this may take a long time on very large databases.
+    #[arg(
+        long,
+        default_value = "true",
+        env = "CERAMIC_ONE_DB_OPTIMIZE",
+        requires = "experimental_features"
+    )]
+    db_optimize: bool,
+}
+
+impl From<DBOptsExperimental> for SqliteOpts {
+    fn from(value: DBOptsExperimental) -> Self {
+        Self {
+            cache_size: value.db_cache_size,
+            mmap_size: value.db_mmap_size,
+            max_ro_connections: value
+                .db_max_connections,
+            temp_store: value.db_temp_store.map(|v| v.into()),
+            analysis_limit: value.db_analysis_limit,
+            optimize: value.db_optimize,
+        }
+    }
 }
 
 // Shared options for how logging is configured.
@@ -262,7 +314,7 @@ pub async fn run() -> Result<()> {
 
 impl DBOpts {
     /// This function will create the database directory if it does not exist.
-    async fn get_sqlite_pool(&self) -> Result<SqlitePool> {
+    async fn get_sqlite_pool(&self, opts: SqliteOpts) -> Result<SqlitePool> {
         match tokio::fs::create_dir_all(&self.store_dir).await {
             Ok(_) => {}
             Err(err) => match err.kind() {
@@ -279,13 +331,7 @@ impl DBOpts {
         let sql_db_path = self.store_dir.join("db.sqlite3").display().to_string();
         Ok(ceramic_sql::sqlite::SqlitePool::connect(
             &sql_db_path,
-            SqliteOpts {
-                mmap_size: self.db_mmap_size,
-                cache_size: self.db_cache_size,
-                max_ro_connections: self.db_max_connections,
-                temp_store: self.db_temp_store.map(|t| t.into()),
-                analysis_limit: self.db_analysis_limit.try_into().ok(), // negative means off (None)
-            },
+            opts,
             ceramic_sql::sqlite::Migrations::Apply,
         )
         .await?)

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -198,20 +198,20 @@ struct DBOpts {
     /// Use the negative version, which represents Kib e.g. 20000 = 20 Mb
     /// Or the postive version, representing pages
     /// None means the default is used.
-    cache_size: Option<i64>,
+    db_cache_size: Option<i64>,
     /// Used for pragma mmap_size
     /// 10737418240: 10 GB of memory mapped IO
     /// if this is slightly bigger than your db file it can improve read performance
     /// Set to 0 to disable. None is the default
     #[arg(long, env = "CERAMIC_ONE_DB_MMAP_SIZE")]
-    mmap_size: Option<u64>,
+    db_mmap_size: Option<u64>,
     /// The maximum number of read only connections in the pool
     #[arg(long, default_value = "8", env = "CERAMIC_ONE_DB_MAX_CONNECTIONS")]
-    max_connections: u32,
+    db_max_connections: u32,
     /// The sqlite temp_store value to use
     /// 0 = default, 1 = file, 2 = memory
-    #[arg(long, env = "CERAMIC_ONE_TEMP_STORE")]
-    temp_store: Option<SqliteTempStore>,
+    #[arg(long, env = "CERAMIC_ONE_DB_TEMP_STORE")]
+    db_temp_store: Option<SqliteTempStore>,
 }
 
 // Shared options for how logging is configured.
@@ -274,10 +274,10 @@ impl DBOpts {
         Ok(ceramic_sql::sqlite::SqlitePool::connect(
             &sql_db_path,
             SqliteOpts {
-                mmap_size: self.mmap_size,
-                cache_size: self.cache_size,
-                max_ro_connections: self.max_connections,
-                temp_store: self.temp_store.map(|t| t.into()),
+                mmap_size: self.db_mmap_size,
+                cache_size: self.db_cache_size,
+                max_ro_connections: self.db_max_connections,
+                temp_store: self.db_temp_store.map(|t| t.into()),
             },
             ceramic_sql::sqlite::Migrations::Apply,
         )

--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -207,11 +207,13 @@ struct DBOptsExperimental {
     /// Use the negative version, which represents Kib e.g. -20000 = 20 Mb
     /// Or the postive version, representing pages
     /// None means the default is used.
+    /// Requires using the experimental-features flag
     db_cache_size: Option<i64>,
     /// Used for pragma mmap_size
     /// 10737418240: 10 GB of memory mapped IO
     /// if this is slightly bigger than your db file it can improve read performance
     /// Set to 0 to disable. None is the default
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         env = "CERAMIC_ONE_DB_MMAP_SIZE",
@@ -219,6 +221,7 @@ struct DBOptsExperimental {
     )]
     db_mmap_size: Option<u64>,
     /// The maximum number of read only connections in the pool
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value = "8",
@@ -227,6 +230,7 @@ struct DBOptsExperimental {
     )]
     db_max_connections: u32,
     /// The sqlite temp_store value to use
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         env = "CERAMIC_ONE_DB_TEMP_STORE",
@@ -237,6 +241,7 @@ struct DBOptsExperimental {
     /// Values between 100 and 1000 are recommended, with lower values doing less work.
     /// Or, to disable the analysis limit, causing ANALYZE to do a complete scan of each index, set the analysis limit to 0.
     /// This MAY take extemely long (minutes to hours) on very large databases.
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value = "1000",
@@ -249,6 +254,7 @@ struct DBOptsExperimental {
     /// If it's set, optimize is run immediately and daily in the background.
     /// Will use the `analysis_limit` to control how much work is done.
     /// It shouldn't, but it's possible this may take a long time on very large databases.
+    /// Requires using the experimental-features flag
     #[arg(
         long,
         default_value = "true",
@@ -263,8 +269,7 @@ impl From<DBOptsExperimental> for SqliteOpts {
         Self {
             cache_size: value.db_cache_size,
             mmap_size: value.db_mmap_size,
-            max_ro_connections: value
-                .db_max_connections,
+            max_ro_connections: value.db_max_connections,
             temp_store: value.db_temp_store.map(|v| v.into()),
             analysis_limit: value.db_analysis_limit,
             optimize: value.db_optimize,

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -110,10 +110,10 @@ impl From<&FromIpfsOpts> for DBOpts {
     fn from(value: &FromIpfsOpts) -> Self {
         Self {
             store_dir: value.output_store_path.clone(),
-            mmap_size: None,
-            cache_size: None,
-            max_connections: 8,
-            temp_store: None,
+            db_mmap_size: None,
+            db_cache_size: None,
+            db_max_connections: 8,
+            db_temp_store: None,
         }
     }
 }

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -110,6 +110,9 @@ impl From<&FromIpfsOpts> for DBOpts {
     fn from(value: &FromIpfsOpts) -> Self {
         Self {
             store_dir: value.output_store_path.clone(),
+            mmap_size: None,
+            cache_size: None,
+            max_connections: 8,
         }
     }
 }

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -114,6 +114,7 @@ impl From<&FromIpfsOpts> for DBOpts {
             db_cache_size: None,
             db_max_connections: 8,
             db_temp_store: None,
+            db_analysis_limit: 100,
         }
     }
 }

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -113,6 +113,7 @@ impl From<&FromIpfsOpts> for DBOpts {
             mmap_size: None,
             cache_size: None,
             max_connections: 8,
+            temp_store: None,
         }
     }
 }

--- a/sql/src/sqlite.rs
+++ b/sql/src/sqlite.rs
@@ -39,17 +39,12 @@ impl SqlitePool {
             .foreign_keys(true);
 
         let ro_opts = conn_opts.clone().read_only(true);
-        let write_opts = conn_opts
-            // Recommended practice is that applications with long-lived database connections should run "PRAGMA optimize=0x10002"
-            // when the database connection first opens, then run "PRAGMA optimize" again at periodic intervals - perhaps once per day
-            // https://www.sqlite.org/pragma.html#pragma_optimize
-            .pragma("optimize", "0x10002");
 
         let writer = SqlitePoolOptions::new()
             .min_connections(1)
             .max_connections(1)
             .acquire_timeout(std::time::Duration::from_secs(5))
-            .connect_with(write_opts)
+            .connect_with(conn_opts)
             .await?;
         let reader = SqlitePoolOptions::new()
             .min_connections(1)

--- a/sql/src/sqlite.rs
+++ b/sql/src/sqlite.rs
@@ -43,13 +43,11 @@ impl SqlitePool {
         let writer = SqlitePoolOptions::new()
             .min_connections(1)
             .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(5))
             .connect_with(conn_opts)
             .await?;
         let reader = SqlitePoolOptions::new()
             .min_connections(1)
             .max_connections(8)
-            .acquire_timeout(std::time::Duration::from_secs(5))
             .connect_with(ro_opts)
             .await?;
 


### PR DESCRIPTION
Calling optimize when setting up the connection pool could timeout on big databases. Apparently `acquire_timeout` applies to all statements executed at startup. This also removes the `acquire_timeout` override and uses the default of 30 seconds, continues processing the ordering task loop when there's a "transient" error and, and allows specifying a few sqlite pragmas from the command line which may improve performance (`mmap_size`, `cache_size`, `temp_store`, `analysis_limit`) and a max number of read only connections for the pool (default is 8).

Analysis limit is a bit odd, as it has a default of 1000 and needs to be negative to be disabled. I don't think you can set a clap default to `Some(val)` and have the cli set it to none, but maybe I missed something. If that value is set, we run database optimize at startup and daily in the background.

Importantly, sqlx was reverted to 0.7. Something in the 0.8 upgrade (most likely the libsqlite3-sys version bump) is causing the `pragma optimize` statements to hang forever on the gitcoin database (though apparently not on our test infrastructure). I haven't gotten to the bottom of it, but this is a workaround for now. If this PR is contentious, I can pull that fix and the more trivial changes to logging out.