### PR TITLE
refactor: more efficient list udf impls

### DIFF
--- a/pipeline/src/stream_id_string.rs
+++ b/pipeline/src/stream_id_string.rs
@@ -3,7 +3,7 @@
 use std::{any::Any, sync::Arc};
 
 use arrow::{
-    array::{Array, ArrayRef, AsArray as _, GenericByteArray, GenericListArray},
+    array::{Array, AsArray as _, GenericByteArray, GenericListArray},
     datatypes::{GenericBinaryType, GenericStringType},
 };
 use arrow_schema::Field;


### PR DESCRIPTION
This is a more efficient list UDF implementation when the list structure does not change. We simply map over the values array directly and reuse the list offsets and nulls.

This is not strictly necessary. However setting a standard to always operate on a single Arrow array at a time is kinda the whole point of Arrow. Therefore I thinks is valuable to make this change so we set a good pattern to follow in the future.