### PR TITLE
feat: adds /peers endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2125,6 +2125,7 @@ dependencies = [
  "ipld-core",
  "jemalloc_pprof",
  "mockall",
+ "multiaddr",
  "multibase 0.9.1",
  "object_store",
  "recon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,10 @@ sha3 = "0.10"
 smallvec = "1.10"
 # pragma optimize hangs forver on 0.8, possibly due to libsqlite-sys upgrade
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio", "chrono"] }
-ssh-key = { version = "0.5.1", default-features = false }
+ssh-key = { version = "0.5.1", default-features = false, features = [
+    "std",
+    "rand_core",
+] }
 ssi = { version = "0.7", features = ["ed25519"] }
 swagger = { version = "6.1", features = [
     "serdejson",

--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -14,6 +14,8 @@ docs/Interest.md
 docs/InterestsGet.md
 docs/InterestsGetInterestsInner.md
 docs/NetworkInfo.md
+docs/Peer.md
+docs/Peers.md
 docs/StreamState.md
 docs/Version.md
 docs/default_api.md

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.45.0
-- Build date: 2024-11-25T18:44:34.261235426Z[Etc/UTC]
+- Build date: 2024-12-06T08:58:05.827048302-07:00[America/Denver]
 
 
 
@@ -82,6 +82,9 @@ cargo run --example client InterestsSortKeySortValueOptions
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
 cargo run --example client LivenessOptions
+cargo run --example client PeersGet
+cargo run --example client PeersOptions
+cargo run --example client PeersPost
 cargo run --example client StreamsStreamIdGet
 cargo run --example client StreamsStreamIdOptions
 cargo run --example client VersionGet
@@ -142,6 +145,9 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /liveness | cors
+[****](docs/default_api.md#) | **GET** /peers | Get list of connected peers
+[****](docs/default_api.md#) | **OPTIONS** /peers | cors
+[****](docs/default_api.md#) | **POST** /peers | Connect to a peer
 [****](docs/default_api.md#) | **GET** /streams/{stream_id} | Get stream state
 [****](docs/default_api.md#) | **OPTIONS** /streams/{stream_id} | cors
 [****](docs/default_api.md#) | **GET** /version | Get the version of the Ceramic node
@@ -162,6 +168,8 @@ Method | HTTP request | Description
  - [InterestsGet](docs/InterestsGet.md)
  - [InterestsGetInterestsInner](docs/InterestsGetInterestsInner.md)
  - [NetworkInfo](docs/NetworkInfo.md)
+ - [Peer](docs/Peer.md)
+ - [Peers](docs/Peers.md)
  - [StreamState](docs/StreamState.md)
  - [Version](docs/Version.md)
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -566,6 +566,68 @@ paths:
         "200":
           description: cors
       summary: cors
+  /peers:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Peers'
+          description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get list of connected peers
+    options:
+      parameters:
+      - description: "Multiaddress of peer to connect to, at least one address must\
+          \ contain the peer id."
+        explode: true
+        in: query
+        name: addresses
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        "200":
+          description: cors
+      summary: cors
+    post:
+      parameters:
+      - description: "Multiaddress of peer to connect to, at least one address must\
+          \ contain the peer id."
+        explode: true
+        in: query
+        name: addresses
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        "204":
+          description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Connect to a peer
 components:
   requestBodies:
     EventData:
@@ -788,6 +850,49 @@ components:
       - event_cid
       - id
       title: State of a Ceramic stream
+      type: object
+    Peers:
+      example:
+        peers:
+        - addresses:
+          - addresses
+          - addresses
+          id: id
+        - addresses:
+          - addresses
+          - addresses
+          id: id
+      properties:
+        peers:
+          items:
+            $ref: '#/components/schemas/Peer'
+          type: array
+      required:
+      - peers
+      title: List of Peers
+      type: object
+    Peer:
+      description: Information about a connected peer
+      example:
+        addresses:
+        - addresses
+        - addresses
+        id: id
+      properties:
+        id:
+          description: DID of peer
+          type: string
+        addresses:
+          description: "List of known multiaddress of peer, will always include the\
+            \ peer id"
+          items:
+            description: Multiaddress where peer may be dialed
+            type: string
+          type: array
+      required:
+      - addresses
+      - id
+      title: Information about a connected peer
       type: object
     _feed_resumeToken_get_200_response:
       example:

--- a/api-server/docs/Peer.md
+++ b/api-server/docs/Peer.md
@@ -1,0 +1,11 @@
+# Peer
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **String** | DID of peer | 
+**addresses** | **Vec<String>** | List of known multiaddress of peer, will always include the peer id | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/Peers.md
+++ b/api-server/docs/Peers.md
@@ -1,0 +1,10 @@
+# Peers
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**peers** | [**Vec<models::Peer>**](Peer.md) |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -26,6 +26,9 @@ Method | HTTP request | Description
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /liveness | cors
+****](default_api.md#) | **GET** /peers | Get list of connected peers
+****](default_api.md#) | **OPTIONS** /peers | cors
+****](default_api.md#) | **POST** /peers | Connect to a peer
 ****](default_api.md#) | **GET** /streams/{stream_id} | Get stream state
 ****](default_api.md#) | **OPTIONS** /streams/{stream_id} | cors
 ****](default_api.md#) | **GET** /version | Get the version of the Ceramic node
@@ -598,6 +601,78 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::Peers ()
+Get list of connected peers
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**models::Peers**](Peers.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (addresses)
+cors
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **addresses** | [**String**](String.md)| Multiaddress of peer to connect to, at least one address must contain the peer id. | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (addresses)
+Connect to a peer
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **addresses** | [**String**](String.md)| Multiaddress of peer to connect to, at least one address must contain the peer id. | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -10,8 +10,9 @@ use ceramic_api_server::{
     FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
     InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -61,6 +62,9 @@ fn main() {
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
                     "LivenessOptions",
+                    "PeersGet",
+                    "PeersOptions",
+                    "PeersPost",
                     "StreamsStreamIdGet",
                     "StreamsStreamIdOptions",
                     "VersionGet",
@@ -317,6 +321,30 @@ fn main() {
         }
         Some("LivenessOptions") => {
             let result = rt.block_on(client.liveness_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersGet") => {
+            let result = rt.block_on(client.peers_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersOptions") => {
+            let result = rt.block_on(client.peers_options(&Vec::new()));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersPost") => {
+            let result = rt.block_on(client.peers_post(&Vec::new()));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -109,8 +109,9 @@ use ceramic_api_server::{
     FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
     InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -392,6 +393,40 @@ where
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
         info!(
             "liveness_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Get list of connected peers
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError> {
+        info!("peers_get() - X-Span-ID: {:?}", context.get().0.clone());
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        info!(
+            "peers_options({:?}) - X-Span-ID: {:?}",
+            addresses,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Connect to a peer
+    async fn peers_post(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError> {
+        info!(
+            "peers_post({:?}) - X-Span-ID: {:?}",
+            addresses,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -50,8 +50,9 @@ use crate::{
     FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
     InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -2387,6 +2388,286 @@ where
 
         match response.status().as_u16() {
             200 => Ok(LivenessOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::Peers>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersGetResponse::Success(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersGetResponse::InternalServerError(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_options(
+        &self,
+        param_addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.append_pair(
+                "addresses",
+                &param_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(PeersOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_post(
+        &self,
+        param_addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.append_pair(
+                "addresses",
+                &param_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            204 => Ok(PeersPostResponse::Success),
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(PeersPostResponse::BadRequest(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersPostResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -207,6 +207,32 @@ pub enum LivenessOptionsResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum PeersGetResponse {
+    /// success
+    Success(models::Peers),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum PeersOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+pub enum PeersPostResponse {
+    /// success
+    Success,
+    /// bad request
+    BadRequest(models::BadRequestResponse),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum StreamsStreamIdGetResponse {
     /// success
     Success(models::StreamState),
@@ -391,6 +417,23 @@ pub trait Api<C: Send + Sync> {
     /// cors
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError>;
 
+    /// Get list of connected peers
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError>;
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError>;
+
+    /// Connect to a peer
+    async fn peers_post(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError>;
+
     /// Get stream state
     async fn streams_stream_id_get(
         &self,
@@ -536,6 +579,18 @@ pub trait ApiNoContext<C: Send + Sync> {
 
     /// cors
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError>;
+
+    /// Get list of connected peers
+    async fn peers_get(&self) -> Result<PeersGetResponse, ApiError>;
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+    ) -> Result<PeersOptionsResponse, ApiError>;
+
+    /// Connect to a peer
+    async fn peers_post(&self, addresses: &Vec<String>) -> Result<PeersPostResponse, ApiError>;
 
     /// Get stream state
     async fn streams_stream_id_get(
@@ -777,6 +832,27 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError> {
         let context = self.context().clone();
         self.api().liveness_options(&context).await
+    }
+
+    /// Get list of connected peers
+    async fn peers_get(&self) -> Result<PeersGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_get(&context).await
+    }
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_options(addresses, &context).await
+    }
+
+    /// Connect to a peer
+    async fn peers_post(&self, addresses: &Vec<String>) -> Result<PeersPostResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_post(addresses, &context).await
     }
 
     /// Get stream state

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,6 +21,7 @@ futures.workspace = true
 ipld-core.workspace = true
 ceramic-car.workspace = true
 multibase.workspace = true
+multiaddr.workspace = true
 recon.workspace = true
 serde.workspace = true
 serde_ipld_dagcbor.workspace = true

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -519,6 +519,62 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  "/peers":
+    options:
+      summary: cors
+      parameters:
+        - name: addresses
+          in: query
+          description: Multiaddress of peer to connect to, at least one address must contain the peer id.
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+      responses:
+        "200":
+          description: cors
+    get:
+      summary: Get list of connected peers
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Peers"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Connect to a peer
+      parameters:
+        - name: addresses
+          in: query
+          description: Multiaddress of peer to connect to, at least one address must contain the peer id.
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+      responses:
+        "204":
+          description: success
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   requestBodies:
     EventData:
@@ -705,3 +761,31 @@ components:
         data:
           type: string
           description: Multibase encoding of the data of the stream. Content is stream type specific.
+    Peers:
+      title: List of Peers
+      type: object
+      required:
+        - peers
+      properties:
+        peers:
+          type: array
+          items:
+            schema:
+            $ref: "#/components/schemas/Peer"
+    Peer:
+      title: Information about a connected peer
+      description: Information about a connected peer
+      type: object
+      required:
+        - id
+        - addresses
+      properties:
+        id:
+          type: string
+          description: DID of peer
+        addresses:
+          type: array
+          description: List of known multiaddress of peer, will always include the peer id
+          items:
+            type: string
+            description: Multiaddress where peer may be dialed

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,7 +5,7 @@ pub use resume_token::ResumeToken;
 
 pub use server::{
     ApiItem, EventDataResult, EventInsertResult, EventService, IncludeEventData, InterestService,
-    Server,
+    Multiaddr, P2PService, PeerInfo, Server,
 };
 
 #[cfg(test)]

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -1304,7 +1304,7 @@ where
                 .any(|protocol| matches!(protocol, Protocol::P2p(_)))
         }) {
             return Ok(PeersPostResponse::BadRequest(BadRequestResponse::new(
-                format!("at least one address must contain a peer id"),
+                "at least one address must contain a peer id".to_string(),
             )));
         };
         self.peer_connect(addrs)

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -2,9 +2,10 @@
 
 use std::{ops::Range, str::FromStr, sync::Arc};
 
-use crate::server::{decode_multibase_data, BuildResponse, Server};
+use crate::server::{decode_multibase_data, BuildResponse, P2PService, Server};
 use crate::{
     ApiItem, EventDataResult, EventInsertResult, EventService, IncludeEventData, InterestService,
+    PeerInfo,
 };
 
 use anyhow::Result;
@@ -28,6 +29,7 @@ use datafusion::execution::config::SessionConfig;
 use datafusion::execution::context::SessionContext;
 use expect_test::expect;
 use mockall::{mock, predicate};
+use multiaddr::Multiaddr;
 use multibase::Base;
 use recon::Key;
 use test_log::test;
@@ -144,6 +146,15 @@ mock! {
     }
 }
 
+mock! {
+    pub P2PService {}
+    #[async_trait]
+    impl crate::P2PService for P2PService {
+        async fn peers(&self) -> Result<Vec<crate::PeerInfo>>;
+        async fn peer_connect(&self, addrs: &[Multiaddr]) -> Result<()>;
+    }
+}
+
 /// Given a mock of the EventStore, prepare it to expect calls to load the init event.
 pub fn mock_get_init_event(mock_store: &mut MockEventStoreTest) {
     // Expect two get_block calls
@@ -178,19 +189,21 @@ pub fn mock_get_unsigned_init_event(mock_store: &mut MockEventStoreTest) {
 }
 
 /// Wrapper around server initialization that handles creating the shutdown handler
-fn create_test_server<C, I, M>(
+fn create_test_server<C, I, M, P>(
     node_id: NodeId,
     network: Network,
     interest: I,
     model: Arc<M>,
+    p2p: P,
     pipeline: Option<SessionContext>,
-) -> Server<C, I, M>
+) -> Server<C, I, M, P>
 where
     I: InterestService,
     M: EventService + 'static,
+    P: P2PService,
 {
     let (_, rx) = tokio::sync::broadcast::channel(1);
-    Server::new(node_id, network, interest, model, pipeline, rx)
+    Server::new(node_id, network, interest, model, p2p, pipeline, rx)
 }
 
 #[test(tokio::test)]
@@ -227,6 +240,7 @@ async fn create_event() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -276,6 +290,7 @@ async fn create_event_twice() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let (resp1, resp2) = join!(
@@ -334,6 +349,7 @@ async fn create_event_fails() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -390,6 +406,7 @@ async fn register_interest_sort_value() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let interest = models::Interest {
@@ -418,6 +435,7 @@ async fn register_interest_sort_value_bad_request() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let interest = models::Interest {
@@ -473,6 +491,7 @@ async fn register_interest_sort_value_controller() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -531,6 +550,7 @@ async fn register_interest_value_controller_stream() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -603,6 +623,7 @@ async fn get_interests() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -695,6 +716,7 @@ async fn get_interests_for_peer() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -762,6 +784,7 @@ async fn get_events_for_interest_range() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let resp = server
@@ -817,6 +840,7 @@ async fn events_event_id_get_by_event_id_success() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let result = server.events_event_id_get(event_id_str, &Context).await;
@@ -850,6 +874,7 @@ async fn events_event_id_get_by_cid_success() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         None,
     );
     let result = server
@@ -863,6 +888,109 @@ async fn events_event_id_get_by_cid_success() {
         multibase::encode(multibase::Base::Base32Lower, event_cid.to_bytes())
     );
     assert_eq!(event.data.unwrap(), event_data_base64);
+}
+
+#[test(tokio::test)]
+async fn peers() {
+    let node_id = NodeKey::random().id();
+    let network = Network::InMemory;
+    let mut mock_p2p_svc = MockP2PService::new();
+    mock_p2p_svc.expect_peers().once().returning(|| {
+        Ok(vec![
+            PeerInfo {
+                id: NodeId::try_from_did_key(
+                    "did:key:z6MktxbrtQY3yx8Wue2hNS1eA3mEXXVb5n8FDL6a7bHkdZqJ",
+                )
+                .unwrap(),
+                addresses: vec!["/ip4/127.0.0.1/tcp/4111", "/ip4/127.0.0.1/udp/4111/quic-v1"]
+                    .into_iter()
+                    .map(Multiaddr::from_str)
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap(),
+            },
+            PeerInfo {
+                id: NodeId::try_from_did_key(
+                    "did:key:z6Mkr5oAhjqJc2sedxmaiUQUdQGkdtNkDNpmc9M1gxopvkfP",
+                )
+                .unwrap(),
+                addresses: vec!["/ip4/127.0.0.1/tcp/4112"]
+                    .into_iter()
+                    .map(Multiaddr::from_str)
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap(),
+            },
+        ])
+    });
+    let server = create_test_server(
+        node_id,
+        network,
+        MockAccessInterestStoreTest::new(),
+        Arc::new(MockEventStoreTest::new()),
+        mock_p2p_svc,
+        None,
+    );
+    let peers = server.peers_get(&Context).await.unwrap();
+    expect![[r#"
+        Success(
+            Peers {
+                peers: [
+                    Peer {
+                        id: "did:key:z6MktxbrtQY3yx8Wue2hNS1eA3mEXXVb5n8FDL6a7bHkdZqJ",
+                        addresses: [
+                            "/ip4/127.0.0.1/tcp/4111/p2p/12D3KooWQKhz3HsKqJuYD2hRKTo95kJ5CHGNhaxNUuYffJUdcHmr",
+                            "/ip4/127.0.0.1/udp/4111/quic-v1/p2p/12D3KooWQKhz3HsKqJuYD2hRKTo95kJ5CHGNhaxNUuYffJUdcHmr",
+                        ],
+                    },
+                    Peer {
+                        id: "did:key:z6Mkr5oAhjqJc2sedxmaiUQUdQGkdtNkDNpmc9M1gxopvkfP",
+                        addresses: [
+                            "/ip4/127.0.0.1/tcp/4112/p2p/12D3KooWMSuHrdAaTPefwMSJfWByZ6obJe9XqBetsio7EfzhuUbw",
+                        ],
+                    },
+                ],
+            },
+        )
+    "#]].assert_debug_eq(&peers)
+}
+
+#[test(tokio::test)]
+async fn peer_connect() {
+    let node_id = NodeKey::random().id();
+    let network = Network::InMemory;
+    let mut mock_p2p_svc = MockP2PService::new();
+    let addresses = vec![
+        "/ip4/127.0.0.1/tcp/4101/p2p/12D3KooWPFGbRHWfDaWt5MFFeqAHBBq3v5BqeJ4X7pmn2V1t6uNs",
+        "/ip4/127.0.0.1/udp/4111/quic-v1",
+    ];
+    let addrs = addresses
+        .iter()
+        .map(|addr| addr.parse())
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    mock_p2p_svc
+        .expect_peer_connect()
+        .once()
+        .with(predicate::eq(addrs))
+        .returning(|_| Ok(()));
+    let server = create_test_server(
+        node_id,
+        network,
+        MockAccessInterestStoreTest::new(),
+        Arc::new(MockEventStoreTest::new()),
+        mock_p2p_svc,
+        None,
+    );
+    let result = server
+        .peers_post(
+            &addresses.into_iter().map(ToOwned::to_owned).collect(),
+            &Context,
+        )
+        .await
+        .unwrap();
+    expect![[r#"
+        Success
+    "#]]
+    .assert_debug_eq(&result);
 }
 
 #[test(tokio::test)]
@@ -890,6 +1018,7 @@ async fn stream_state() {
         network,
         mock_interest,
         Arc::new(mock_event_store),
+        MockP2PService::new(),
         Some(pipeline),
     );
     let result = server

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,7 +21,7 @@ pub use interest::{Interest, PeerId};
 pub use jwk::Jwk;
 pub use network::Network;
 pub use node_id::{NodeId, NodeKey};
-pub use peer::{PeerEntry, PeerKey};
+pub use peer::{ensure_multiaddr_has_p2p, PeerEntry, PeerKey};
 pub use range::RangeOpen;
 pub use serialize_ext::SerializeExt;
 pub use stream_id::{StreamId, StreamIdType, METAMODEL_STREAM_ID};

--- a/core/src/peer.rs
+++ b/core/src/peer.rs
@@ -78,7 +78,8 @@ impl PeerEntry {
     }
 }
 
-fn ensure_multiaddr_has_p2p(addr: Multiaddr, peer_id: PeerId) -> Multiaddr {
+/// Returns a the provided multiaddr ensuring it contains the specified peer id.
+pub fn ensure_multiaddr_has_p2p(addr: Multiaddr, peer_id: PeerId) -> Multiaddr {
     if !addr.iter().any(|protocol| match protocol {
         multiaddr::Protocol::P2p(id) => id == peer_id,
         _ => false,

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -700,6 +700,7 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
         network,
         interest_api_svc,
         Arc::new(model_svc),
+        ipfs.client(),
         pipeline_ctx,
         shutdown_signal.resubscribe(),
     );

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -2,12 +2,14 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
-use ceramic_core::{EventId, Interest, NodeKey, PeerKey};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ceramic_core::{EventId, Interest, NodeId, NodeKey, PeerKey};
 use ceramic_kubo_rpc::{IpfsMetrics, IpfsMetricsMiddleware, IpfsService};
 use ceramic_p2p::{Config as P2pConfig, Libp2pConfig, Node, PeerService};
 use iroh_rpc_client::P2pClient;
 use iroh_rpc_types::{p2p::P2pAddr, Addr};
+use multiaddr::Protocol;
 use recon::{libp2p::Recon, Sha256a};
 use tokio::task::{self, JoinHandle};
 use tracing::{debug, error};
@@ -85,13 +87,12 @@ impl Builder<WithP2p> {
     where
         S: iroh_bitswap::Store,
     {
-        let ipfs_service = Arc::new(IpfsService::new(
-            P2pClient::new(self.state.p2p.addr.clone()).await?,
-            block_store,
-        ));
+        let client = P2pClient::new(self.state.p2p.addr.clone()).await?;
+        let ipfs_service = Arc::new(IpfsService::new(client.clone(), block_store));
         let ipfs_service = IpfsMetricsMiddleware::new(ipfs_service, ipfs_metrics);
         Ok(Ipfs {
             api: ipfs_service,
+            client,
             p2p: self.state.p2p,
         })
     }
@@ -100,6 +101,7 @@ impl Builder<WithP2p> {
 // Provides Ipfs node implementation
 pub struct Ipfs<S> {
     api: IpfsMetricsMiddleware<Arc<IpfsService<S>>>,
+    client: P2pClient,
     p2p: Service<P2pAddr>,
 }
 
@@ -110,9 +112,51 @@ impl<S> Ipfs<S> {
     pub fn api(&self) -> IpfsMetricsMiddleware<Arc<IpfsService<S>>> {
         self.api.clone()
     }
+    pub fn client(&self) -> IpfsClient {
+        IpfsClient(self.client.clone())
+    }
     pub async fn stop(self) -> Result<()> {
         self.p2p.stop().await?;
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct IpfsClient(P2pClient);
+
+#[async_trait]
+impl ceramic_api::P2PService for IpfsClient {
+    async fn peers(&self) -> Result<Vec<ceramic_api::PeerInfo>> {
+        self.0
+            .get_peers()
+            .await?
+            .into_iter()
+            .map(|(peer_id, addresses)| {
+                Ok(ceramic_api::PeerInfo {
+                    id: NodeId::try_from_peer_id(&peer_id)?,
+                    addresses,
+                })
+            })
+            .collect()
+    }
+    async fn peer_connect(&self, addrs: &[ceramic_api::Multiaddr]) -> Result<()> {
+        // Find peer id in one of the addresses
+        let peer_id = addrs
+            .iter()
+            .filter_map(|addr| {
+                addr.iter()
+                    .filter_map(|protocol| {
+                        if let Protocol::P2p(peer_id) = protocol {
+                            Some(peer_id)
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+            })
+            .next()
+            .ok_or_else(|| anyhow!("multi addr must contain a peer id"))?;
+        self.0.connect(peer_id, addrs.to_vec()).await
     }
 }
 


### PR DESCRIPTION
With this change a new API endpoint is added for accessing connected peers. The API is similar to the /api/v0/swarm/peers endpoint however it allows for multiple addresses and does not have to remain Kubo RPC compatible.

The endpoint allows posting an address and therefore connecting to a new peer.

Fixes: #608