### PR TITLE
chore: use explicit os versions

### DIFF
--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -72,7 +72,7 @@ jobs:
           gem install fpm
       - name: Run package script
         run: |
-          ./ci-scripts/package.sh -a ${{ matrix.arch }} -e ${{ matrix.ext }}
+          ./ci-scripts/package.sh -a ${{ matrix.arch }} -e ${{ matrix.ext }} -v ${{ matrix.os }}
       - name: Archive Binary
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -20,23 +20,26 @@ jobs:
         # For these target platforms
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04
+            arch: x86_64
+            ext: deb
+            protoc-arch: linux-x86_64
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-22.04
             arch: x86_64
             ext: deb
             protoc-arch: linux-x86_64
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-14
             arch: x86_64
             ext: bin
             protoc-arch: osx-x86_64
           - target: aarch64-apple-darwin
-            os: macos-latest
+            os: macos-14
             config-file: fpm/osx.fpm
             arch: aarch64
             ext: bin
             protoc-arch: osx-aarch_64
-        #- target: x86_64-pc-windows-msvc
-        #  os: windows-latest
     runs-on: ${{ matrix.os }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -73,14 +76,14 @@ jobs:
       - name: Archive Binary
         uses: actions/upload-artifact@v3
         with:
-          name: ceramic-one_${{ matrix.target }}
-          path: ceramic-one_${{ matrix.target }}.bin.tar.gz
+          name: ceramic-one_${{ matrix.target }}-${{ matrix.os }}
+          path: ceramic-one_${{ matrix.target }}-${{ matrix.os }}.bin.tar.gz
       - name: Archive Debian Package
         uses: actions/upload-artifact@v3
         if: ${{ matrix.ext == 'deb' }}
         with:
-          name: ceramic-one_${{ matrix.target }}
-          path: ceramic-one_${{ matrix.target }}.tar.gz
+          name: ceramic-one_${{ matrix.target }}-${{ matrix.os }}
+          path: ceramic-one_${{ matrix.target }}-${{ matrix.os }}.tar.gz
 
   release:
     needs: [build-binaries]

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -21,8 +21,8 @@ jobs:
           echo "VERSION=$(jq -r '.tagName' release.json)" >> $GITHUB_OUTPUT
           echo "X86_URL=$(jq -r '.assets[] | select(.name | contains("x86_64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
           echo "ARM_URL=$(jq -r '.assets[] | select(.name | contains("aarch64-apple-darwin")) | .url' release.json)" >> $GITHUB_OUTPUT
-          echo "X86_SHA=$(sha256sum ceramic-one_x86_64-apple-darwin.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
-          echo "ARM_SHA=$(sha256sum ceramic-one_aarch64-apple-darwin.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "X86_SHA=$(sha256sum ceramic-one_x86_64-apple-darwin-macos-*.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
+          echo "ARM_SHA=$(sha256sum ceramic-one_aarch64-apple-darwin-macos-*.bin.tar.gz | cut -d ' ' -f 1)" >> $GITHUB_OUTPUT
       - name: Checkout Homebrew Tap
         uses: actions/checkout@v4
         with:

--- a/ci-scripts/package.sh
+++ b/ci-scripts/package.sh
@@ -10,6 +10,7 @@ INSTALL_DIR="/usr/local/bin"
 
 OS="unknown-linux-gnu"
 ARCH=""
+OS_VERSION=""
 case $(uname -m) in
   x86_64) ARCH="x86_64" ;;
   arm64) ARCH="aarch64" ;;
@@ -29,7 +30,7 @@ fi
 
 echo "Evaluating program arguments '$@'"
 
-while getopts "f:e:d:i:a:" opt
+while getopts "f:e:d:i:a:v" opt
 do
   case "$opt" in
     f)
@@ -51,6 +52,10 @@ do
     a)
       echo "Setting architecture to "$OPTARG
       ARCH=$OPTARG
+      ;;
+    v)
+      echo "Setting os version to "$OPTARG
+      OS_VERSION="-${OPTARG}"
       ;;
     \? )
       echo "Invalid option: -$OPTARG" 1>&2
@@ -83,12 +88,12 @@ echo "Building artifacts for "$TARGET
 cargo build --release --locked --target $TARGET
 
 echo "Compressing binary package for $TARGET"
-tar -cvzf ceramic-one_$TARGET.bin.tar.gz -C $BIN_DIR ceramic-one
+tar -cvzf ceramic-one_${TARGET}${OS_VERSION}.bin.tar.gz -C $BIN_DIR ceramic-one
 
 if [ "$EXT" != "bin" ]; then
     echo "Building package for $TARGET"
     fpm --fpm-options-file $CONFIG_FILE -C $BIN_DIR -v $PKG_VERSION -p $OUT_PATH ceramic-one=$INSTALL_DIR/ceramic-one
 
     echo "Compressing package for $TARGET"
-    tar -cvzf ceramic-one_$TARGET.tar.gz -C $ARTIFACTS_DIR $OUT_FILE
+    tar -cvzf ceramic-one_${TARGET}${OS_VERSION}.tar.gz -C $ARTIFACTS_DIR $OUT_FILE
 fi


### PR DESCRIPTION
This week github updated the `ubuntu-latest` tag to be ubuntu-24.04. This meant that version 0.47.0 of ceramic-one no longer runs on ubuntu-22. This is unexpected and not in our control. With this change we explicitly name the os versions we target (this matters because of glibc versions). This means we will need to add new versions and deprecate old versions as they are released.