### PR TITLE
feat: partition event states by event cid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,7 +2478,6 @@ name = "ceramic-one"
 version = "0.48.0"
 dependencies = [
  "anyhow",
- "arrow",
  "arrow-cast",
  "arrow-flight",
  "async-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,9 +788,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91839b07e474b3995035fd8ac33ee54f9c9ccbbb1ea33d9909c71bffdf1259d"
+checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855c57c4efd26722b044dcd3e348252560e3e0333087fb9f6479dc0bf744054f"
+checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -824,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd03279cea46569acf9295f6224fbc370c5df184b4d2ecfe97ccb131d5615a7f"
+checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
 dependencies = [
  "ahash 0.8.11",
  "arrow-buffer",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4a9b9b1d6d7117f6138e13bc4dd5daa7f94e671b70e8c9c4dc37b4f5ecfc16"
+checksum = "2b02656a35cc103f28084bc80a0159668e0a680d919cef127bd7e0aaccb06ec1"
 dependencies = [
  "bytes 1.7.2",
  "half 2.4.1",
@@ -852,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc70e39916e60c5b7af7a8e2719e3ae589326039e1e863675a008bee5ffe90fd"
+checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789b2af43c1049b03a8d088ff6b2257cdcea1756cd76b174b1f2600356771b97"
+checksum = "ec222848d70fea5a32af9c3602b08f5d740d5e2d33fbd76bf6fd88759b5b13a7"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e75edf21ffd53744a9b8e3ed11101f610e7ceb1a29860432824f1834a1f623"
+checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -904,9 +904,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-flight"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c09b331887a526f203f2123444792aee924632bd08b9940435070901075832e"
+checksum = "3ab7635558f3f803b492eae56c03cde97ea5f85a1c768f94181cb7db69cd81be"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -932,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d186a909dece9160bf8312f5124d797884f608ef5435a36d9d608e0b2a9bcbf8"
+checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66ff2fedc1222942d0bd2fd391cb14a85baa3857be95c9373179bd616753b85"
+checksum = "0eff38eeb8a971ad3a4caf62c5d57f0cff8a48b64a55e3207c4fd696a9234aad"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -967,9 +967,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece7b5bc1180e6d82d1a60e1688c199829e8842e38497563c3ab6ea813e527fd"
+checksum = "c6f202a879d287099139ff0d121e7f55ae5e0efe634b8cf2106ebc27a8715dee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -982,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745c114c8f0e8ce211c83389270de6fbe96a9088a7b32c2a041258a443fe83ff"
+checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -996,15 +996,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95513080e728e4cec37f1ff5af4f12c9688d47795d17cda80b6ec2cf74d4678"
+checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
 
 [[package]]
 name = "arrow-select"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e415279094ea70323c032c6e739c48ad8d80e78a09bef7117b8718ad5bf3722"
+checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
 dependencies = [
  "ahash 0.8.11",
  "arrow-array",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d956cae7002eb8d83a27dbd34daaea1cf5b75852f0b84deb4d93a276e92bbf"
+checksum = "72993b01cb62507b06f1fb49648d7286c8989ecfabdb7b77a750fcb54410731b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2478,6 +2478,7 @@ name = "ceramic-one"
 version = "0.48.0"
 dependencies = [
  "anyhow",
+ "arrow",
  "arrow-cast",
  "arrow-flight",
  "async-stream",
@@ -5314,7 +5315,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -8889,8 +8890,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes 1.7.2",
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8936,7 +8937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/pipeline/src/cache_table.rs
+++ b/pipeline/src/cache_table.rs
@@ -52,7 +52,7 @@ use datafusion::{
 use futures::StreamExt as _;
 use parking_lot::Mutex;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tracing::{debug, instrument, Level};
 
 /// Type alias for partition data
 pub type PartitionData = Arc<RwLock<Vec<RecordBatch>>>;
@@ -224,7 +224,7 @@ struct CacheSink {
 
 impl Debug for CacheSink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("MemSink")
+        f.debug_struct("CacheSink")
             .field("num_partitions", &self.batches.len())
             .finish()
     }
@@ -257,6 +257,7 @@ impl DataSink for CacheSink {
         None
     }
 
+    #[instrument(skip_all, ret(level = Level::DEBUG), err(level = Level::ERROR))]
     async fn write_all(
         &self,
         mut data: SendableRecordBatchStream,

--- a/pipeline/src/cid_part.rs
+++ b/pipeline/src/cid_part.rs
@@ -1,0 +1,69 @@
+//! Provides a scalar udf implementation that computes a partition value from CID bytes.
+//! The current implementation keeps only the last byte.
+
+use std::{any::Any, sync::Arc};
+
+use arrow::array::Int32Builder;
+use datafusion::{
+    arrow::datatypes::DataType,
+    common::cast::as_binary_array,
+    logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, TypeSignature, Volatility},
+};
+
+/// Scalar UDF that computes the a partition value from CID bytes.
+///
+/// The current implementation retruns the last bytes of the CID.
+#[derive(Debug)]
+pub struct CidPart {
+    signature: Signature,
+}
+
+impl Default for CidPart {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CidPart {
+    /// Construct new instance
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(
+                TypeSignature::Exact(vec![DataType::Binary]),
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for CidPart {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "cid_part"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _args: &[DataType]) -> datafusion::common::Result<DataType> {
+        Ok(DataType::Int32)
+    }
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        number_rows: usize,
+    ) -> datafusion::common::Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(args)?;
+        let cids = as_binary_array(&args[0])?;
+        let mut parts = Int32Builder::with_capacity(number_rows);
+        for cid in cids {
+            if let Some(cid) = cid {
+                parts.append_value(cid[cid.len() - 1] as i32);
+            } else {
+                parts.append_null()
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(parts.finish())))
+    }
+}

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod aggregator;
 mod cache_table;
+pub mod cid_part;
 pub mod cid_string;
 pub mod concluder;
 mod config;

--- a/pipeline/src/schemas.rs
+++ b/pipeline/src/schemas.rs
@@ -5,6 +5,7 @@ use datafusion::arrow::datatypes::{DataType, Field, Fields, SchemaBuilder, Schem
 
 static CONCLUSION_EVENTS: OnceLock<SchemaRef> = OnceLock::new();
 static EVENT_STATES: OnceLock<SchemaRef> = OnceLock::new();
+static EVENT_STATES_PARTITIONED: OnceLock<SchemaRef> = OnceLock::new();
 
 /// The `conclusion_events` table contains the raw events annotated with conclusions about each
 /// event.
@@ -62,12 +63,12 @@ pub fn conclusion_events() -> SchemaRef {
 pub fn event_states() -> SchemaRef {
     Arc::clone(EVENT_STATES.get_or_init(|| {
         Arc::new(
-            SchemaBuilder::from(&Fields::from([
-                Arc::new(Field::new("index", DataType::UInt64, false)),
-                Arc::new(Field::new("stream_cid", DataType::Binary, false)),
-                Arc::new(Field::new("stream_type", DataType::UInt8, false)),
-                Arc::new(Field::new("controller", DataType::Utf8, false)),
-                Arc::new(Field::new(
+            SchemaBuilder::from(&Fields::from(vec![
+                Field::new("index", DataType::UInt64, false),
+                Field::new("stream_cid", DataType::Binary, false),
+                Field::new("stream_type", DataType::UInt8, false),
+                Field::new("controller", DataType::Utf8, false),
+                Field::new(
                     "dimensions",
                     DataType::Map(
                         Field::new(
@@ -92,11 +93,34 @@ pub fn event_states() -> SchemaRef {
                         false,
                     ),
                     true,
-                )),
-                Arc::new(Field::new("event_cid", DataType::Binary, false)),
-                Arc::new(Field::new("event_type", DataType::UInt8, false)),
-                Arc::new(Field::new("data", DataType::Binary, true)),
+                ),
+                Field::new("event_cid", DataType::Binary, false),
+                Field::new("event_type", DataType::UInt8, false),
+                Field::new("data", DataType::Binary, true),
             ]))
+            .finish(),
+        )
+    }))
+}
+
+/// The `event_states` table contains the aggregated state for each event for each stream.
+/// This schema includes the partition columns of the table.
+pub fn event_states_partitioned() -> SchemaRef {
+    Arc::clone(EVENT_STATES_PARTITIONED.get_or_init(|| {
+        Arc::new(
+            arrow_schema::SchemaBuilder::from(&arrow_schema::Fields::from(
+                // Append partition fields to the end of the unpartitioned schema
+                event_states()
+                    .fields()
+                    .into_iter()
+                    .cloned()
+                    .chain(vec![Arc::new(arrow_schema::Field::new(
+                        "event_cid_partition",
+                        DataType::Int32,
+                        false,
+                    ))])
+                    .collect::<Vec<_>>(),
+            ))
             .finish(),
         )
     }))


### PR DESCRIPTION
BREAKING CHANGE:

This change is breaking to the structure of the event_states table in object store. With this change any existing data in the event_states object store is invalidated. On the next startup the data will be recomputed from the conclusion_events table. It is recommended once a successful upgrade is complete to delete the old parquet files for the event_states table from object store, as that data will no longer be read in its current form. The old parquet files will be in the `ceramic/v0/event_states/` directory. The new parquet files are in `ceramic/rev1/event_states/` directory.

This change achieve two main improvements:

1. By partitioning the event_states table by the event_cid the join to aggregate a new event with its previous event is much more efficient.
2. In some cases previously the join would fail as it was a very large NestedLoopJoin. A nested loop join would need to compute a cross product of left and right sides. Given the batch size is 10K rows that is a output product of 100M rows. This large structure would either consume huge amounts of memory or simply fail if there was not enough memory. With this change we now join on the partition columns and can use a more efficient join implementation which avoids the failure.