### PR TITLE
fix: shutdown ordering tasks with sigint

### DIFF
--- a/event-svc/src/event/mod.rs
+++ b/event-svc/src/event/mod.rs
@@ -6,5 +6,5 @@ mod service;
 mod store;
 mod validator;
 
-pub use service::{BlockStore, DeliverableRequirement, EventService};
+pub use service::{BlockStore, DeliverableRequirement, EventService, UndeliveredEventReview};
 pub use validator::ChainInclusionProvider;

--- a/event-svc/src/lib.rs
+++ b/event-svc/src/lib.rs
@@ -10,6 +10,6 @@ mod tests;
 pub use ceramic_validation::eth_rpc;
 pub use error::Error;
 pub use event::ChainInclusionProvider;
-pub use event::{BlockStore, EventService};
+pub use event::{BlockStore, EventService, UndeliveredEventReview};
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;

--- a/event-svc/src/tests/event.rs
+++ b/event-svc/src/tests/event.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::EventService;
+use crate::{EventService, UndeliveredEventReview};
 use anyhow::Error;
 use bytes::Bytes;
 use ceramic_api::{ApiItem, EventService as ApiEventService};
@@ -25,7 +25,7 @@ macro_rules! test_with_sqlite {
             async fn [<$test_name _sqlite>]() {
 
                 let conn = $crate::store::SqlitePool::connect_in_memory().await.unwrap();
-                let store = $crate::EventService::try_new(conn, true, true, vec![]).await.unwrap();
+                let store = $crate::EventService::try_new(conn, UndeliveredEventReview::Skip, true, vec![]).await.unwrap();
                 $(
                     for stmt in $sql_stmts {
                         store.pool.run_statement(stmt).await.unwrap();
@@ -664,7 +664,7 @@ where
 #[test(tokio::test)]
 async fn test_conclusion_events_since() -> Result<(), Box<dyn std::error::Error>> {
     let pool = SqlitePool::connect_in_memory().await?;
-    let service = EventService::try_new(pool, false, false, vec![]).await?;
+    let service = EventService::try_new(pool, UndeliveredEventReview::Skip, false, vec![]).await?;
     let test_events = generate_chained_events().await;
 
     ceramic_api::EventService::insert_many(

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -148,7 +148,15 @@ async fn from_ipfs(opts: FromIpfsOpts) -> Result<()> {
     let db_opts: DBOpts = (&opts).into();
     let sqlite_pool = db_opts.get_sqlite_pool(SqliteOpts::default()).await?;
     // TODO: feature flags here? or just remove this entirely when enabling
-    let event_svc = Arc::new(EventService::try_new(sqlite_pool, false, false, vec![]).await?);
+    let event_svc = Arc::new(
+        EventService::try_new(
+            sqlite_pool,
+            ceramic_event_svc::UndeliveredEventReview::Skip,
+            false,
+            vec![],
+        )
+        .await?,
+    );
     let blocks = FSBlockStore {
         input_ipfs_path: opts.input_ipfs_path,
         sharded_paths: !opts.non_sharded_paths,

--- a/p2p/tests/node.rs
+++ b/p2p/tests/node.rs
@@ -35,8 +35,15 @@ impl TestRunnerBuilder {
         let sql_pool = SqlitePool::connect_in_memory().await.unwrap();
         let peer_svc = Arc::new(ceramic_peer_svc::PeerService::new(sql_pool.clone()));
         let interest_svc = Arc::new(ceramic_interest_svc::InterestService::new(sql_pool.clone()));
-        let event_svc =
-            Arc::new(ceramic_event_svc::EventService::try_new(sql_pool, true, true, vec![]).await?);
+        let event_svc = Arc::new(
+            ceramic_event_svc::EventService::try_new(
+                sql_pool,
+                ceramic_event_svc::UndeliveredEventReview::Skip,
+                true,
+                vec![],
+            )
+            .await?,
+        );
 
         let mut registry = prometheus_client::registry::Registry::default();
         let metrics = Metrics::register(&mut registry);

--- a/peer-svc/src/tests/peer.rs
+++ b/peer-svc/src/tests/peer.rs
@@ -41,7 +41,7 @@ pub(crate) fn peer_key_builder() -> Builder<Init> {
 
 // Generate an event for the same network,model,controller,stream
 // The event and height are random when when its None.
-pub(crate) fn random_peer_key<'a>(expiration: Option<u64>) -> PeerKey {
+pub(crate) fn random_peer_key(expiration: Option<u64>) -> PeerKey {
     peer_key_builder()
         .with_expiration(expiration.unwrap_or_else(|| thread_rng().gen()))
         .with_id(&NodeKey::random())


### PR DESCRIPTION
The ordering tasks wouldn't shutdown gracefully and could take forever. Worst case you killed the process and left a lock on the sqlite file and had to go find another pid to kill it. Now they exit with sigint.