### PR TITLE
feat: stop synchronizing interests

### DIFF
--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -19,7 +19,7 @@ use ceramic_sql::sqlite::SqlitePool;
 use clap::Args;
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
-use recon::{FullInterests, Recon, ReconInterestProvider};
+use recon::{Recon, ReconInterestProvider};
 use signal_hook::consts::signal::*;
 use signal_hook_tokio::Signals;
 use std::sync::Arc;
@@ -530,13 +530,6 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
     // Construct a recon implementation for peers.
     let recon_peer = Recon::new(peer_svc.clone(), PeerKeyInterests, recon_metrics.clone());
 
-    // Construct a recon implementation for interests.
-    let recon_interest = Recon::new(
-        interest_svc.clone(),
-        FullInterests::default(),
-        recon_metrics.clone(),
-    );
-
     // Construct a recon implementation for models.
     let recon_model = Recon::new(
         model_svc.clone(),
@@ -545,7 +538,7 @@ pub async fn run(opts: DaemonOpts) -> Result<()> {
         recon_metrics,
     );
 
-    let recons = Some((recon_peer, recon_interest, recon_model));
+    let recons = Some((recon_peer, recon_model));
     let ipfs_metrics =
         ceramic_metrics::MetricsHandle::register(ceramic_kubo_rpc::IpfsMetrics::register);
     let p2p_metrics = MetricsHandle::register(ceramic_p2p::Metrics::register);

--- a/one/src/network.rs
+++ b/one/src/network.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use ceramic_core::{EventId, Interest, NodeId, NodeKey, PeerKey};
+use ceramic_core::{EventId, NodeId, NodeKey, PeerKey};
 use ceramic_kubo_rpc::{IpfsMetrics, IpfsMetricsMiddleware, IpfsService};
 use ceramic_p2p::{Config as P2pConfig, Libp2pConfig, Node, PeerService};
 use iroh_rpc_client::P2pClient;
@@ -34,18 +34,17 @@ impl BuilderState for WithP2p {}
 
 /// Configure the p2p service
 impl Builder<Init> {
-    pub async fn with_p2p<P, I, M, S>(
+    pub async fn with_p2p<P, M, S>(
         self,
         libp2p_config: Libp2pConfig,
         node_key: NodeKey,
         peer_svc: impl PeerService + 'static,
-        recons: Option<(P, I, M)>,
+        recons: Option<(P, M)>,
         block_store: Arc<S>,
         metrics: ceramic_p2p::Metrics,
     ) -> anyhow::Result<Builder<WithP2p>>
     where
         P: Recon<Key = PeerKey, Hash = Sha256a>,
-        I: Recon<Key = Interest, Hash = Sha256a>,
         M: Recon<Key = EventId, Hash = Sha256a>,
         S: iroh_bitswap::Store,
     {

--- a/p2p/src/behaviour.rs
+++ b/p2p/src/behaviour.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use ceramic_core::{EventId, Interest, PeerKey};
+use ceramic_core::{EventId, PeerKey};
 use iroh_bitswap::{Bitswap, Block, Config as BitswapConfig};
 use libp2p::{
     autonat,
@@ -36,7 +36,7 @@ pub const AGENT_VERSION: &str = concat!("ceramic-one/", env!("CARGO_PKG_VERSION"
 /// Libp2p behaviour for the node.
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "Event")]
-pub(crate) struct NodeBehaviour<P, I, M, S>
+pub(crate) struct NodeBehaviour<P, M, S>
 where
     S: iroh_bitswap::Store + Send + Sync,
 {
@@ -56,13 +56,12 @@ where
     relay: Toggle<relay::Behaviour>,
     relay_client: Toggle<relay::client::Behaviour>,
     dcutr: Toggle<dcutr::Behaviour>,
-    recon: Toggle<recon::libp2p::Behaviour<P, I, M>>,
+    recon: Toggle<recon::libp2p::Behaviour<P, M>>,
 }
 
-impl<P, I, M, S> NodeBehaviour<P, I, M, S>
+impl<P, M, S> NodeBehaviour<P, M, S>
 where
     P: Recon<Key = PeerKey, Hash = Sha256a> + Send + Sync,
-    I: Recon<Key = Interest, Hash = Sha256a> + Send + Sync,
     M: Recon<Key = EventId, Hash = Sha256a> + Send + Sync,
     S: iroh_bitswap::Store + Send + Sync,
 {
@@ -70,7 +69,7 @@ where
         local_key: &Keypair,
         config: &Libp2pConfig,
         relay_client: Option<relay::client::Behaviour>,
-        recons: Option<(P, I, M)>,
+        recons: Option<(P, M)>,
         block_store: Arc<S>,
         peers_tx: tokio::sync::mpsc::Sender<peers::Message>,
         metrics: Metrics,
@@ -186,8 +185,8 @@ where
                 .with_max_pending_incoming(Some(config.max_conns_pending_in))
                 .with_max_established_per_peer(Some(config.max_conns_per_peer)),
         );
-        let recon = recons.map(|(peer, interest, model)| {
-            recon::libp2p::Behaviour::new(peer, interest, model, recon::libp2p::Config::default())
+        let recon = recons.map(|(peer, model)| {
+            recon::libp2p::Behaviour::new(peer, model, recon::libp2p::Config::default())
         });
         Ok(NodeBehaviour {
             ping: Ping::default(),

--- a/p2p/src/swarm.rs
+++ b/p2p/src/swarm.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use ceramic_core::{EventId, Interest, PeerKey};
+use ceramic_core::{EventId, PeerKey};
 use libp2p::{dns, noise, relay, tcp, tls, yamux, Swarm, SwarmBuilder};
 use libp2p_identity::Keypair;
 use recon::{libp2p::Recon, Sha256a};
@@ -28,17 +28,16 @@ fn get_dns_config() -> (dns::ResolverConfig, dns::ResolverOpts) {
     }
 }
 
-pub(crate) async fn build_swarm<P, I, M, S>(
+pub(crate) async fn build_swarm<P, M, S>(
     config: &Libp2pConfig,
     keypair: Keypair,
-    recons: Option<(P, I, M)>,
+    recons: Option<(P, M)>,
     block_store: Arc<S>,
     peers_tx: tokio::sync::mpsc::Sender<peers::Message>,
     metrics: Metrics,
-) -> Result<Swarm<NodeBehaviour<P, I, M, S>>>
+) -> Result<Swarm<NodeBehaviour<P, M, S>>>
 where
     P: Recon<Key = PeerKey, Hash = Sha256a>,
-    I: Recon<Key = Interest, Hash = Sha256a>,
     M: Recon<Key = EventId, Hash = Sha256a>,
     S: iroh_bitswap::Store,
 {
@@ -105,18 +104,17 @@ where
     }
 }
 
-fn new_behavior<P, I, M, S>(
+fn new_behavior<P, M, S>(
     config: &Libp2pConfig,
     keypair: &Keypair,
     relay_client: Option<relay::client::Behaviour>,
-    recons: Option<(P, I, M)>,
+    recons: Option<(P, M)>,
     block_store: Arc<S>,
     peers_tx: tokio::sync::mpsc::Sender<peers::Message>,
     metrics: Metrics,
-) -> Result<NodeBehaviour<P, I, M, S>>
+) -> Result<NodeBehaviour<P, M, S>>
 where
     P: Recon<Key = PeerKey, Hash = Sha256a> + Send,
-    I: Recon<Key = Interest, Hash = Sha256a> + Send,
     M: Recon<Key = EventId, Hash = Sha256a> + Send,
     S: iroh_bitswap::Store,
 {

--- a/p2p/tests/node.rs
+++ b/p2p/tests/node.rs
@@ -6,7 +6,7 @@ use ceramic_event_svc::store::SqlitePool;
 use iroh_rpc_client::P2pClient;
 use iroh_rpc_types::Addr;
 use libp2p::{Multiaddr, PeerId};
-use recon::{FullInterests, Recon, ReconInterestProvider};
+use recon::{Recon, ReconInterestProvider};
 use test_log::test;
 
 use ceramic_p2p::{Config, Metrics, NetworkEvent, Node, PeerKeyInterests};
@@ -50,11 +50,6 @@ impl TestRunnerBuilder {
             Arc::clone(&peer_svc),
             Some((
                 Recon::new(peer_svc, PeerKeyInterests, recon_metrics.clone()),
-                Recon::new(
-                    Arc::clone(&interest_svc),
-                    FullInterests::default(),
-                    recon_metrics.clone(),
-                ),
                 Recon::new(
                     Arc::clone(&event_svc),
                     ReconInterestProvider::new(node_key.id(), interest_svc),

--- a/recon/src/libp2p/stream_set.rs
+++ b/recon/src/libp2p/stream_set.rs
@@ -1,14 +1,12 @@
 use anyhow::anyhow;
 
-use super::{PROTOCOL_NAME_INTEREST, PROTOCOL_NAME_MODEL, PROTOCOL_NAME_PEER};
+use super::{PROTOCOL_NAME_MODEL, PROTOCOL_NAME_PEER};
 
 /// Represents a stream set key
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub enum StreamSet {
     /// Stream set of peer ranges
     Peer,
-    /// Stream set of interest ranges
-    Interest,
     /// Stream set of models
     Model,
 }
@@ -18,7 +16,6 @@ impl StreamSet {
     pub fn sort_key(&self) -> &str {
         match self {
             StreamSet::Peer => "peer",
-            StreamSet::Interest => "interest",
             StreamSet::Model => "model",
         }
     }
@@ -31,7 +28,6 @@ impl TryFrom<&str> for StreamSet {
         match value {
             "peer" => Ok(StreamSet::Peer),
             "model" => Ok(StreamSet::Model),
-            "interest" => Ok(StreamSet::Interest),
             _ => Err(anyhow!("unknown sort_key {}", value)),
         }
     }
@@ -40,7 +36,6 @@ impl TryFrom<&str> for StreamSet {
 impl AsRef<str> for StreamSet {
     fn as_ref(&self) -> &str {
         match self {
-            StreamSet::Interest => PROTOCOL_NAME_INTEREST,
             StreamSet::Peer => PROTOCOL_NAME_PEER,
             StreamSet::Model => PROTOCOL_NAME_MODEL,
         }


### PR DESCRIPTION
With this change the interests ring is no longer synchronized between peers. A local node will still use the interest-svc to know its own interests and the beginning of each Recon conversation negotiates shared interests. Therefore it is no longer necessary to synchronize interests.

In the future we may decide that we want to use Recon to sync interests instead of a linear sharing of interests before each conversation, however that is only a performance optimization that is not important at this stage.

Fixes #610
Fixes #611