### PR TITLE
feat: adds stream_id_string udf

### DIFF
--- a/pipeline/src/cid_string.rs
+++ b/pipeline/src/cid_string.rs
@@ -78,7 +78,7 @@ impl ScalarUDFImpl for CidString {
     }
 }
 
-/// ScalarUDF to convert a binary CID into a string for easier inspection.
+/// ScalarUDF to convert a a list of binary CIDs into a list of strings for easier inspection.
 #[derive(Debug)]
 pub struct CidStringList {
     signature: Signature,

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -14,6 +14,7 @@ mod config;
 mod metrics;
 pub mod schemas;
 mod since;
+pub mod stream_id_string;
 #[cfg(test)]
 mod tests;
 
@@ -33,6 +34,7 @@ use tokio::task::JoinHandle;
 use url::Url;
 
 use cid_string::{CidString, CidStringList};
+use stream_id_string::{StreamIdString, StreamIdStringList};
 
 pub use concluder::{
     conclusion_events_to_record_batch, ConclusionData, ConclusionEvent, ConclusionFeed,
@@ -147,6 +149,8 @@ pub async fn pipeline_ctx(object_store: Arc<dyn ObjectStore>) -> Result<Pipeline
     ctx.register_udaf(AggregateUDF::new_from_impl(LastValue::default()));
     ctx.register_udf(ScalarUDF::new_from_impl(CidString::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(CidStringList::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(StreamIdString::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(StreamIdStringList::new()));
 
     // Register JSON functions
     datafusion_functions_json::register_all(&mut ctx)?;

--- a/pipeline/src/stream_id_string.rs
+++ b/pipeline/src/stream_id_string.rs
@@ -1,0 +1,387 @@
+//! Provides a scalar udf implementation that converts StreamId bytes to a utf8 string.
+
+use std::{any::Any, sync::Arc};
+
+use arrow::{
+    array::{AsArray as _, GenericByteArray},
+    datatypes::{GenericBinaryType, GenericStringType},
+};
+use ceramic_core::StreamId;
+use datafusion::{
+    arrow::{
+        array::{ArrayIter, ListBuilder, StringBuilder},
+        datatypes::DataType,
+    },
+    common::{
+        cast::{as_binary_array, as_list_array},
+        exec_datafusion_err,
+    },
+    logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, TypeSignature, Volatility},
+};
+
+// Number of bytes in a typical Ceramic Stream ID as a UTF8 string.
+const STREAM_ID_STRING_BYTES: usize = 63;
+
+/// ScalarUDF to convert a binary StreamId into a string for easier inspection.
+#[derive(Debug)]
+pub struct StreamIdString {
+    signature: Signature,
+}
+
+impl Default for StreamIdString {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamIdString {
+    /// Construct new instance
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![DataType::Binary]),
+                    // Enumerate all possible dictionary key types.
+                    // We handle dictionary types explicitly because we know that we are a 1:1
+                    // transformation and can preserve the dictionary encoding.
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int8),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int16),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int32),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int64),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt8),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt16),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt32),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt64),
+                        Box::new(DataType::Binary),
+                    )]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+    fn map_ids(
+        &self,
+        stream_ids: &GenericByteArray<GenericBinaryType<i32>>,
+        number_rows: usize,
+    ) -> datafusion::common::Result<GenericByteArray<GenericStringType<i32>>> {
+        let mut strs =
+            StringBuilder::with_capacity(number_rows, STREAM_ID_STRING_BYTES * number_rows);
+        for stream_id in stream_ids {
+            if let Some(stream_id) = stream_id {
+                strs.append_value(
+                    StreamId::try_from(stream_id)
+                        .map_err(|err| exec_datafusion_err!("Error {err}"))?
+                        .to_string(),
+                );
+            } else {
+                strs.append_null()
+            }
+        }
+        Ok(strs.finish())
+    }
+}
+
+impl ScalarUDFImpl for StreamIdString {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "stream_id_string"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, args: &[DataType]) -> datafusion::common::Result<DataType> {
+        if let DataType::Dictionary(key, _value) = &args[0] {
+            Ok(DataType::Dictionary(
+                key.to_owned(),
+                Box::new(DataType::Utf8),
+            ))
+        } else {
+            Ok(DataType::Utf8)
+        }
+    }
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        number_rows: usize,
+    ) -> datafusion::common::Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(args)?;
+
+        if let Some(dict) = args[0].as_any_dictionary_opt() {
+            let stream_ids = as_binary_array(dict.values())?;
+            let ids = self.map_ids(stream_ids, number_rows)?;
+            Ok(ColumnarValue::Array(dict.with_values(Arc::new(ids))))
+        } else {
+            let stream_ids = as_binary_array(&args[0])?;
+            let ids = self.map_ids(stream_ids, number_rows)?;
+            Ok(ColumnarValue::Array(Arc::new(ids)))
+        }
+    }
+}
+
+/// ScalarUDF to convert a list of binary StreamIds into a list of strings for easier inspection.
+#[derive(Debug)]
+pub struct StreamIdStringList {
+    signature: Signature,
+}
+
+impl Default for StreamIdStringList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StreamIdStringList {
+    /// Construct new instance
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(
+                TypeSignature::Exact(vec![DataType::new_list(DataType::Binary, true)]),
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for StreamIdStringList {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "array_stream_id_string"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _args: &[DataType]) -> datafusion::common::Result<DataType> {
+        Ok(DataType::new_list(DataType::Utf8, true))
+    }
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        number_rows: usize,
+    ) -> datafusion::common::Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(args)?;
+        let all_stream_ids = as_list_array(&args[0])?;
+        // Count the number of stream ids before allocating.
+        let stream_id_count = all_stream_ids.values().len();
+        let mut strs = ListBuilder::with_capacity(
+            StringBuilder::with_capacity(stream_id_count, STREAM_ID_STRING_BYTES * stream_id_count),
+            number_rows,
+        );
+        for stream_ids in ArrayIter::new(all_stream_ids) {
+            if let Some(stream_ids) = stream_ids {
+                let stream_ids = as_binary_array(&stream_ids)?;
+                for stream_id in stream_ids {
+                    if let Some(stream_id) = stream_id {
+                        strs.values().append_value(
+                            StreamId::try_from(stream_id)
+                                .map_err(|err| exec_datafusion_err!("Error {err}"))?
+                                .to_string(),
+                        );
+                    } else {
+                        strs.values().append_null()
+                    }
+                }
+                strs.append(true)
+            } else {
+                strs.append_null()
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(strs.finish())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{StreamIdString, StreamIdStringList};
+
+    use std::{str::FromStr as _, sync::Arc};
+
+    use arrow::{
+        array::{ArrayRef, BinaryDictionaryBuilder, ListBuilder},
+        datatypes::Int32Type,
+        util::pretty::pretty_format_batches,
+    };
+    use ceramic_core::StreamId;
+    use datafusion::{
+        arrow::array::{BinaryBuilder, StructArray},
+        logical_expr::{expr::ScalarFunction, ScalarUDF},
+        prelude::{col, Expr, SessionContext},
+    };
+    use expect_test::expect;
+    use test_log::test;
+
+    #[test(tokio::test)]
+    async fn stream_id_string() -> anyhow::Result<()> {
+        let mut stream_ids = BinaryBuilder::new();
+        stream_ids.append_value(
+            StreamId::from_str("k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4")?
+                .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId::from_str("k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj")?
+                .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId::from_str("k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13")?
+                .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId::from_str("k2t6wzhjp5kk2g9iztfm7ol8lrbxoabkh3rn1u3nzm7mffdri2a1gpg5kcuge6")?
+                .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId::from_str("k2t6wzhjp5kk2efsq5cvws7s0nrcdn1de9h0rfemmz5d6vcavm340yv2sxxd9m")?
+                .to_vec(),
+        );
+        let batch = StructArray::try_from(vec![(
+            "stream_id",
+            Arc::new(stream_ids.finish()) as ArrayRef,
+        )])?;
+        let stream_id_string = Arc::new(ScalarUDF::from(StreamIdString::new()));
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![Expr::ScalarFunction(ScalarFunction::new_udf(
+                stream_id_string,
+                vec![col("stream_id")],
+            ))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +----------------------------------------------------------------+
+            | stream_id_string(?table?.stream_id)                            |
+            +----------------------------------------------------------------+
+            | k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4 |
+            | k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj |
+            | k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13 |
+            | k2t6wzhjp5kk2g9iztfm7ol8lrbxoabkh3rn1u3nzm7mffdri2a1gpg5kcuge6 |
+            | k2t6wzhjp5kk2efsq5cvws7s0nrcdn1de9h0rfemmz5d6vcavm340yv2sxxd9m |
+            +----------------------------------------------------------------+"#]]
+        .assert_eq(&output.to_string());
+        Ok(())
+    }
+    #[test(tokio::test)]
+    async fn stream_id_string_dict() -> anyhow::Result<()> {
+        let mut stream_ids = BinaryDictionaryBuilder::<Int32Type>::new();
+        let si4 =
+            StreamId::from_str("k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4")?
+                .to_vec();
+        let gtj =
+            StreamId::from_str("k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj")?
+                .to_vec();
+        let r13 =
+            StreamId::from_str("k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13")?
+                .to_vec();
+
+        stream_ids.append_value(si4.clone());
+        stream_ids.append_value(gtj.clone());
+        stream_ids.append_value(gtj);
+        stream_ids.append_value(r13);
+        stream_ids.append_value(si4.clone());
+        stream_ids.append_value(si4);
+
+        let batch = StructArray::try_from(vec![(
+            "stream_id",
+            Arc::new(stream_ids.finish()) as ArrayRef,
+        )])?;
+        let stream_id_string = Arc::new(ScalarUDF::from(StreamIdString::new()));
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![Expr::ScalarFunction(ScalarFunction::new_udf(
+                stream_id_string,
+                vec![col("stream_id")],
+            ))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +----------------------------------------------------------------+
+            | stream_id_string(?table?.stream_id)                            |
+            +----------------------------------------------------------------+
+            | k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4 |
+            | k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj |
+            | k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj |
+            | k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13 |
+            | k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4 |
+            | k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4 |
+            +----------------------------------------------------------------+"#]]
+        .assert_eq(&output.to_string());
+        Ok(())
+    }
+    #[test(tokio::test)]
+    async fn stream_id_string_list() -> anyhow::Result<()> {
+        let mut stream_ids = ListBuilder::new(BinaryBuilder::new());
+        stream_ids.values().append_value(
+            StreamId::from_str("k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4")?
+                .to_vec(),
+        );
+        stream_ids.values().append_value(
+            StreamId::from_str("k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj")?
+                .to_vec(),
+        );
+        stream_ids.append(true);
+        stream_ids.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13")?
+                .to_vec(),
+        );
+        stream_ids.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk2g9iztfm7ol8lrbxoabkh3rn1u3nzm7mffdri2a1gpg5kcuge6")?
+                .to_vec(),
+        );
+        stream_ids.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk2efsq5cvws7s0nrcdn1de9h0rfemmz5d6vcavm340yv2sxxd9m")?
+                .to_vec(),
+        );
+        stream_ids.append(true);
+        let batch = StructArray::try_from(vec![(
+            "stream_ids",
+            Arc::new(stream_ids.finish()) as ArrayRef,
+        )])?;
+        let stream_id_string_list = Arc::new(ScalarUDF::from(StreamIdStringList::new()));
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![Expr::ScalarFunction(ScalarFunction::new_udf(
+                stream_id_string_list,
+                vec![col("stream_ids")],
+            ))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+            | array_stream_id_string(?table?.stream_ids)                                                                                                                                                       |
+            +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+            | [k2t6wz4yhfp1mpv0qjl1aipdhcekgsyj8lpb2rv42q0k457bvedqsa7scmtsi4, k2t6wz4yhfp1m6aqsagtswyvan3kfnmgu84bzbr99nh0px38swqyegskd2agtj]                                                                 |
+            | [k2t6wzhjp5kk1fuyrvdp2ednbfeawsdr1agd6qsoaim5vyliu5rex69dfyvr13, k2t6wzhjp5kk2g9iztfm7ol8lrbxoabkh3rn1u3nzm7mffdri2a1gpg5kcuge6, k2t6wzhjp5kk2efsq5cvws7s0nrcdn1de9h0rfemmz5d6vcavm340yv2sxxd9m] |
+            +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+"#]].assert_eq(&output.to_string());
+        Ok(())
+    }
+}


### PR DESCRIPTION
This UDF is helpful in decoding the model dimension as it is a stream id bytes.

For example this query:

```sql
SELECT stream_id_string(array_extract(map_extract(dimensions, 'model'), 1)) FROM event_states WHERE ...
```