### PR TITLE
chore: version v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.46.0] - 2024-12-09
+
+### 🚀 Features
+
+- Add peer entry and peer key structs ([#615](https://github.com/ceramicnetwork/rust-ceramic/issues/615))
+- Add support for local file object store ([#623](https://github.com/ceramicnetwork/rust-ceramic/issues/623))
+- Add support for prepared statements ([#600](https://github.com/ceramicnetwork/rust-ceramic/issues/600))
+- Add peer recon ring ([#616](https://github.com/ceramicnetwork/rust-ceramic/issues/616))
+- Use many tasks to order streams and discover undelivered events at startup ([#620](https://github.com/ceramicnetwork/rust-ceramic/issues/620))
+- Adds transitive sharing of peer information ([#618](https://github.com/ceramicnetwork/rust-ceramic/issues/618))
+- Adds /peers endpoint ([#628](https://github.com/ceramicnetwork/rust-ceramic/issues/628))
+
+### 🐛 Bug Fixes
+
+- Sqlite optimize during connect could timeout and allow specifying db options ([#622](https://github.com/ceramicnetwork/rust-ceramic/issues/622))
+
+### 🚜 Refactor
+
+- Remove offset/limit where too generic ([#624](https://github.com/ceramicnetwork/rust-ceramic/issues/624))
+- Remove unused version code ([#627](https://github.com/ceramicnetwork/rust-ceramic/issues/627))
+
+### ⚙️ Miscellaneous Tasks
+
+- Log current highwater mark when processing events ([#619](https://github.com/ceramicnetwork/rust-ceramic/issues/619))
+- Run sqlite optimize at startup and interval ([#621](https://github.com/ceramicnetwork/rust-ceramic/issues/621))
+- Use arrow release 53.3 ([#625](https://github.com/ceramicnetwork/rust-ceramic/issues/625))
+
 ## [0.45.0] - 2024-11-25
 
 ### 🚀 Features
@@ -16,6 +43,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Automatically select release level ([#612](https://github.com/ceramicnetwork/rust-ceramic/issues/612))
+- Version v0.45.0 ([#617](https://github.com/ceramicnetwork/rust-ceramic/issues/617))
 
 ## [0.44.0] - 2024-11-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-arrow-test"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "ceramic-pipeline",
  "datafusion",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2267,7 +2267,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2371,7 +2371,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "built",
  "project-root",
@@ -2444,7 +2444,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arrow-cast",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2568,7 +2568,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5769,7 +5769,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -5842,7 +5842,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -244,7 +244,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.45.0"
+version = "0.46.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.45.0
-- Build date: 2024-12-06T08:58:05.827048302-07:00[America/Denver]
+- API version: 0.46.0
+- Build date: 2024-12-09T20:17:08.556875752Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.45.0
+  version: 0.46.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.45.0";
+pub const API_VERSION: &str = "0.46.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.45.0
+  version: 0.46.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.45.0"
+version = "0.46.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.45.0
-- Build date: 2024-11-25T18:44:36.536427437Z[Etc/UTC]
+- API version: 0.46.0
+- Build date: 2024-12-09T20:17:10.763483392Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.45.0
+  version: 0.46.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.45.0";
+pub const API_VERSION: &str = "0.46.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.45.0
+  version: 0.46.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.46.0] - 2024-12-09

### 🚀 Features

- Add peer entry and peer key structs ([#615](https://github.com/ceramicnetwork/rust-ceramic/issues/615))
- Add support for local file object store ([#623](https://github.com/ceramicnetwork/rust-ceramic/issues/623))
- Add support for prepared statements ([#600](https://github.com/ceramicnetwork/rust-ceramic/issues/600))
- Add peer recon ring ([#616](https://github.com/ceramicnetwork/rust-ceramic/issues/616))
- Use many tasks to order streams and discover undelivered events at startup ([#620](https://github.com/ceramicnetwork/rust-ceramic/issues/620))
- Adds transitive sharing of peer information ([#618](https://github.com/ceramicnetwork/rust-ceramic/issues/618))
- Adds /peers endpoint ([#628](https://github.com/ceramicnetwork/rust-ceramic/issues/628))

### 🐛 Bug Fixes

- Sqlite optimize during connect could timeout and allow specifying db options ([#622](https://github.com/ceramicnetwork/rust-ceramic/issues/622))

### 🚜 Refactor

- Remove offset/limit where too generic ([#624](https://github.com/ceramicnetwork/rust-ceramic/issues/624))
- Remove unused version code ([#627](https://github.com/ceramicnetwork/rust-ceramic/issues/627))

### ⚙️ Miscellaneous Tasks

- Log current highwater mark when processing events ([#619](https://github.com/ceramicnetwork/rust-ceramic/issues/619))
- Run sqlite optimize at startup and interval ([#621](https://github.com/ceramicnetwork/rust-ceramic/issues/621))
- Use arrow release 53.3 ([#625](https://github.com/ceramicnetwork/rust-ceramic/issues/625))