### PR TITLE
feat: add support for local file object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,6 +2507,7 @@ dependencies = [
  "tokio-stream",
  "tonic 0.12.3",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/flight/tests/server.rs
+++ b/flight/tests/server.rs
@@ -33,7 +33,6 @@ async fn start_server(feed: MockFeed) -> FlightSqlServiceClient<Channel> {
     let ctx = ceramic_pipeline::session_from_config(ceramic_pipeline::Config {
         conclusion_feed: feed.into(),
         object_store: Arc::new(object_store::memory::InMemory::new()),
-        object_store_bucket_name: "test_bucket".to_string(),
     })
     .await
     .unwrap();

--- a/one/Cargo.toml
+++ b/one/Cargo.toml
@@ -59,6 +59,7 @@ tokio-stream = { workspace = true, features = ["io-util"] }
 tokio.workspace = true
 tonic.workspace = true
 tracing.workspace = true
+url.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator.workspace = true

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -256,9 +256,11 @@ pub struct DaemonOpts {
     ///   * file:///absolute/path/to/object_store/directory
     ///   * file://./relative/path/from/store_dir
     ///
+    /// When an file:// URL is used it must be either an absolute path or a relative path.
+    /// When relative, the path is relative to the `store_dir` directory.
     ///
     /// When an s3:// URL is used the following environment variables are used
-    /// to configure the s3 API access:
+    /// to configure access to s3 API:
     ///
     ///   * AWS_ACCESS_KEY_ID -> access_key_id
     ///   * AWS_SECRET_ACCESS_KEY -> secret_access_key

--- a/pipeline/src/aggregator/mod.rs
+++ b/pipeline/src/aggregator/mod.rs
@@ -283,7 +283,6 @@ mod tests {
     async fn init_ctx() -> anyhow::Result<SessionContext> {
         session_from_config(Config {
             conclusion_feed: MockConclusionFeed::new().into(),
-            object_store_bucket_name: "test_bucket".to_string(),
             object_store: Arc::new(InMemory::new()),
         })
         .await
@@ -294,7 +293,6 @@ mod tests {
             conclusion_feed: ConclusionFeedSource::<MockConclusionFeed>::InMemory(
                 MemTable::try_new(schemas::conclusion_events(), vec![vec![conclusion_events]])?,
             ),
-            object_store_bucket_name: "test_bucket".to_string(),
             object_store: Arc::new(InMemory::new()),
         })
         .await

--- a/pipeline/src/config.rs
+++ b/pipeline/src/config.rs
@@ -7,9 +7,6 @@ pub struct Config<F> {
     /// Define how the conclusion feed will be accessed.
     pub conclusion_feed: ConclusionFeedSource<F>,
 
-    /// Bucket name in which to store objects.
-    pub object_store_bucket_name: String,
-
     /// Access to an object store.
     pub object_store: Arc<dyn ObjectStore>,
 }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -82,9 +82,9 @@ pub async fn session_from_config<F: ConclusionFeed + 'static>(
     // Register JSON functions
     datafusion_functions_json::register_all(&mut ctx)?;
 
-    // Register s3 object store
-    let mut url = Url::parse("s3://")?;
-    url.set_host(Some(&config.object_store_bucket_name))?;
+    // Register s3 object store, use hardcoded bucket name `pipeline` as the actual bucket name is
+    // already known by the object store.
+    let mut url = Url::parse("s3://pipeline")?;
     ctx.register_object_store(&url, config.object_store);
 
     // Configure event_states listing table


### PR DESCRIPTION
Testing and developing ceramic-one is much easier with fewer dependencies. This change makes it so that an s3 API compatible object store is not required. Rather objects can be stored on local disk.