### PR TITLE
chore: version v0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.49.0] - 2025-02-07
+
+### 🚀 Features
+
+- Adds stream_id_string udf ([#653](https://github.com/ceramicnetwork/rust-ceramic/issues/653))
+- Add dimension_extract udf ([#654](https://github.com/ceramicnetwork/rust-ceramic/issues/654))
+- Adds output format options to query command ([#659](https://github.com/ceramicnetwork/rust-ceramic/issues/659))
+- [**breaking**] Partition event states by event cid ([#658](https://github.com/ceramicnetwork/rust-ceramic/issues/658))
+
+### 🐛 Bug Fixes
+
+- Use invoke_batch on UDFs as invoke is deprecated ([#652](https://github.com/ceramicnetwork/rust-ceramic/issues/652))
+- Adds batching logic to conclusion-feed-table ([#656](https://github.com/ceramicnetwork/rust-ceramic/issues/656))
+
+### 🚜 Refactor
+
+- More efficient list udf impls ([#657](https://github.com/ceramicnetwork/rust-ceramic/issues/657))
+
 ## [0.48.0] - 2025-01-28
 
 ### 🚀 Features
@@ -25,6 +43,7 @@ All notable changes to this project will be documented in this file.
 
 - Make clippy happy about lifetimes ([#642](https://github.com/ceramicnetwork/rust-ceramic/issues/642))
 - Fix event-svc bench ([#639](https://github.com/ceramicnetwork/rust-ceramic/issues/639))
+- Version v0.48.0 ([#650](https://github.com/ceramicnetwork/rust-ceramic/issues/650))
 
 ## [0.47.3] - 2025-01-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2058,7 +2058,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "ceramic-actor-macros",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor-macros"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "ceramic-actor",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2275,7 +2275,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2382,7 +2382,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2446,7 +2446,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "built",
  "serde",
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2612,7 +2612,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5806,7 +5806,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5824,7 +5824,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -5839,7 +5839,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9229,7 +9229,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10262,7 +10262,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shutdown"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,7 +250,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.48.0"
+version = "0.49.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.48.0"
+version = "0.49.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.48.0
-- Build date: 2025-01-28T19:21:11.089895361Z[Etc/UTC]
+- API version: 0.49.0
+- Build date: 2025-02-07T15:39:12.809620321Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.48.0
+  version: 0.49.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.48.0";
+pub const API_VERSION: &str = "0.49.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.48.0
+  version: 0.49.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.48.0"
+version = "0.49.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.48.0
-- Build date: 2025-01-28T19:21:13.750804233Z[Etc/UTC]
+- API version: 0.49.0
+- Build date: 2025-02-07T15:39:15.493123042Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.48.0
+  version: 0.49.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.48.0";
+pub const API_VERSION: &str = "0.49.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.48.0
+  version: 0.49.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.49.0] - 2025-02-07

### 🚀 Features

- Adds stream_id_string udf ([#653](https://github.com/ceramicnetwork/rust-ceramic/issues/653))
- Add dimension_extract udf ([#654](https://github.com/ceramicnetwork/rust-ceramic/issues/654))
- Adds output format options to query command ([#659](https://github.com/ceramicnetwork/rust-ceramic/issues/659))
- [**breaking**] Partition event states by event cid ([#658](https://github.com/ceramicnetwork/rust-ceramic/issues/658))

### 🐛 Bug Fixes

- Use invoke_batch on UDFs as invoke is deprecated ([#652](https://github.com/ceramicnetwork/rust-ceramic/issues/652))
- Adds batching logic to conclusion-feed-table ([#656](https://github.com/ceramicnetwork/rust-ceramic/issues/656))

### 🚜 Refactor

- More efficient list udf impls ([#657](https://github.com/ceramicnetwork/rust-ceramic/issues/657))