### PR TITLE
refactor: remove offset/limit where too generic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest as builder
+FROM public.ecr.aws/r5b3e0r5/3box/rust-builder:latest AS builder
 
 RUN mkdir -p /home/builder/rust-ceramic
 WORKDIR /home/builder/rust-ceramic

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -114,8 +114,6 @@ mock! {
             &self,
             start: &Interest,
             end: &Interest,
-            offset: usize,
-            limit: usize,
         ) -> Result<Vec<Interest>>;
     }
 }
@@ -128,8 +126,8 @@ mock! {
         async fn range_with_values(
             &self,
             range: Range<EventId>,
-            offset: usize,
-            limit: usize,
+            offset: u32,
+            limit: u32,
         ) -> Result<Vec<(Cid, Vec<u8>)>>;
         async fn value_for_order_key(&self, key: &EventId) -> Result<Option<Vec<u8>>>;
         async fn value_for_cid(&self, key: &Cid) -> Result<Option<Vec<u8>>>;
@@ -580,11 +578,9 @@ async fn get_interests() {
         .with(
             predicate::eq(Interest::min_value()),
             predicate::eq(Interest::max_value()),
-            predicate::eq(0),
-            predicate::eq(usize::MAX),
         )
         .once()
-        .return_once(move |_, _, _, _| {
+        .return_once(move |_, _| {
             Ok(vec![
                 Interest::builder()
                     .with_sep_key("model")
@@ -662,11 +658,9 @@ async fn get_interests_for_peer() {
         .with(
             predicate::eq(Interest::min_value()),
             predicate::eq(Interest::max_value()),
-            predicate::eq(0),
-            predicate::eq(usize::MAX),
         )
         .once()
-        .return_once(move |_, _, _, _| {
+        .return_once(move |_, _| {
             Ok(vec![
                 Interest::builder()
                     .with_sep_key("model")

--- a/event-svc/src/store/metrics.rs
+++ b/event-svc/src/store/metrics.rs
@@ -173,8 +173,8 @@ where
     async fn range_with_values(
         &self,
         range: Range<EventId>,
-        offset: usize,
-        limit: usize,
+        offset: u32,
+        limit: u32,
     ) -> anyhow::Result<Vec<(Cid, Vec<u8>)>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
@@ -277,28 +277,14 @@ where
     async fn range(
         &self,
         range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
-        StoreMetricsMiddleware::<S>::record(
-            &self.metrics,
-            "range",
-            self.store.range(range, offset, limit),
-        )
-        .await
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "range", self.store.range(range)).await
     }
-    async fn range_with_values(
-        &self,
-        range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
-    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        StoreMetricsMiddleware::<S>::record(
-            &self.metrics,
-            "range_with_values",
-            self.store.range_with_values(range, offset, limit),
-        )
-        .await
+    async fn first(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "first", self.store.first(range)).await
+    }
+    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "middle", self.store.middle(range)).await
     }
 
     async fn full_range(
@@ -306,10 +292,6 @@ where
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "full_range", self.store.full_range())
             .await
-    }
-
-    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
-        StoreMetricsMiddleware::<S>::record(&self.metrics, "middle", self.store.middle(range)).await
     }
     async fn count(&self, range: Range<&Self::Key>) -> ReconResult<usize> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "count", self.store.count(range)).await

--- a/event-svc/src/store/sql/query.rs
+++ b/event-svc/src/store/sql/query.rs
@@ -26,9 +26,9 @@ impl EventQuery {
     /// Requires binding 1 parameter. Finds the `BlockRow` values needed to rebuild the event
     /// Looks up the event by the EventID (ie order_key).
     pub fn value_blocks_by_order_key_one() -> &'static str {
-        r#"SELECT 
+        r#"SELECT
                 eb.codec, eb.root, b.multihash, b.bytes
-        FROM ceramic_one_event_block eb 
+        FROM ceramic_one_event_block eb
             JOIN ceramic_one_block b on b.multihash = eb.block_multihash
             JOIN ceramic_one_event e on e.cid = eb.event_cid
         WHERE e.order_key = $1
@@ -129,7 +129,7 @@ impl EventQuery {
     }
 
     pub fn new_delivered_events_id_only() -> &'static str {
-        r#"SELECT 
+        r#"SELECT
                 cid, COALESCE(delivered, 0) as "new_highwater_mark"
             FROM ceramic_one_event
             WHERE delivered >= $1 -- we return delivered+1 so we must match it next search
@@ -139,8 +139,8 @@ impl EventQuery {
 
     /// Returns the max delivered value in the event table
     pub fn max_delivered() -> &'static str {
-        r#"SELECT 
-            COALESCE(MAX(delivered), 0) as res 
+        r#"SELECT
+            COALESCE(MAX(delivered), 0) as res
         FROM ceramic_one_event;"#
     }
 
@@ -214,7 +214,7 @@ impl ReconQuery {
                     TOTAL(ahash_4) & 0xFFFFFFFF as ahash_4, TOTAL(ahash_5) & 0xFFFFFFFF as ahash_5,
                     TOTAL(ahash_6) & 0xFFFFFFFF as ahash_6, TOTAL(ahash_7) & 0xFFFFFFFF as ahash_7,
                     COUNT(1) as count
-                FROM ceramic_one_event 
+                FROM ceramic_one_event
                 WHERE order_key >= $1 AND order_key < $2;"#
             }
         }
@@ -252,9 +252,10 @@ impl ReconQuery {
                 order_key >= $1 AND order_key < $2
             ORDER BY
                 order_key ASC
+            LIMIT
+                1
             OFFSET
-                $3
-            LIMIT 1;"#
+                $3;"#
     }
 
     pub fn count(db: SqlBackend) -> &'static str {

--- a/event-svc/src/store/sql/query.rs
+++ b/event-svc/src/store/sql/query.rs
@@ -228,11 +228,33 @@ impl ReconQuery {
             WHERE
                 order_key >= $1 AND order_key < $2
             ORDER BY
+                order_key ASC;"#
+    }
+    /// Requires binding 2 parameters
+    pub fn first() -> &'static str {
+        r#"SELECT
+                order_key
+            FROM
+            ceramic_one_event
+            WHERE
+                order_key >= $1 AND order_key < $2
+            ORDER BY
                 order_key ASC
-            LIMIT
-                $3
+            LIMIT 1;"#
+    }
+    /// Requires binding 3 parameters
+    pub fn middle() -> &'static str {
+        r#"SELECT
+                order_key
+            FROM
+            ceramic_one_event
+            WHERE
+                order_key >= $1 AND order_key < $2
+            ORDER BY
+                order_key ASC
             OFFSET
-                $4;"#
+                $3
+            LIMIT 1;"#
     }
 
     pub fn count(db: SqlBackend) -> &'static str {

--- a/event-svc/src/store/sql/test.rs
+++ b/event-svc/src/store/sql/test.rs
@@ -101,8 +101,6 @@ async fn range_query() {
         .range(
             &event_id_builder().with_min_event().build()
                 ..&event_id_builder().with_max_event().build(),
-            0,
-            usize::MAX,
         )
         .await
         .unwrap();

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -47,6 +47,96 @@ macro_rules! test_with_dbs {
 }
 
 test_with_dbs!(
+    range_query,
+    range_query,
+    [
+        "delete from ceramic_one_event_block",
+        "delete from ceramic_one_event",
+        "delete from ceramic_one_block",
+    ]
+);
+
+async fn range_query<S>(store: S)
+where
+    S: recon::Store<Key = EventId, Hash = Sha256a>,
+{
+    let (model, events) = get_events_return_model().await;
+    let init_cid = events[0].key.cid().unwrap();
+    let min_id = event_id_min(&init_cid, &model);
+    let max_id = event_id_max(&init_cid, &model);
+    recon::Store::insert_many(&store, &events, NodeKey::random().id())
+        .await
+        .unwrap();
+    let values: Vec<EventId> = recon::Store::range(&store, &min_id..&max_id)
+        .await
+        .unwrap()
+        .collect();
+
+    let mut expected: Vec<_> = events.into_iter().map(|item| item.key).collect();
+    expected.sort();
+    assert_eq!(expected, values);
+}
+
+test_with_dbs!(
+    first_query,
+    first_query,
+    [
+        "delete from ceramic_one_event_block",
+        "delete from ceramic_one_event",
+        "delete from ceramic_one_block",
+    ]
+);
+
+async fn first_query<S>(store: S)
+where
+    S: recon::Store<Key = EventId, Hash = Sha256a> + std::marker::Sync,
+{
+    let (model, events) = get_events_return_model().await;
+    let init_cid = events[0].key.cid().unwrap();
+    let min_id = event_id_min(&init_cid, &model);
+    let max_id = event_id_max(&init_cid, &model);
+    recon::Store::insert_many(&store, &events, NodeKey::random().id())
+        .await
+        .unwrap();
+    let first = recon::Store::first(&store, &min_id..&max_id).await.unwrap();
+
+    // Sort events into expected because event ids are not sorted in log order
+    let mut expected: Vec<_> = events.into_iter().map(|item| item.key).collect();
+    expected.sort();
+    assert_eq!(Some(expected[0].clone()), first);
+}
+test_with_dbs!(
+    middle_query,
+    middle_query,
+    [
+        "delete from ceramic_one_event_block",
+        "delete from ceramic_one_event",
+        "delete from ceramic_one_block",
+    ]
+);
+
+async fn middle_query<S>(store: S)
+where
+    S: recon::Store<Key = EventId, Hash = Sha256a>,
+{
+    let (model, events) = get_events_return_model().await;
+    let init_cid = events[0].key.cid().unwrap();
+    let min_id = event_id_min(&init_cid, &model);
+    let max_id = event_id_max(&init_cid, &model);
+    recon::Store::insert_many(&store, &events, NodeKey::random().id())
+        .await
+        .unwrap();
+    let middle = recon::Store::middle(&store, &min_id..&max_id)
+        .await
+        .unwrap();
+
+    // Sort events into expected because event ids are not sorted in log order
+    let mut expected: Vec<_> = events.into_iter().map(|item| item.key).collect();
+    expected.sort();
+    assert_eq!(Some(expected[expected.len() / 2].clone()), middle);
+}
+
+test_with_dbs!(
     double_insert,
     double_insert,
     [

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -47,46 +47,6 @@ macro_rules! test_with_dbs {
 }
 
 test_with_dbs!(
-    range_query_with_values,
-    range_query_with_values,
-    [
-        "delete from ceramic_one_event_block",
-        "delete from ceramic_one_event",
-        "delete from ceramic_one_block",
-    ]
-);
-
-async fn range_query_with_values<S>(store: S)
-where
-    S: recon::Store<Key = EventId, Hash = Sha256a>,
-{
-    let (model, events) = get_events_return_model().await;
-    let one = &events[0];
-    let two = &events[1];
-    let init_cid = one.key.cid().unwrap();
-    let min_id = event_id_min(&init_cid, &model);
-    let max_id = event_id_max(&init_cid, &model);
-    recon::Store::insert_many(&store, &[one.clone()], NodeKey::random().id())
-        .await
-        .unwrap();
-    recon::Store::insert_many(&store, &[two.clone()], NodeKey::random().id())
-        .await
-        .unwrap();
-    let values: Vec<(EventId, Vec<u8>)> =
-        recon::Store::range_with_values(&store, &min_id..&max_id, 0, usize::MAX)
-            .await
-            .unwrap()
-            .collect();
-
-    let mut expected = vec![
-        (one.key.to_owned(), one.value.to_vec()),
-        (two.key.to_owned(), two.value.to_vec()),
-    ];
-    expected.sort();
-    assert_eq!(expected, values);
-}
-
-test_with_dbs!(
     double_insert,
     double_insert,
     [

--- a/event-svc/src/tests/migration.rs
+++ b/event-svc/src/tests/migration.rs
@@ -59,14 +59,15 @@ async fn test_migration(cars: Vec<Vec<u8>>) {
         .migrate_from_ipfs(Network::Local(42), blocks, false)
         .await
         .unwrap();
-    let actual_events: BTreeSet<_> = recon::Store::range_with_values(
+    let actual_events: BTreeSet<_> = ceramic_api::EventService::range_with_values(
         &service,
-        &EventId::min_value()..&EventId::max_value(),
+        EventId::min_value()..EventId::max_value(),
         0,
-        usize::MAX,
+        u32::MAX,
     )
     .await
     .unwrap()
+    .into_iter()
     .map(|(_event_id, car)| multibase::encode(multibase::Base::Base64Url, car))
     .collect();
     assert_eq!(expected_events, actual_events)

--- a/event-svc/src/tests/mod.rs
+++ b/event-svc/src/tests/mod.rs
@@ -30,27 +30,6 @@ pub(crate) fn build_event_id(cid: &Cid, init: &Cid, model: &StreamId) -> EventId
         .build()
 }
 
-// The EventId that is the minumum of all possible random event ids for that stream
-pub(crate) fn event_id_min(init: &Cid, model: &StreamId) -> EventId {
-    EventId::builder()
-        .with_network(&Network::DevUnstable)
-        .with_sep(SEP_KEY, &model.to_vec())
-        .with_controller(CONTROLLER)
-        .with_init(init)
-        .with_min_event()
-        .build_fencepost()
-}
-// The EventId that is the maximum of all possible random event ids for that stream
-pub(crate) fn event_id_max(init: &Cid, model: &StreamId) -> EventId {
-    EventId::builder()
-        .with_network(&Network::DevUnstable)
-        .with_sep(SEP_KEY, &model.to_vec())
-        .with_controller(CONTROLLER)
-        .with_init(init)
-        .with_max_event()
-        .build_fencepost()
-}
-
 pub(crate) fn random_cid() -> Cid {
     let mut data = [0u8; 8];
     rand::Rng::fill(&mut ::rand::thread_rng(), &mut data);
@@ -231,12 +210,6 @@ async fn get_init_plus_n_events_with_model(
         events.push(ReconItem::new(data_id, data_car));
     }
     events
-}
-
-pub(crate) async fn get_events_return_model() -> (StreamId, Vec<ReconItem<EventId>>) {
-    let model = StreamId::document(random_cid());
-    let events = get_init_plus_n_events_with_model(&model, 3).await;
-    (model, events)
 }
 
 // builds init -> data -> data that are a stream (will be a different stream each call)

--- a/event-svc/src/tests/mod.rs
+++ b/event-svc/src/tests/mod.rs
@@ -30,6 +30,27 @@ pub(crate) fn build_event_id(cid: &Cid, init: &Cid, model: &StreamId) -> EventId
         .build()
 }
 
+// The EventId that is the minumum of all possible random event ids for that stream
+pub(crate) fn event_id_min(init: &Cid, model: &StreamId) -> EventId {
+    EventId::builder()
+        .with_network(&Network::DevUnstable)
+        .with_sep(SEP_KEY, &model.to_vec())
+        .with_controller(CONTROLLER)
+        .with_init(init)
+        .with_min_event()
+        .build_fencepost()
+}
+// The EventId that is the maximum of all possible random event ids for that stream
+pub(crate) fn event_id_max(init: &Cid, model: &StreamId) -> EventId {
+    EventId::builder()
+        .with_network(&Network::DevUnstable)
+        .with_sep(SEP_KEY, &model.to_vec())
+        .with_controller(CONTROLLER)
+        .with_init(init)
+        .with_max_event()
+        .build_fencepost()
+}
+
 pub(crate) fn random_cid() -> Cid {
     let mut data = [0u8; 8];
     rand::Rng::fill(&mut ::rand::thread_rng(), &mut data);
@@ -210,6 +231,12 @@ async fn get_init_plus_n_events_with_model(
         events.push(ReconItem::new(data_id, data_car));
     }
     events
+}
+
+pub(crate) async fn get_events_return_model() -> (StreamId, Vec<ReconItem<EventId>>) {
+    let model = StreamId::document(random_cid());
+    let events = get_init_plus_n_events_with_model(&model, 3).await;
+    (model, events)
 }
 
 // builds init -> data -> data that are a stream (will be a different stream each call)

--- a/interest-svc/src/interest/store.rs
+++ b/interest-svc/src/interest/store.rs
@@ -13,9 +13,6 @@ impl recon::Store for InterestService {
     type Key = Interest;
     type Hash = Sha256a;
 
-    /// Insert new keys into the key space.
-    /// Returns true for each key if it did not previously exist, in the
-    /// same order as the input iterator.
     #[instrument(skip(self))]
     async fn insert_many(
         &self,
@@ -29,9 +26,6 @@ impl recon::Store for InterestService {
             .map_err(Error::from)?)
     }
 
-    /// Return the hash of all keys in the range between left_fencepost and right_fencepost.
-    /// Both range bounds are exclusive.
-    /// Returns ReconResult<(Hash, count), Err>
     #[instrument(skip(self))]
     async fn hash_range(&self, range: Range<&Self::Key>) -> ReconResult<HashCount<Self::Hash>> {
         Ok(CeramicOneInterest::hash_range(&self.pool, range)
@@ -39,43 +33,31 @@ impl recon::Store for InterestService {
             .map_err(Error::from)?)
     }
 
-    /// Return all keys in the range between left_fencepost and right_fencepost.
-    /// Both range bounds are exclusive.
-    ///
-    /// Offset and limit values are applied within the range of keys.
     #[instrument(skip(self))]
     async fn range(
         &self,
         range: Range<&Self::Key>,
-
-        offset: usize,
-        limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         Ok(Box::new(
-            CeramicOneInterest::range(&self.pool, range, offset, limit)
+            CeramicOneInterest::range(&self.pool, range)
                 .await
                 .map_err(Error::from)?
                 .into_iter(),
         ))
     }
-
-    /// Return all keys and values in the range between left_fencepost and right_fencepost.
-    /// Both range bounds are exclusive.
-    ///
-    /// Offset and limit values are applied within the range of keys.
     #[instrument(skip(self))]
-    async fn range_with_values(
-        &self,
-        range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
-    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        let res = CeramicOneInterest::range(&self.pool, range, offset, limit)
+    async fn first(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        Ok(CeramicOneInterest::first(&self.pool, range)
             .await
-            .map_err(Error::from)?;
-        Ok(Box::new(res.into_iter().map(|key| (key, vec![]))))
+            .map_err(Error::from)?)
     }
-    /// Return the number of keys within the range.
+    #[instrument(skip(self))]
+    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        Ok(CeramicOneInterest::middle(&self.pool, range)
+            .await
+            .map_err(Error::from)?)
+    }
+
     #[instrument(skip(self))]
     async fn count(&self, range: Range<&Self::Key>) -> ReconResult<usize> {
         Ok(CeramicOneInterest::count(&self.pool, range)
@@ -83,10 +65,6 @@ impl recon::Store for InterestService {
             .map_err(Error::from)?)
     }
 
-    /// value_for_key returns
-    /// Ok(Some(value)) if stored,
-    /// Ok(None) if not stored, and
-    /// Err(e) if retrieving failed.
     #[instrument(skip(self))]
     async fn value_for_key(&self, _key: &Interest) -> ReconResult<Option<Vec<u8>>> {
         Ok(Some(vec![]))
@@ -98,13 +76,7 @@ impl ceramic_api::InterestService for InterestService {
     async fn insert(&self, key: Interest) -> anyhow::Result<bool> {
         Ok(CeramicOneInterest::insert(&self.pool, &key).await?)
     }
-    async fn range(
-        &self,
-        start: &Interest,
-        end: &Interest,
-        offset: usize,
-        limit: usize,
-    ) -> anyhow::Result<Vec<Interest>> {
-        Ok(CeramicOneInterest::range(&self.pool, start..end, offset, limit).await?)
+    async fn range(&self, start: &Interest, end: &Interest) -> anyhow::Result<Vec<Interest>> {
+        Ok(CeramicOneInterest::range(&self.pool, start..end).await?)
     }
 }

--- a/interest-svc/src/store/metrics.rs
+++ b/interest-svc/src/store/metrics.rs
@@ -137,17 +137,11 @@ where
         self.record_key_insert(new);
         Ok(new)
     }
-    async fn range(
-        &self,
-        start: &Interest,
-        end: &Interest,
-        offset: usize,
-        limit: usize,
-    ) -> anyhow::Result<Vec<Interest>> {
+    async fn range(&self, start: &Interest, end: &Interest) -> anyhow::Result<Vec<Interest>> {
         StoreMetricsMiddleware::<S>::record(
             &self.metrics,
             "api_interest_range",
-            self.store.range(start, end, offset, limit),
+            self.store.range(start, end),
         )
         .await
     }
@@ -194,28 +188,14 @@ where
     async fn range(
         &self,
         range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
-        StoreMetricsMiddleware::<S>::record(
-            &self.metrics,
-            "range",
-            self.store.range(range, offset, limit),
-        )
-        .await
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "range", self.store.range(range)).await
     }
-    async fn range_with_values(
-        &self,
-        range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
-    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
-        StoreMetricsMiddleware::<S>::record(
-            &self.metrics,
-            "range_with_values",
-            self.store.range_with_values(range, offset, limit),
-        )
-        .await
+    async fn first(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "first", self.store.first(range)).await
+    }
+    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        StoreMetricsMiddleware::<S>::record(&self.metrics, "middle", self.store.middle(range)).await
     }
 
     async fn full_range(
@@ -225,9 +205,6 @@ where
             .await
     }
 
-    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
-        StoreMetricsMiddleware::<S>::record(&self.metrics, "middle", self.store.middle(range)).await
-    }
     async fn count(&self, range: Range<&Self::Key>) -> ReconResult<usize> {
         StoreMetricsMiddleware::<S>::record(&self.metrics, "count", self.store.count(range)).await
     }

--- a/interest-svc/src/store/sql/entities/mod.rs
+++ b/interest-svc/src/store/sql/entities/mod.rs
@@ -1,5 +1,7 @@
 mod hash;
+mod order_key;
 mod version;
 
 pub use hash::ReconHash;
+pub use order_key::OrderKey;
 pub use version::VersionRow;

--- a/interest-svc/src/store/sql/entities/order_key.rs
+++ b/interest-svc/src/store/sql/entities/order_key.rs
@@ -1,0 +1,14 @@
+use ceramic_core::Interest;
+
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct OrderKey {
+    pub order_key: Vec<u8>,
+}
+
+impl TryFrom<OrderKey> for Interest {
+    type Error = ceramic_core::interest::InvalidInterest;
+
+    fn try_from(value: OrderKey) -> std::prelude::v1::Result<Self, Self::Error> {
+        Interest::try_from(value.order_key)
+    }
+}

--- a/interest-svc/src/store/sql/query.rs
+++ b/interest-svc/src/store/sql/query.rs
@@ -43,11 +43,35 @@ impl ReconQuery {
             WHERE
                 order_key >= $1 AND order_key < $2
             ORDER BY
+                order_key ASC;"#
+    }
+    /// Requires binding 2 parameters
+    pub fn first() -> &'static str {
+        r#"SELECT
+                order_key
+            FROM
+                ceramic_one_interest
+            WHERE
+                order_key >= $1 AND order_key < $2
+            ORDER BY
                 order_key ASC
             LIMIT
-                $3
+                1;"#
+    }
+    /// Requires binding 3 parameters
+    pub fn middle() -> &'static str {
+        r#"SELECT
+                order_key
+            FROM
+                ceramic_one_interest
+            WHERE
+                order_key >= $1 AND order_key < $2
+            ORDER BY
+                order_key ASC
             OFFSET
-                $4;"#
+                $3
+            LIMIT
+                1;"#
     }
 
     pub fn count(db: SqlBackend) -> &'static str {

--- a/interest-svc/src/store/sql/query.rs
+++ b/interest-svc/src/store/sql/query.rs
@@ -68,10 +68,10 @@ impl ReconQuery {
                 order_key >= $1 AND order_key < $2
             ORDER BY
                 order_key ASC
-            OFFSET
-                $3
             LIMIT
-                1;"#
+                1
+            OFFSET
+                $3;"#
     }
 
     pub fn count(db: SqlBackend) -> &'static str {

--- a/interest-svc/src/tests/interest.rs
+++ b/interest-svc/src/tests/interest.rs
@@ -85,15 +85,9 @@ async fn access_interest_model(store: impl InterestService) {
     InterestService::insert(&store, interest_1.clone())
         .await
         .unwrap();
-    let interests = InterestService::range(
-        &store,
-        &random_interest_min(),
-        &random_interest_max(),
-        0,
-        usize::MAX,
-    )
-    .await
-    .unwrap();
+    let interests = InterestService::range(&store, &random_interest_min(), &random_interest_max())
+        .await
+        .unwrap();
     assert_eq!(
         BTreeSet::from_iter([interest_0, interest_1]),
         BTreeSet::from_iter(interests)
@@ -166,57 +160,10 @@ where
     )
     .await
     .unwrap();
-    let ids = recon::Store::range(
-        &store,
-        &random_interest_min()..&random_interest_max(),
-        0,
-        usize::MAX,
-    )
-    .await
-    .unwrap();
+    let ids = recon::Store::range(&store, &random_interest_min()..&random_interest_max())
+        .await
+        .unwrap();
     let interests = ids.collect::<BTreeSet<Interest>>();
-    assert_eq!(BTreeSet::from_iter([interest_0, interest_1]), interests);
-}
-
-test_with_dbs!(
-    test_range_with_values_query,
-    test_range_with_values_query,
-    ["delete from ceramic_one_interest"]
-);
-
-async fn test_range_with_values_query<S>(store: S)
-where
-    S: recon::Store<Key = Interest, Hash = Sha256a>,
-{
-    let interest_0 = random_interest(None, None);
-    let interest_1 = random_interest(None, None);
-
-    store
-        .insert_many(
-            &[ReconItem::new(interest_0.clone(), Vec::new())],
-            NodeKey::random().id(),
-        )
-        .await
-        .unwrap();
-    store
-        .insert_many(
-            &[ReconItem::new(interest_1.clone(), Vec::new())],
-            NodeKey::random().id(),
-        )
-        .await
-        .unwrap();
-    let ids = store
-        .range_with_values(
-            &random_interest_min()..&random_interest_max(),
-            0,
-            usize::MAX,
-        )
-        .await
-        .unwrap();
-    let interests = ids
-        .into_iter()
-        .map(|(i, _v)| i)
-        .collect::<BTreeSet<Interest>>();
     assert_eq!(BTreeSet::from_iter([interest_0, interest_1]), interests);
 }
 

--- a/interest-svc/src/tests/interest.rs
+++ b/interest-svc/src/tests/interest.rs
@@ -95,12 +95,12 @@ async fn access_interest_model(store: impl InterestService) {
 }
 
 test_with_dbs!(
-    test_hash_range_query,
-    test_hash_range_query,
+    hash_range_query,
+    hash_range_query,
     ["delete from ceramic_one_interest"]
 );
 
-async fn test_hash_range_query<S>(store: S)
+async fn hash_range_query<S>(store: S)
 where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
@@ -134,46 +134,92 @@ where
 }
 
 test_with_dbs!(
-    test_range_query,
-    test_range_query,
+    range_query,
+    range_query,
     ["delete from ceramic_one_interest"]
 );
 
-async fn test_range_query<S>(store: S)
+async fn range_query<S>(store: S)
 where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
-    let interest_0 = random_interest(None, None);
-    let interest_1 = random_interest(None, None);
+    let mut interests: Vec<_> = (0..10).map(|_| random_interest(None, None)).collect();
+    let items: Vec<_> = interests
+        .iter()
+        .map(|interest| ReconItem::new(interest.clone(), Vec::new()))
+        .collect();
 
-    recon::Store::insert_many(
-        &store,
-        &[ReconItem::new(interest_0.clone(), Vec::new())],
-        NodeKey::random().id(),
-    )
-    .await
-    .unwrap();
-    recon::Store::insert_many(
-        &store,
-        &[ReconItem::new(interest_1.clone(), Vec::new())],
-        NodeKey::random().id(),
-    )
-    .await
-    .unwrap();
+    recon::Store::insert_many(&store, &items, NodeKey::random().id())
+        .await
+        .unwrap();
     let ids = recon::Store::range(&store, &random_interest_min()..&random_interest_max())
         .await
         .unwrap();
-    let interests = ids.collect::<BTreeSet<Interest>>();
-    assert_eq!(BTreeSet::from_iter([interest_0, interest_1]), interests);
+    let mut ids: Vec<Interest> = ids.collect();
+    interests.sort();
+    ids.sort();
+    assert_eq!(interests, ids);
 }
 
 test_with_dbs!(
-    test_double_insert,
-    test_double_insert,
+    first_query,
+    first_query,
     ["delete from ceramic_one_interest"]
 );
 
-async fn test_double_insert<S>(store: S)
+async fn first_query<S>(store: S)
+where
+    S: recon::Store<Key = Interest, Hash = Sha256a> + Sync,
+{
+    let mut interests: Vec<_> = (0..10).map(|_| random_interest(None, None)).collect();
+    let items: Vec<_> = interests
+        .iter()
+        .map(|interest| ReconItem::new(interest.clone(), Vec::new()))
+        .collect();
+
+    recon::Store::insert_many(&store, &items, NodeKey::random().id())
+        .await
+        .unwrap();
+    let first = recon::Store::first(&store, &random_interest_min()..&random_interest_max())
+        .await
+        .unwrap();
+    interests.sort();
+    assert_eq!(Some(interests[0].clone()), first);
+}
+
+test_with_dbs!(
+    middle_query,
+    middle_query,
+    ["delete from ceramic_one_interest"]
+);
+
+async fn middle_query<S>(store: S)
+where
+    S: recon::Store<Key = Interest, Hash = Sha256a> + Sync,
+{
+    let mut interests: Vec<_> = (0..10).map(|_| random_interest(None, None)).collect();
+    let items: Vec<_> = interests
+        .iter()
+        .map(|interest| ReconItem::new(interest.clone(), Vec::new()))
+        .collect();
+
+    recon::Store::insert_many(&store, &items, NodeKey::random().id())
+        .await
+        .unwrap();
+    let middle = recon::Store::middle(&store, &random_interest_min()..&random_interest_max())
+        .await
+        .unwrap();
+    interests.sort();
+    assert_eq!(Some(interests[interests.len() / 2].clone()), middle);
+}
+
+test_with_dbs!(
+    double_insert,
+    double_insert,
+    ["delete from ceramic_one_interest"]
+);
+
+async fn double_insert<S>(store: S)
 where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {
@@ -200,12 +246,12 @@ where
 }
 
 test_with_dbs!(
-    test_value_for_key,
-    test_value_for_key,
+    value_for_key,
+    value_for_key,
     ["delete from ceramic_one_interest"]
 );
 
-async fn test_value_for_key<S>(store: S)
+async fn value_for_key<S>(store: S)
 where
     S: recon::Store<Key = Interest, Hash = Sha256a>,
 {

--- a/p2p/src/node.rs
+++ b/p2p/src/node.rs
@@ -1269,13 +1269,7 @@ mod tests {
             unreachable!()
         }
 
-        async fn range(
-            &self,
-            _left_fencepost: Self::Key,
-            _right_fencepost: Self::Key,
-            _offset: usize,
-            _limit: usize,
-        ) -> ReconResult<Vec<Self::Key>> {
+        async fn range(&self, _range: std::ops::Range<&Self::Key>) -> ReconResult<Vec<Self::Key>> {
             unreachable!()
         }
 

--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -82,22 +82,20 @@ where
     async fn range(
         &self,
         range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
     ) -> ReconResult<Box<dyn Iterator<Item = Self::Key> + Send + 'static>> {
         self.as_error()?;
 
-        self.inner.range(range, offset, limit).await
+        self.inner.range(range).await
     }
-    async fn range_with_values(
-        &self,
-        range: Range<&Self::Key>,
-        offset: usize,
-        limit: usize,
-    ) -> ReconResult<Box<dyn Iterator<Item = (Self::Key, Vec<u8>)> + Send + 'static>> {
+    async fn first(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
         self.as_error()?;
 
-        self.inner.range_with_values(range, offset, limit).await
+        self.inner.first(range).await
+    }
+    async fn middle(&self, range: Range<&Self::Key>) -> ReconResult<Option<Self::Key>> {
+        self.as_error()?;
+
+        self.inner.middle(range).await
     }
 
     async fn value_for_key(&self, key: &Self::Key) -> ReconResult<Option<Vec<u8>>> {


### PR DESCRIPTION
This change removes the offset/limit pagination pattern where it implies a more flexible API than was needed or used. Having the flexible API meant that casts from usize to smaller types for limits and offsets could break pagination assumptions. Now with this change more specific APIs are exposed where its safe to make assumptions about the size of limit offset values in queries.

Additionally in the API where true pagination was the desired API u32 is used instead of usize to keep page sizes small.

Finally, the range_with_values method on the Recon trait was removed as it was unused