### PR TITLE
feat: adds /peers endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,6 +2137,7 @@ dependencies = [
  "ipld-core",
  "jemalloc_pprof",
  "mockall",
+ "multiaddr",
  "multibase 0.9.1",
  "object_store",
  "recon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,10 @@ sha3 = "0.10"
 smallvec = "1.10"
 # pragma optimize hangs forver on 0.8, possibly due to libsqlite-sys upgrade
 sqlx = { version = "0.7", features = ["sqlite", "runtime-tokio", "chrono"] }
-ssh-key = { version = "0.5.1", default-features = false }
+ssh-key = { version = "0.5.1", default-features = false, features = [
+    "std",
+    "rand_core",
+] }
 ssi = { version = "0.7", features = ["ed25519"] }
 swagger = { version = "6.1", features = [
     "serdejson",

--- a/api-server/.openapi-generator/FILES
+++ b/api-server/.openapi-generator/FILES
@@ -14,6 +14,8 @@ docs/Interest.md
 docs/InterestsGet.md
 docs/InterestsGetInterestsInner.md
 docs/NetworkInfo.md
+docs/Peer.md
+docs/Peers.md
 docs/StreamState.md
 docs/Version.md
 docs/default_api.md

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.45.0
-- Build date: 2024-11-25T18:44:34.261235426Z[Etc/UTC]
+- Build date: 2024-12-06T08:58:05.827048302-07:00[America/Denver]
 
 
 
@@ -82,6 +82,9 @@ cargo run --example client InterestsSortKeySortValueOptions
 cargo run --example client InterestsSortKeySortValuePost
 cargo run --example client LivenessGet
 cargo run --example client LivenessOptions
+cargo run --example client PeersGet
+cargo run --example client PeersOptions
+cargo run --example client PeersPost
 cargo run --example client StreamsStreamIdGet
 cargo run --example client StreamsStreamIdOptions
 cargo run --example client VersionGet
@@ -142,6 +145,9 @@ Method | HTTP request | Description
 [****](docs/default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 [****](docs/default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 [****](docs/default_api.md#) | **OPTIONS** /liveness | cors
+[****](docs/default_api.md#) | **GET** /peers | Get list of connected peers
+[****](docs/default_api.md#) | **OPTIONS** /peers | cors
+[****](docs/default_api.md#) | **POST** /peers | Connect to a peer
 [****](docs/default_api.md#) | **GET** /streams/{stream_id} | Get stream state
 [****](docs/default_api.md#) | **OPTIONS** /streams/{stream_id} | cors
 [****](docs/default_api.md#) | **GET** /version | Get the version of the Ceramic node
@@ -162,6 +168,8 @@ Method | HTTP request | Description
  - [InterestsGet](docs/InterestsGet.md)
  - [InterestsGetInterestsInner](docs/InterestsGetInterestsInner.md)
  - [NetworkInfo](docs/NetworkInfo.md)
+ - [Peer](docs/Peer.md)
+ - [Peers](docs/Peers.md)
  - [StreamState](docs/StreamState.md)
  - [Version](docs/Version.md)
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -566,6 +566,68 @@ paths:
         "200":
           description: cors
       summary: cors
+  /peers:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Peers'
+          description: success
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Get list of connected peers
+    options:
+      parameters:
+      - description: "Multiaddress of peer to connect to, at least one address must\
+          \ contain the peer id."
+        explode: true
+        in: query
+        name: addresses
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        "200":
+          description: cors
+      summary: cors
+    post:
+      parameters:
+      - description: "Multiaddress of peer to connect to, at least one address must\
+          \ contain the peer id."
+        explode: true
+        in: query
+        name: addresses
+        required: true
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      responses:
+        "204":
+          description: success
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequestResponse'
+          description: bad request
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: Internal server error
+      summary: Connect to a peer
 components:
   requestBodies:
     EventData:
@@ -788,6 +850,49 @@ components:
       - event_cid
       - id
       title: State of a Ceramic stream
+      type: object
+    Peers:
+      example:
+        peers:
+        - addresses:
+          - addresses
+          - addresses
+          id: id
+        - addresses:
+          - addresses
+          - addresses
+          id: id
+      properties:
+        peers:
+          items:
+            $ref: '#/components/schemas/Peer'
+          type: array
+      required:
+      - peers
+      title: List of Peers
+      type: object
+    Peer:
+      description: Information about a connected peer
+      example:
+        addresses:
+        - addresses
+        - addresses
+        id: id
+      properties:
+        id:
+          description: DID of peer
+          type: string
+        addresses:
+          description: "List of known multiaddress of peer, will always include the\
+            \ peer id"
+          items:
+            description: Multiaddress where peer may be dialed
+            type: string
+          type: array
+      required:
+      - addresses
+      - id
+      title: Information about a connected peer
       type: object
     _feed_resumeToken_get_200_response:
       example:

--- a/api-server/docs/Peer.md
+++ b/api-server/docs/Peer.md
@@ -1,0 +1,11 @@
+# Peer
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**id** | **String** | DID of peer | 
+**addresses** | **Vec<String>** | List of known multiaddress of peer, will always include the peer id | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/Peers.md
+++ b/api-server/docs/Peers.md
@@ -1,0 +1,10 @@
+# Peers
+
+## Properties
+Name | Type | Description | Notes
+------------ | ------------- | ------------- | -------------
+**peers** | [**Vec<models::Peer>**](Peer.md) |  | 
+
+[[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
+
+

--- a/api-server/docs/default_api.md
+++ b/api-server/docs/default_api.md
@@ -26,6 +26,9 @@ Method | HTTP request | Description
 ****](default_api.md#) | **POST** /interests/{sort_key}/{sort_value} | Register interest for a sort key
 ****](default_api.md#) | **GET** /liveness | Test the liveness of the Ceramic node
 ****](default_api.md#) | **OPTIONS** /liveness | cors
+****](default_api.md#) | **GET** /peers | Get list of connected peers
+****](default_api.md#) | **OPTIONS** /peers | cors
+****](default_api.md#) | **POST** /peers | Connect to a peer
 ****](default_api.md#) | **GET** /streams/{stream_id} | Get stream state
 ****](default_api.md#) | **OPTIONS** /streams/{stream_id} | cors
 ****](default_api.md#) | **GET** /version | Get the version of the Ceramic node
@@ -598,6 +601,78 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> models::Peers ()
+Get list of connected peers
+
+### Required Parameters
+This endpoint does not need any parameter.
+
+### Return type
+
+[**models::Peers**](Peers.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (addresses)
+cors
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **addresses** | [**String**](String.md)| Multiaddress of peer to connect to, at least one address must contain the peer id. | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# ****
+> (addresses)
+Connect to a peer
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **addresses** | [**String**](String.md)| Multiaddress of peer to connect to, at least one address must contain the peer id. | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/api-server/examples/client/main.rs
+++ b/api-server/examples/client/main.rs
@@ -10,8 +10,9 @@ use ceramic_api_server::{
     FeedEventsOptionsResponse, FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse,
     InterestsOptionsResponse, InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use clap::{App, Arg};
 #[allow(unused_imports)]
@@ -61,6 +62,9 @@ fn main() {
                     "InterestsSortKeySortValuePost",
                     "LivenessGet",
                     "LivenessOptions",
+                    "PeersGet",
+                    "PeersOptions",
+                    "PeersPost",
                     "StreamsStreamIdGet",
                     "StreamsStreamIdOptions",
                     "VersionGet",
@@ -317,6 +321,30 @@ fn main() {
         }
         Some("LivenessOptions") => {
             let result = rt.block_on(client.liveness_options());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersGet") => {
+            let result = rt.block_on(client.peers_get());
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersOptions") => {
+            let result = rt.block_on(client.peers_options(&Vec::new()));
+            info!(
+                "{:?} (X-Span-ID: {:?})",
+                result,
+                (client.context() as &dyn Has<XSpanIdString>).get().clone()
+            );
+        }
+        Some("PeersPost") => {
+            let result = rt.block_on(client.peers_post(&Vec::new()));
             info!(
                 "{:?} (X-Span-ID: {:?})",
                 result,

--- a/api-server/examples/server/server.rs
+++ b/api-server/examples/server/server.rs
@@ -109,8 +109,9 @@ use ceramic_api_server::{
     FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
     InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 use std::error::Error;
 use swagger::ApiError;
@@ -392,6 +393,40 @@ where
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError> {
         info!(
             "liveness_options() - X-Span-ID: {:?}",
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Get list of connected peers
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError> {
+        info!("peers_get() - X-Span-ID: {:?}", context.get().0.clone());
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        info!(
+            "peers_options({:?}) - X-Span-ID: {:?}",
+            addresses,
+            context.get().0.clone()
+        );
+        Err(ApiError("Generic failure".into()))
+    }
+
+    /// Connect to a peer
+    async fn peers_post(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError> {
+        info!(
+            "peers_post({:?}) - X-Span-ID: {:?}",
+            addresses,
             context.get().0.clone()
         );
         Err(ApiError("Generic failure".into()))

--- a/api-server/src/client/mod.rs
+++ b/api-server/src/client/mod.rs
@@ -50,8 +50,9 @@ use crate::{
     FeedResumeTokenGetResponse, FeedResumeTokenOptionsResponse, InterestsOptionsResponse,
     InterestsPostResponse, InterestsSortKeySortValueOptionsResponse,
     InterestsSortKeySortValuePostResponse, LivenessGetResponse, LivenessOptionsResponse,
-    StreamsStreamIdGetResponse, StreamsStreamIdOptionsResponse, VersionGetResponse,
-    VersionOptionsResponse, VersionPostResponse,
+    PeersGetResponse, PeersOptionsResponse, PeersPostResponse, StreamsStreamIdGetResponse,
+    StreamsStreamIdOptionsResponse, VersionGetResponse, VersionOptionsResponse,
+    VersionPostResponse,
 };
 
 /// Convert input into a base path, e.g. "http://example:123". Also checks the scheme as it goes.
@@ -2387,6 +2388,286 @@ where
 
         match response.status().as_u16() {
             200 => Ok(LivenessOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("GET")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::Peers>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersGetResponse::Success(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersGetResponse::InternalServerError(body))
+            }
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_options(
+        &self,
+        param_addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.append_pair(
+                "addresses",
+                &param_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("OPTIONS")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            200 => Ok(PeersOptionsResponse::Cors),
+            code => {
+                let headers = response.headers().clone();
+                let body = response.into_body().take(100).into_raw().await;
+                Err(ApiError(format!(
+                    "Unexpected response code {}:\n{:?}\n\n{}",
+                    code,
+                    headers,
+                    match body {
+                        Ok(body) => match String::from_utf8(body) {
+                            Ok(body) => body,
+                            Err(e) => format!("<Body was not UTF8: {:?}>", e),
+                        },
+                        Err(e) => format!("<Failed to read body: {}>", e),
+                    }
+                )))
+            }
+        }
+    }
+
+    async fn peers_post(
+        &self,
+        param_addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError> {
+        let mut client_service = self.client_service.clone();
+        let mut uri = format!("{}/ceramic/peers", self.base_path);
+
+        // Query parameters
+        let query_string = {
+            let mut query_string = form_urlencoded::Serializer::new("".to_owned());
+            query_string.append_pair(
+                "addresses",
+                &param_addresses
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+                    .join(","),
+            );
+            query_string.finish()
+        };
+        if !query_string.is_empty() {
+            uri += "?";
+            uri += &query_string;
+        }
+
+        let uri = match Uri::from_str(&uri) {
+            Ok(uri) => uri,
+            Err(err) => return Err(ApiError(format!("Unable to build URI: {}", err))),
+        };
+
+        let mut request = match Request::builder()
+            .method("POST")
+            .uri(uri)
+            .body(Body::empty())
+        {
+            Ok(req) => req,
+            Err(e) => return Err(ApiError(format!("Unable to create request: {}", e))),
+        };
+
+        let header = HeaderValue::from_str(Has::<XSpanIdString>::get(context).0.as_str());
+        request.headers_mut().insert(
+            HeaderName::from_static("x-span-id"),
+            match header {
+                Ok(h) => h,
+                Err(e) => {
+                    return Err(ApiError(format!(
+                        "Unable to create X-Span ID header value: {}",
+                        e
+                    )))
+                }
+            },
+        );
+
+        let response = client_service
+            .call((request, context.clone()))
+            .map_err(|e| ApiError(format!("No response received: {}", e)))
+            .await?;
+
+        match response.status().as_u16() {
+            204 => Ok(PeersPostResponse::Success),
+            400 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body =
+                    serde_json::from_str::<models::BadRequestResponse>(body).map_err(|e| {
+                        ApiError(format!("Response body did not match the schema: {}", e))
+                    })?;
+                Ok(PeersPostResponse::BadRequest(body))
+            }
+            500 => {
+                let body = response.into_body();
+                let body = body
+                    .into_raw()
+                    .map_err(|e| ApiError(format!("Failed to read response: {}", e)))
+                    .await?;
+                let body = str::from_utf8(&body)
+                    .map_err(|e| ApiError(format!("Response was not valid UTF8: {}", e)))?;
+                let body = serde_json::from_str::<models::ErrorResponse>(body).map_err(|e| {
+                    ApiError(format!("Response body did not match the schema: {}", e))
+                })?;
+                Ok(PeersPostResponse::InternalServerError(body))
+            }
             code => {
                 let headers = response.headers().clone();
                 let body = response.into_body().take(100).into_raw().await;

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -207,6 +207,32 @@ pub enum LivenessOptionsResponse {
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
+pub enum PeersGetResponse {
+    /// success
+    Success(models::Peers),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub enum PeersOptionsResponse {
+    /// cors
+    Cors,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+pub enum PeersPostResponse {
+    /// success
+    Success,
+    /// bad request
+    BadRequest(models::BadRequestResponse),
+    /// Internal server error
+    InternalServerError(models::ErrorResponse),
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
 pub enum StreamsStreamIdGetResponse {
     /// success
     Success(models::StreamState),
@@ -391,6 +417,23 @@ pub trait Api<C: Send + Sync> {
     /// cors
     async fn liveness_options(&self, context: &C) -> Result<LivenessOptionsResponse, ApiError>;
 
+    /// Get list of connected peers
+    async fn peers_get(&self, context: &C) -> Result<PeersGetResponse, ApiError>;
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError>;
+
+    /// Connect to a peer
+    async fn peers_post(
+        &self,
+        addresses: &Vec<String>,
+        context: &C,
+    ) -> Result<PeersPostResponse, ApiError>;
+
     /// Get stream state
     async fn streams_stream_id_get(
         &self,
@@ -536,6 +579,18 @@ pub trait ApiNoContext<C: Send + Sync> {
 
     /// cors
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError>;
+
+    /// Get list of connected peers
+    async fn peers_get(&self) -> Result<PeersGetResponse, ApiError>;
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+    ) -> Result<PeersOptionsResponse, ApiError>;
+
+    /// Connect to a peer
+    async fn peers_post(&self, addresses: &Vec<String>) -> Result<PeersPostResponse, ApiError>;
 
     /// Get stream state
     async fn streams_stream_id_get(
@@ -777,6 +832,27 @@ impl<T: Api<C> + Send + Sync, C: Clone + Send + Sync> ApiNoContext<C> for Contex
     async fn liveness_options(&self) -> Result<LivenessOptionsResponse, ApiError> {
         let context = self.context().clone();
         self.api().liveness_options(&context).await
+    }
+
+    /// Get list of connected peers
+    async fn peers_get(&self) -> Result<PeersGetResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_get(&context).await
+    }
+
+    /// cors
+    async fn peers_options(
+        &self,
+        addresses: &Vec<String>,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_options(addresses, &context).await
+    }
+
+    /// Connect to a peer
+    async fn peers_post(&self, addresses: &Vec<String>) -> Result<PeersPostResponse, ApiError> {
+        let context = self.context().clone();
+        self.api().peers_post(addresses, &context).await
     }
 
     /// Get stream state

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,6 +21,7 @@ futures.workspace = true
 ipld-core.workspace = true
 ceramic-car.workspace = true
 multibase.workspace = true
+multiaddr.workspace = true
 recon.workspace = true
 serde.workspace = true
 serde_ipld_dagcbor.workspace = true

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -519,6 +519,62 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  "/peers":
+    options:
+      summary: cors
+      parameters:
+        - name: addresses
+          in: query
+          description: Multiaddress of peer to connect to, at least one address must contain the peer id.
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+      responses:
+        "200":
+          description: cors
+    get:
+      summary: Get list of connected peers
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Peers"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    post:
+      summary: Connect to a peer
+      parameters:
+        - name: addresses
+          in: query
+          description: Multiaddress of peer to connect to, at least one address must contain the peer id.
+          schema:
+            type: array
+            items:
+              type: string
+          required: true
+      responses:
+        "204":
+          description: success
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BadRequestResponse"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 components:
   requestBodies:
     EventData:
@@ -705,3 +761,31 @@ components:
         data:
           type: string
           description: Multibase encoding of the data of the stream. Content is stream type specific.
+    Peers:
+      title: List of Peers
+      type: object
+      required:
+        - peers
+      properties:
+        peers:
+          type: array
+          items:
+            schema:
+            $ref: "#/components/schemas/Peer"
+    Peer:
+      title: Information about a connected peer
+      description: Information about a connected peer
+      type: object
+      required:
+        - id
+        - addresses
+      properties:
+        id:
+          type: string
+          description: DID of peer
+        addresses:
+          type: array
+          description: List of known multiaddress of peer, will always include the peer id
+          items:
+            type: string
+            description: Multiaddress where peer may be dialed

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -5,7 +5,7 @@ pub use resume_token::ResumeToken;
 
 pub use server::{
     ApiItem, EventDataResult, EventInsertResult, EventService, IncludeEventData, InterestService,
-    Server,
+    Multiaddr, P2PService, PeerInfo, Server,
 };
 
 #[cfg(test)]

--- a/api/src/server.rs
+++ b/api/src/server.rs
@@ -6,7 +6,7 @@
 
 mod event;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 use std::{future::Future, ops::Range};
 use std::{marker::PhantomData, ops::RangeBounds};
@@ -22,7 +22,7 @@ use std::{
 
 use anyhow::Result;
 use async_trait::async_trait;
-use ceramic_api_server::models::{BadRequestResponse, ErrorResponse, EventData};
+use ceramic_api_server::models::{BadRequestResponse, ErrorResponse, EventData, Peer, Peers};
 use ceramic_api_server::{
     models::{self, Event},
     DebugHeapGetResponse, EventsEventIdGetResponse, EventsPostResponse,
@@ -32,9 +32,11 @@ use ceramic_api_server::{
 use ceramic_api_server::{
     Api, ConfigNetworkGetResponse, ExperimentalEventsSepSepValueGetResponse,
     ExperimentalInterestsGetResponse, FeedEventsGetResponse, FeedResumeTokenGetResponse,
-    InterestsPostResponse,
+    InterestsPostResponse, PeersGetResponse, PeersOptionsResponse, PeersPostResponse,
 };
-use ceramic_core::{Cid, EventId, Interest, Network, NodeId, PeerId, StreamId};
+use ceramic_core::{
+    ensure_multiaddr_has_p2p, Cid, EventId, Interest, Network, NodeId, PeerId, StreamId,
+};
 use ceramic_pipeline::EVENT_STATES_TABLE;
 use datafusion::arrow::array::{
     as_dictionary_array, as_map_array, Array as _, ArrayAccessor as _, BinaryArray,
@@ -48,15 +50,18 @@ use datafusion::functions_aggregate::expr_fn::last_value;
 use datafusion::logical_expr::expr::WindowFunction;
 use datafusion::logical_expr::{col, lit, BuiltInWindowFunction, Expr, ExprFunctionExt};
 use futures::TryFutureExt;
+use multiaddr::Protocol;
 use recon::Key;
 use swagger::{ApiError, ByteArray};
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemalloc_ctl::epoch;
 use tokio::sync::broadcast;
-use tracing::{instrument, Level};
+use tracing::{instrument, trace, Level};
 
 use crate::server::event::event_id_from_car;
 use crate::ResumeToken;
+
+pub use multiaddr::Multiaddr;
 
 /// How many events to try to process at once i.e. read from the channel in batches.
 const EVENTS_TO_RECEIVE: usize = 10;
@@ -145,7 +150,7 @@ impl TryFrom<models::Interest> for ValidatedInterest {
     }
 }
 
-/// Trait for accessing persistent storage of Interests
+/// InterestService must provide access to interests
 #[async_trait]
 pub trait InterestService: Send + Sync {
     /// Returns true if the key was newly inserted, false if it already existed.
@@ -162,6 +167,28 @@ impl<S: InterestService> InterestService for Arc<S> {
     async fn range(&self, start: &Interest, end: &Interest) -> Result<Vec<Interest>> {
         self.as_ref().range(start, end).await
     }
+}
+
+#[async_trait]
+pub trait P2PService: Send + Sync {
+    async fn peers(&self) -> Result<Vec<PeerInfo>>;
+    async fn peer_connect(&self, addrs: &[Multiaddr]) -> Result<()>;
+}
+
+#[async_trait]
+impl<S: P2PService> P2PService for Arc<S> {
+    async fn peers(&self) -> Result<Vec<PeerInfo>> {
+        self.as_ref().peers().await
+    }
+    async fn peer_connect(&self, addrs: &[Multiaddr]) -> Result<()> {
+        self.as_ref().peer_connect(addrs).await
+    }
+}
+
+/// Information about connected peers
+pub struct PeerInfo {
+    pub id: NodeId,
+    pub addresses: Vec<Multiaddr>,
 }
 
 #[derive(Debug, Clone)]
@@ -346,11 +373,12 @@ struct InsertTask {
 }
 
 #[derive(Clone)]
-pub struct Server<C, I, M> {
+pub struct Server<C, I, M, P> {
     node_id: NodeId,
     network: Network,
     interest: I,
     model: Arc<M>,
+    p2p: P,
     // If we need to restart this ever, we'll need a mutex. For now we want to avoid locking the channel
     // so we just keep track to gracefully shutdown, but if the task dies, the server is in a fatal error state.
     insert_task: Arc<InsertTask>,
@@ -360,16 +388,18 @@ pub struct Server<C, I, M> {
     pipeline: Option<SessionContext>,
 }
 
-impl<C, I, M> Server<C, I, M>
+impl<C, I, M, P> Server<C, I, M, P>
 where
     I: InterestService,
     M: EventService + 'static,
+    P: P2PService,
 {
     pub fn new(
         node_id: NodeId,
         network: Network,
         interest: I,
         model: Arc<M>,
+        p2p: P,
         pipeline: Option<SessionContext>,
         shutdown_signal: broadcast::Receiver<()>,
     ) -> Self {
@@ -386,6 +416,7 @@ where
             network,
             interest,
             model,
+            p2p,
             insert_task,
             marker: PhantomData,
             authentication: false,
@@ -457,7 +488,7 @@ where
     }
 
     async fn process_events(events: &mut Vec<EventInsert>, event_store: &Arc<M>, node_id: NodeId) {
-        tracing::debug!(count = events.len(), "process_events");
+        trace!(count = events.len(), "process_events");
         if events.is_empty() {
             return;
         }
@@ -969,6 +1000,38 @@ where
             },
         ))
     }
+    async fn get_peers(&self) -> Result<PeersGetResponse, ErrorResponse> {
+        let peers =
+            self.p2p.peers().await.map_err(|err| {
+                ErrorResponse::new(format!("failed to get peer information: {err}"))
+            })?;
+        Ok(PeersGetResponse::Success(Peers {
+            peers: peers
+                .into_iter()
+                .map(|peer| {
+                    let peer_id = peer.id.peer_id();
+                    Peer {
+                        id: peer.id.did_key(),
+                        addresses: peer
+                            .addresses
+                            .into_iter()
+                            .map(|addr| ensure_multiaddr_has_p2p(addr, peer_id).to_string())
+                            .collect(),
+                    }
+                })
+                .collect(),
+        }))
+    }
+    async fn peer_connect(
+        &self,
+        addrs: Vec<Multiaddr>,
+    ) -> Result<PeersPostResponse, ErrorResponse> {
+        self.p2p
+            .peer_connect(&addrs)
+            .await
+            .map_err(|err| ErrorResponse::new(format!("failed to get peer information: {err}")))?;
+        Ok(PeersPostResponse::Success)
+    }
 }
 
 pub(crate) fn decode_event_id(value: &str) -> Result<EventId, BadRequestResponse> {
@@ -998,11 +1061,12 @@ pub(crate) fn decode_multibase_data(value: &str) -> Result<Vec<u8>, BadRequestRe
 }
 
 #[async_trait]
-impl<C, I, M> Api<C> for Server<C, I, M>
+impl<C, I, M, P> Api<C> for Server<C, I, M, P>
 where
     C: Send + Sync,
     I: InterestService + Sync,
     M: EventService + Sync + 'static,
+    P: P2PService,
 {
     #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn liveness_get(
@@ -1080,6 +1144,7 @@ where
             .or_else(|err| Ok(FeedResumeTokenGetResponse::InternalServerError(err)))
     }
 
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn experimental_interests_get(
         &self,
         peer_id: Option<String>,
@@ -1178,6 +1243,7 @@ where
         }))
     }
 
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn streams_stream_id_get(
         &self,
         stream_id: String,
@@ -1206,6 +1272,57 @@ where
                 },
             ))
         }
+    }
+
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
+    async fn peers_get(&self, _context: &C) -> Result<PeersGetResponse, ApiError> {
+        self.get_peers()
+            .await
+            .or_else(|err| Ok(PeersGetResponse::InternalServerError(err)))
+    }
+
+    #[instrument(skip(self, _context), ret(level = Level::DEBUG), err(level = Level::ERROR))]
+    async fn peers_post(
+        &self,
+        addresses: &Vec<String>,
+        _context: &C,
+    ) -> Result<PeersPostResponse, ApiError> {
+        let mut addrs: Vec<Multiaddr> = Vec::new();
+        for address in addresses {
+            match address.parse() {
+                Ok(a) => addrs.push(a),
+                Err(err) => {
+                    return Ok(PeersPostResponse::BadRequest(BadRequestResponse::new(
+                        format!("address is not a well formed multiaddr: {err}"),
+                    )))
+                }
+            }
+        }
+        let peer_ids: HashSet<_> = addrs
+            .iter()
+            .flat_map(|addr| {
+                addr.iter().filter_map(|protocol| {
+                    if let Protocol::P2p(peer_id) = protocol {
+                        Some(peer_id)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+        if peer_ids.is_empty() {
+            return Ok(PeersPostResponse::BadRequest(BadRequestResponse::new(
+                "at least one address must contain a peer id".to_string(),
+            )));
+        };
+        if peer_ids.len() > 1 {
+            return Ok(PeersPostResponse::BadRequest(BadRequestResponse::new(
+                "more than one unique peer id found in the addresses".to_string(),
+            )));
+        };
+        self.peer_connect(addrs)
+            .await
+            .or_else(|err| Ok(PeersPostResponse::InternalServerError(err)))
     }
 
     /// cors
@@ -1293,8 +1410,14 @@ where
     ) -> Result<ceramic_api_server::InterestsSortKeySortValueOptionsResponse, ApiError> {
         Ok(ceramic_api_server::InterestsSortKeySortValueOptionsResponse::Cors)
     }
-
-    /// Test the liveness of the Ceramic node
+    /// cors
+    async fn peers_options(
+        &self,
+        _addresses: &Vec<String>,
+        _context: &C,
+    ) -> Result<PeersOptionsResponse, ApiError> {
+        Ok(PeersOptionsResponse::Cors)
+    }
 
     /// cors
     async fn liveness_options(
@@ -1312,6 +1435,7 @@ where
         Ok(ceramic_api_server::VersionOptionsResponse::Cors)
     }
 
+    /// cors
     async fn streams_stream_id_options(
         &self,
         _stream_id: String,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -21,7 +21,7 @@ pub use interest::{Interest, PeerId};
 pub use jwk::Jwk;
 pub use network::Network;
 pub use node_id::{NodeId, NodeKey};
-pub use peer::{PeerEntry, PeerKey};
+pub use peer::{ensure_multiaddr_has_p2p, PeerEntry, PeerKey};
 pub use range::RangeOpen;
 pub use serialize_ext::SerializeExt;
 pub use stream_id::{StreamId, StreamIdType, METAMODEL_STREAM_ID};

--- a/core/src/peer.rs
+++ b/core/src/peer.rs
@@ -78,7 +78,8 @@ impl PeerEntry {
     }
 }
 
-fn ensure_multiaddr_has_p2p(addr: Multiaddr, peer_id: PeerId) -> Multiaddr {
+/// Returns a the provided multiaddr ensuring it contains the specified peer id.
+pub fn ensure_multiaddr_has_p2p(addr: Multiaddr, peer_id: PeerId) -> Multiaddr {
     if !addr.iter().any(|protocol| match protocol {
         multiaddr::Protocol::P2p(id) => id == peer_id,
         _ => false,

--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -700,6 +700,7 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
         network,
         interest_api_svc,
         Arc::new(model_svc),
+        ipfs.client(),
         pipeline_ctx,
         shutdown_signal.resubscribe(),
     );

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -2,12 +2,14 @@
 
 use std::sync::Arc;
 
-use anyhow::Result;
-use ceramic_core::{EventId, Interest, NodeKey, PeerKey};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use ceramic_core::{EventId, Interest, NodeId, NodeKey, PeerKey};
 use ceramic_kubo_rpc::{IpfsMetrics, IpfsMetricsMiddleware, IpfsService};
 use ceramic_p2p::{Config as P2pConfig, Libp2pConfig, Node, PeerService};
 use iroh_rpc_client::P2pClient;
 use iroh_rpc_types::{p2p::P2pAddr, Addr};
+use multiaddr::Protocol;
 use recon::{libp2p::Recon, Sha256a};
 use tokio::task::{self, JoinHandle};
 use tracing::{debug, error};
@@ -85,13 +87,12 @@ impl Builder<WithP2p> {
     where
         S: iroh_bitswap::Store,
     {
-        let ipfs_service = Arc::new(IpfsService::new(
-            P2pClient::new(self.state.p2p.addr.clone()).await?,
-            block_store,
-        ));
+        let client = P2pClient::new(self.state.p2p.addr.clone()).await?;
+        let ipfs_service = Arc::new(IpfsService::new(client.clone(), block_store));
         let ipfs_service = IpfsMetricsMiddleware::new(ipfs_service, ipfs_metrics);
         Ok(Ipfs {
             api: ipfs_service,
+            client,
             p2p: self.state.p2p,
         })
     }
@@ -100,6 +101,7 @@ impl Builder<WithP2p> {
 // Provides Ipfs node implementation
 pub struct Ipfs<S> {
     api: IpfsMetricsMiddleware<Arc<IpfsService<S>>>,
+    client: P2pClient,
     p2p: Service<P2pAddr>,
 }
 
@@ -110,9 +112,51 @@ impl<S> Ipfs<S> {
     pub fn api(&self) -> IpfsMetricsMiddleware<Arc<IpfsService<S>>> {
         self.api.clone()
     }
+    pub fn client(&self) -> IpfsClient {
+        IpfsClient(self.client.clone())
+    }
     pub async fn stop(self) -> Result<()> {
         self.p2p.stop().await?;
         Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct IpfsClient(P2pClient);
+
+#[async_trait]
+impl ceramic_api::P2PService for IpfsClient {
+    async fn peers(&self) -> Result<Vec<ceramic_api::PeerInfo>> {
+        self.0
+            .get_peers()
+            .await?
+            .into_iter()
+            .map(|(peer_id, addresses)| {
+                Ok(ceramic_api::PeerInfo {
+                    id: NodeId::try_from_peer_id(&peer_id)?,
+                    addresses,
+                })
+            })
+            .collect()
+    }
+    async fn peer_connect(&self, addrs: &[ceramic_api::Multiaddr]) -> Result<()> {
+        // Find peer id in one of the addresses
+        let peer_id = addrs
+            .iter()
+            .filter_map(|addr| {
+                addr.iter()
+                    .filter_map(|protocol| {
+                        if let Protocol::P2p(peer_id) = protocol {
+                            Some(peer_id)
+                        } else {
+                            None
+                        }
+                    })
+                    .next()
+            })
+            .next()
+            .ok_or_else(|| anyhow!("multi addr must contain a peer id"))?;
+        self.0.connect(peer_id, addrs.to_vec()).await
     }
 }
 


### PR DESCRIPTION
With this change a new API endpoint is added for accessing connected peers. The API is similar to the /api/v0/swarm/peers endpoint however it allows for multiple addresses and does not have to remain Kubo RPC compatible.

The endpoint allows posting an address and therefore connecting to a new peer.

Fixes: #608