### PR TITLE
fix: fix off by one, projection and not found bugs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
-[build]
+[target.'cfg(all())']
 rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2631,6 +2631,7 @@ dependencies = [
  "ipld-core",
  "json-patch",
  "mockall",
+ "multibase 0.9.1",
  "object_store",
  "parking_lot",
  "prometheus-client",

--- a/event-svc/src/event/feed.rs
+++ b/event-svc/src/event/feed.rs
@@ -11,7 +11,8 @@ impl ConclusionFeed for EventService {
             .event_access
             .get_highwater_mark()
             .await
-            .map(|h| Some(h as u64))?)
+            // highwater marks are 1 based, subtract one to get zero based index
+            .map(|h| (h - 1).try_into().ok())?)
     }
     /// Fetches Conclusion Events that have occurred since a given highwater mark.
     ///

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -31,6 +31,7 @@ int-enum.workspace = true
 ipld-core.workspace = true
 json-patch = "3.0.1"
 mockall = { workspace = true, optional = true }
+multibase.workspace = true
 object_store.workspace = true
 parking_lot = "0.12.3"
 prometheus-client.workspace = true

--- a/pipeline/src/since/stream.rs
+++ b/pipeline/src/since/stream.rs
@@ -191,7 +191,8 @@ impl<S: StreamTableSource> ExecutionPlan for StreamExec<S> {
             }
         };
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            self.source.schema(),
+            // Use the projected schema
+            self.schema(),
             stream.map_err(|err: anyhow::Error| exec_datafusion_err!("{err}")),
         )))
     }


### PR DESCRIPTION
There was an off by one bug in translating highwater marks to offsets.

There was a bug in projecting stream tables as they reported the wrong schema.

Finally there was a bug in the stream state query that would panic if the stream didn't exist and datafusion returned an empty batch.