### PR TITLE
fix: use new default testnet eth rpc url

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -126,8 +126,8 @@ impl Network {
                 anyhow::bail!("no Ethereum RPC URLs specified for Mainnet")
             }
             Network::TestnetClay => {
-                info!("no Ethereum RPC URLs specified for Clay Testnet, defaulting to https://gnosis-rpc.publicnode.com");
-                Ok(vec!["https://gnosis-rpc.publicnode.com".to_string()])
+                info!("no Ethereum RPC URLs specified for Clay Testnet, defaulting to https://rpc.ankr.com/gnosis");
+                Ok(vec!["https://rpc.ankr.com/gnosis".to_string()])
             }
             Network::DevUnstable => {
                 info!("no Ethereum RPC URLs specified for dev-unstable network, defaulting to https://ethereum-sepolia-rpc.publicnode.com");

--- a/validation/src/blockchain/eth_rpc/http.rs
+++ b/validation/src/blockchain/eth_rpc/http.rs
@@ -55,7 +55,7 @@ static BLOCK_THRESHHOLDS: Lazy<HashMap<caip2::ChainId, u64>> = Lazy::new(|| {
     ])
 });
 
-const TRANSACTION_CACHE_SIZE: usize = 50;
+const TRANSACTION_CACHE_SIZE: usize = 1_000;
 const BLOCK_CACHE_SIZE: usize = 50;
 
 type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
The previous default would report that tx did not exist when looked up by hash. This new url works without issue. Also increase the cache size to reduce the chances of being rate limited.

Now standing up a local node can successfully synchronize with the bootstrap nodes without being rate limited.