### PR TITLE
feat: add dimension_extract udf

### DIFF
--- a/pipeline/src/dimension_extract.rs
+++ b/pipeline/src/dimension_extract.rs
@@ -1,0 +1,164 @@
+//! Provides single method that can extract the dimensions of an event.
+//! This is in practice just an alias for array_extract(map_extract(dimensions, <name>), 1).
+
+use std::{any::Any, sync::Arc};
+
+use datafusion::{
+    arrow::datatypes::DataType,
+    functions_array::{extract::array_element_udf, map_extract::map_extract_udf},
+    logical_expr::{ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature},
+    scalar::ScalarValue,
+};
+
+/// ScalarUDF to convert a binary CID into a string for easier inspection.
+#[derive(Debug)]
+pub struct DimensionExtract {
+    map_extract: Arc<ScalarUDF>,
+    array_extract: Arc<ScalarUDF>,
+}
+
+impl Default for DimensionExtract {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DimensionExtract {
+    /// Construct new instance
+    pub fn new() -> Self {
+        Self {
+            map_extract: map_extract_udf(),
+            array_extract: array_element_udf(),
+        }
+    }
+}
+
+impl ScalarUDFImpl for DimensionExtract {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "dimension_extract"
+    }
+    fn signature(&self) -> &Signature {
+        &self.map_extract.signature()
+    }
+    fn coerce_types(&self, arg_types: &[DataType]) -> datafusion::error::Result<Vec<DataType>> {
+        self.map_extract.coerce_types(arg_types)
+    }
+    fn return_type(&self, args: &[DataType]) -> datafusion::common::Result<DataType> {
+        let ret = self.map_extract.inner().return_type(args)?;
+        if let DataType::List(field) = ret {
+            Ok(field.data_type().clone())
+        } else {
+            Err(datafusion::error::DataFusionError::Internal(
+                "map_extract should always return a list datatype".to_owned(),
+            ))
+        }
+    }
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        number_rows: usize,
+    ) -> datafusion::error::Result<ColumnarValue> {
+        let mapped = self.map_extract.invoke_batch(args, number_rows)?;
+        self.array_extract.invoke_batch(
+            &[mapped, ColumnarValue::Scalar(ScalarValue::Int64(Some(1)))],
+            number_rows,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::stream_id_string::StreamIdString;
+
+    use super::DimensionExtract;
+
+    use std::{str::FromStr as _, sync::Arc};
+
+    use arrow::{
+        array::{ArrayRef, BinaryDictionaryBuilder, MapBuilder, MapFieldNames, StringBuilder},
+        datatypes::Int32Type,
+        util::pretty::pretty_format_batches,
+    };
+    use ceramic_core::StreamId;
+    use datafusion::{
+        arrow::array::StructArray,
+        logical_expr::{expr::ScalarFunction, ScalarUDF},
+        prelude::{col, lit, Expr, SessionContext},
+    };
+    use expect_test::expect;
+    use test_log::test;
+
+    #[test(tokio::test)]
+    async fn dimension_extract() -> anyhow::Result<()> {
+        let mut dimensions = MapBuilder::new(
+            Some(MapFieldNames {
+                entry: "entries".to_string(),
+                key: "key".to_string(),
+                value: "value".to_string(),
+            }),
+            StringBuilder::new(),
+            BinaryDictionaryBuilder::<Int32Type>::new(),
+        );
+        dimensions.keys().append_value("model");
+        dimensions.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk57kldpzlnneq20q440sae8azvedfbq5alg66hzl9u5estye4fp")?
+                .to_vec(),
+        );
+        dimensions.append(true).unwrap();
+
+        dimensions.keys().append_value("model");
+        dimensions.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk3c0kf11cq8b23nh85yrriywu6vhoxwsai53nc53wxr7kw31f8y")?
+                .to_vec(),
+        );
+        dimensions.append(true).unwrap();
+
+        dimensions.keys().append_value("model");
+        dimensions.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk4iow3p6qvu06bxhjt7exsnwzz5advmpyvzsrsefus9bmxjywtg")?
+                .to_vec(),
+        );
+        dimensions.append(true).unwrap();
+
+        dimensions.keys().append_value("model");
+        dimensions.values().append_value(
+            StreamId::from_str("k2t6wzhjp5kk5jcv308pv15q50yors7io0t58mtwvjpudkqt05gmjbrr14s3zi")?
+                .to_vec(),
+        );
+        dimensions.append(true).unwrap();
+
+        let batch = StructArray::try_from(vec![(
+            "dimensions",
+            Arc::new(dimensions.finish()) as ArrayRef,
+        )])?;
+        let stream_id_string = Arc::new(ScalarUDF::from(StreamIdString::new()));
+        let dimension_extract = Arc::new(ScalarUDF::from(DimensionExtract::new()));
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![Expr::ScalarFunction(ScalarFunction::new_udf(
+                stream_id_string,
+                vec![Expr::ScalarFunction(ScalarFunction::new_udf(
+                    dimension_extract,
+                    vec![col("dimensions"), lit("model")],
+                ))],
+            ))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +-----------------------------------------------------------------------+
+            | stream_id_string(dimension_extract(?table?.dimensions,Utf8("model"))) |
+            +-----------------------------------------------------------------------+
+            | k2t6wzhjp5kk57kldpzlnneq20q440sae8azvedfbq5alg66hzl9u5estye4fp        |
+            | k2t6wzhjp5kk3c0kf11cq8b23nh85yrriywu6vhoxwsai53nc53wxr7kw31f8y        |
+            | k2t6wzhjp5kk4iow3p6qvu06bxhjt7exsnwzz5advmpyvzsrsefus9bmxjywtg        |
+            | k2t6wzhjp5kk5jcv308pv15q50yors7io0t58mtwvjpudkqt05gmjbrr14s3zi        |
+            +-----------------------------------------------------------------------+"#]]
+        .assert_eq(&output.to_string());
+        Ok(())
+    }
+}

--- a/pipeline/src/dimension_extract.rs
+++ b/pipeline/src/dimension_extract.rs
@@ -41,7 +41,7 @@ impl ScalarUDFImpl for DimensionExtract {
         "dimension_extract"
     }
     fn signature(&self) -> &Signature {
-        &self.map_extract.signature()
+        self.map_extract.signature()
     }
     fn coerce_types(&self, arg_types: &[DataType]) -> datafusion::error::Result<Vec<DataType>> {
         self.map_extract.coerce_types(arg_types)

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -11,6 +11,7 @@ mod cache_table;
 pub mod cid_string;
 pub mod concluder;
 mod config;
+pub mod dimension_extract;
 mod metrics;
 pub mod schemas;
 mod since;
@@ -34,6 +35,7 @@ use tokio::task::JoinHandle;
 use url::Url;
 
 use cid_string::{CidString, CidStringList};
+use dimension_extract::DimensionExtract;
 use stream_id_string::{StreamIdString, StreamIdStringList};
 
 pub use concluder::{
@@ -151,6 +153,7 @@ pub async fn pipeline_ctx(object_store: Arc<dyn ObjectStore>) -> Result<Pipeline
     ctx.register_udf(ScalarUDF::new_from_impl(CidStringList::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(StreamIdString::new()));
     ctx.register_udf(ScalarUDF::new_from_impl(StreamIdStringList::new()));
+    ctx.register_udf(ScalarUDF::new_from_impl(DimensionExtract::new()));
 
     // Register JSON functions
     datafusion_functions_json::register_all(&mut ctx)?;


### PR DESCRIPTION
Simplifies a query like

```sql
SELECT stream_id_string(array_extract(map_extract(dimensions, 'model'), 1)) FROM event_states WHERE ...
```
to

```sql
SELECT stream_id_string(dimension_extract(dimensions, 'model')) FROM event_states WHERE ...
```