### PR TITLE
chore: version v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.48.0] - 2025-01-28
+
+### 🚀 Features
+
+- Adds actor framework ([#644](https://github.com/ceramicnetwork/rust-ceramic/issues/644))
+- Stream flight sql queries ([#645](https://github.com/ceramicnetwork/rust-ceramic/issues/645))
+- Add pipeline metrics ([#646](https://github.com/ceramicnetwork/rust-ceramic/issues/646))
+
+### 🐛 Bug Fixes
+
+- Update built dep ([#641](https://github.com/ceramicnetwork/rust-ceramic/issues/641))
+- Fix off by one, projection and not found bugs ([#647](https://github.com/ceramicnetwork/rust-ceramic/issues/647))
+- Conclusion poll loop no longer stops ([#648](https://github.com/ceramicnetwork/rust-ceramic/issues/648))
+
+### 🚜 Refactor
+
+- Add simpler shutdown handling ([#643](https://github.com/ceramicnetwork/rust-ceramic/issues/643))
+- Rename _stream tables to _feed ([#649](https://github.com/ceramicnetwork/rust-ceramic/issues/649))
+
+### ⚙️ Miscellaneous Tasks
+
+- Make clippy happy about lifetimes ([#642](https://github.com/ceramicnetwork/rust-ceramic/issues/642))
+- Fix event-svc bench ([#639](https://github.com/ceramicnetwork/rust-ceramic/issues/639))
+
 ## [0.47.3] - 2025-01-13
 
 ### 🐛 Bug Fixes
@@ -11,6 +35,7 @@ All notable changes to this project will be documented in this file.
 ### ⚙️ Miscellaneous Tasks
 
 - Add tests for eip55 cacaos ([#636](https://github.com/ceramicnetwork/rust-ceramic/issues/636))
+- Version v0.47.3 ([#640](https://github.com/ceramicnetwork/rust-ceramic/issues/640))
 
 ## [0.47.2] - 2024-12-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "ceramic-actor-macros",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor-macros"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "ceramic-actor",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "built",
  "serde",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arrow-cast",
@@ -2537,7 +2537,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -5838,7 +5838,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10261,7 +10261,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shutdown"
-version = "0.47.3"
+version = "0.48.0"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.47.3"
+version = "0.48.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.47.3"
+version = "0.48.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.47.3
-- Build date: 2025-01-14T10:24:44.041460427-07:00[America/Denver]
+- API version: 0.48.0
+- Build date: 2025-01-28T19:21:11.089895361Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.47.3
+  version: 0.48.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.47.3";
+pub const API_VERSION: &str = "0.48.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.47.3
+  version: 0.48.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.47.3"
+version = "0.48.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.47.3
-- Build date: 2025-01-13T18:59:23.465436135Z[Etc/UTC]
+- API version: 0.48.0
+- Build date: 2025-01-28T19:21:13.750804233Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.47.3
+  version: 0.48.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.47.3";
+pub const API_VERSION: &str = "0.48.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.47.3
+  version: 0.48.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.48.0] - 2025-01-28

### 🚀 Features

- Adds actor framework ([#644](https://github.com/ceramicnetwork/rust-ceramic/issues/644))
- Stream flight sql queries ([#645](https://github.com/ceramicnetwork/rust-ceramic/issues/645))
- Add pipeline metrics ([#646](https://github.com/ceramicnetwork/rust-ceramic/issues/646))

### 🐛 Bug Fixes

- Update built dep ([#641](https://github.com/ceramicnetwork/rust-ceramic/issues/641))
- Fix off by one, projection and not found bugs ([#647](https://github.com/ceramicnetwork/rust-ceramic/issues/647))
- Conclusion poll loop no longer stops ([#648](https://github.com/ceramicnetwork/rust-ceramic/issues/648))

### 🚜 Refactor

- Add simpler shutdown handling ([#643](https://github.com/ceramicnetwork/rust-ceramic/issues/643))
- Rename _stream tables to _feed ([#649](https://github.com/ceramicnetwork/rust-ceramic/issues/649))

### ⚙️ Miscellaneous Tasks

- Make clippy happy about lifetimes ([#642](https://github.com/ceramicnetwork/rust-ceramic/issues/642))
- Fix event-svc bench ([#639](https://github.com/ceramicnetwork/rust-ceramic/issues/639))