### PR TITLE
feat: add/update UDFs for the ceramic pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2635,6 +2635,7 @@ dependencies = [
  "multibase 0.9.1",
  "object_store",
  "parking_lot",
+ "paste",
  "prometheus-client",
  "serde",
  "serde_json",

--- a/pipeline/Cargo.toml
+++ b/pipeline/Cargo.toml
@@ -42,6 +42,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
+paste.workspace = true
 
 [dev-dependencies]
 test-log.workspace = true

--- a/pipeline/src/cid_string.rs
+++ b/pipeline/src/cid_string.rs
@@ -14,6 +14,21 @@ use datafusion::{
     logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, TypeSignature, Volatility},
 };
 
+make_udf_expr_and_func!(
+    CidString,
+    cid_string,
+    cids,
+    "transforms a binary cid to utf8 string.",
+    cid_string_udf
+);
+make_udf_expr_and_func!(
+    CidStringList,
+    array_cid_string,
+    cids,
+    "transforms a list of binary cids to a list of utf8 strings.",
+    cid_string_list_udf
+);
+
 // Length of a typical Ceramic CID as a UTF8 string in bytes.
 const CID_STRING_BYTES: usize = 60;
 

--- a/pipeline/src/dimension_extract.rs
+++ b/pipeline/src/dimension_extract.rs
@@ -10,6 +10,14 @@ use datafusion::{
     scalar::ScalarValue,
 };
 
+make_udf_expr_and_func!(
+    DimensionExtract,
+    dimension_extract,
+    dimensions_map dimension,
+    "extracts the named dimensions from a dimensions map.",
+    dimension_extract_udf
+);
+
 /// ScalarUDF to convert a binary CID into a string for easier inspection.
 #[derive(Debug)]
 pub struct DimensionExtract {

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -6,6 +6,9 @@
 //! tables can be exposed via a FlightSQL server.
 #![warn(missing_docs)]
 
+#[macro_use]
+pub(crate) mod macros;
+
 pub mod aggregator;
 mod cache_table;
 pub mod cid_part;
@@ -17,6 +20,7 @@ mod metrics;
 pub mod schemas;
 mod since;
 pub mod stream_id_string;
+pub mod stream_id_to_cid;
 #[cfg(test)]
 mod tests;
 

--- a/pipeline/src/macros.rs
+++ b/pipeline/src/macros.rs
@@ -1,0 +1,111 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This file is originally from https://docs.rs/datafusion-functions-nested/43.0.0/src/datafusion_functions_nested/macros.rs.html
+// It is copied here as we follow the same pattern howerver the macro is not public.
+// It has been modified to use imports from the datafusion crate directly.
+
+/// Creates external API functions for an array UDF. Specifically, creates
+///
+/// 1. Single `ScalarUDF` instance
+///
+/// Creates a singleton `ScalarUDF` of the `$UDF` function named `STATIC_$(UDF)` and a
+/// function named `$SCALAR_UDF_FUNC` which returns that function named `STATIC_$(UDF)`.
+///
+/// This is used to ensure creating the list of `ScalarUDF` only happens once.
+///
+/// # 2. `expr_fn` style function
+///
+/// These are functions that create an `Expr` that invokes the UDF, used
+/// primarily to programmatically create expressions.
+///
+/// For example:
+/// ```text
+/// pub fn array_to_string(delimiter: Expr) -> Expr {
+/// ...
+/// }
+/// ```
+/// # Arguments
+/// * `UDF`: name of the [`ScalarUDFImpl`]
+/// * `EXPR_FN`: name of the expr_fn function to be created
+/// * `arg`: 0 or more named arguments for the function
+/// * `DOC`: documentation string for the function
+/// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`
+///
+/// [`ScalarUDFImpl`]: datafusion_expr::ScalarUDFImpl
+macro_rules! make_udf_expr_and_func {
+    ($UDF:ty, $EXPR_FN:ident, $($arg:ident)*, $DOC:expr , $SCALAR_UDF_FN:ident) => {
+        paste::paste! {
+            // "fluent expr_fn" style function
+            #[doc = $DOC]
+            pub fn $EXPR_FN($($arg: datafusion::prelude::Expr),*) -> datafusion::prelude::Expr {
+                datafusion::prelude::Expr::ScalarFunction(datafusion::logical_expr::expr::ScalarFunction::new_udf(
+                    $SCALAR_UDF_FN(),
+                    vec![$($arg),*],
+                ))
+            }
+            create_func!($UDF, $SCALAR_UDF_FN);
+        }
+    };
+    ($UDF:ty, $EXPR_FN:ident, $DOC:expr , $SCALAR_UDF_FN:ident) => {
+        paste::paste! {
+            // "fluent expr_fn" style function
+            #[doc = $DOC]
+            pub fn $EXPR_FN(arg: Vec<datafusion_expr::Expr>) -> datafusion_expr::Expr {
+                datafusion_expr::Expr::ScalarFunction(datafusion_expr::expr::ScalarFunction::new_udf(
+                    $SCALAR_UDF_FN(),
+                    arg,
+                ))
+            }
+            create_func!($UDF, $SCALAR_UDF_FN);
+        }
+    };
+}
+
+/// Creates a singleton `ScalarUDF` of the `$UDF` function named `STATIC_$(UDF)` and a
+/// function named `$SCALAR_UDF_FUNC` which returns that function named `STATIC_$(UDF)`.
+///
+/// This is used to ensure creating the list of `ScalarUDF` only happens once.
+///
+/// # Arguments
+/// * `UDF`: name of the [`ScalarUDFImpl`]
+/// * `SCALAR_UDF_FUNC`: name of the function to create (just) the `ScalarUDF`
+///
+/// [`ScalarUDFImpl`]: datafusion_expr::ScalarUDFImpl
+macro_rules! create_func {
+    ($UDF:ty, $SCALAR_UDF_FN:ident) => {
+        paste::paste! {
+            /// Singleton instance of [`$UDF`], ensures the UDF is only created once
+            /// named STATIC_$(UDF). For example `STATIC_ArrayToString`
+            #[allow(non_upper_case_globals)]
+            static [< STATIC_ $UDF >]: std::sync::OnceLock<std::sync::Arc<datafusion::logical_expr::ScalarUDF>> =
+                std::sync::OnceLock::new();
+
+            #[doc = concat!("ScalarFunction that returns a [`ScalarUDF`](datafusion_expr::ScalarUDF) for ")]
+            #[doc = stringify!($UDF)]
+            pub fn $SCALAR_UDF_FN() -> std::sync::Arc<datafusion::logical_expr::ScalarUDF> {
+                [< STATIC_ $UDF >]
+                    .get_or_init(|| {
+                        std::sync::Arc::new(datafusion::logical_expr::ScalarUDF::new_from_impl(
+                            <$UDF>::new(),
+                        ))
+                    })
+                    .clone()
+            }
+        }
+    };
+}

--- a/pipeline/src/stream_id_to_cid.rs
+++ b/pipeline/src/stream_id_to_cid.rs
@@ -1,0 +1,286 @@
+//! Provides a scalar udf implementation that converts StreamId bytes to Cid bytes dropping the
+//! stream type.
+
+use std::{any::Any, sync::Arc};
+
+use arrow::{
+    array::{AsArray as _, BinaryBuilder, GenericByteArray},
+    datatypes::GenericBinaryType,
+};
+use ceramic_core::StreamId;
+use datafusion::{
+    arrow::datatypes::DataType,
+    common::{cast::as_binary_array, exec_datafusion_err},
+    logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, TypeSignature, Volatility},
+};
+
+make_udf_expr_and_func!(
+    StreamIdToCid,
+    stream_id_to_cid,
+    stream_ids,
+    "transforms a binary stream id to binary cid dropping the stream type.",
+    stream_id_to_cid_udf
+);
+
+/// ScalarUDF to convert a binary StreamId into a string for easier inspection.
+#[derive(Debug)]
+pub struct StreamIdToCid {
+    signature: Signature,
+}
+
+impl Default for StreamIdToCid {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// Number of bytes in a typical Ceramic CID
+const CID_BYTES: usize = 36;
+
+impl StreamIdToCid {
+    /// Construct new instance
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![DataType::Binary]),
+                    // Enumerate all possible dictionary key types.
+                    // We handle dictionary types explicitly because we know that we are a 1:1
+                    // transformation and can preserve the dictionary encoding.
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int8),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int16),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int32),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::Int64),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt8),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt16),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt32),
+                        Box::new(DataType::Binary),
+                    )]),
+                    TypeSignature::Exact(vec![DataType::Dictionary(
+                        Box::new(DataType::UInt64),
+                        Box::new(DataType::Binary),
+                    )]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+    fn map_ids(
+        &self,
+        stream_ids: &GenericByteArray<GenericBinaryType<i32>>,
+        number_rows: usize,
+    ) -> datafusion::common::Result<GenericByteArray<GenericBinaryType<i32>>> {
+        let mut cids = BinaryBuilder::with_capacity(number_rows, CID_BYTES * number_rows);
+        for stream_id in stream_ids {
+            if let Some(stream_id) = stream_id {
+                cids.append_value(
+                    StreamId::try_from(stream_id)
+                        .map_err(|err| exec_datafusion_err!("Error {err}"))?
+                        .cid
+                        .to_bytes(),
+                );
+            } else {
+                cids.append_null()
+            }
+        }
+        Ok(cids.finish())
+    }
+}
+
+impl ScalarUDFImpl for StreamIdToCid {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn name(&self) -> &str {
+        "stream_id_string"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, args: &[DataType]) -> datafusion::common::Result<DataType> {
+        if let DataType::Dictionary(key, _value) = &args[0] {
+            Ok(DataType::Dictionary(
+                key.to_owned(),
+                Box::new(DataType::Binary),
+            ))
+        } else {
+            Ok(DataType::Binary)
+        }
+    }
+    fn invoke_batch(
+        &self,
+        args: &[ColumnarValue],
+        number_rows: usize,
+    ) -> datafusion::common::Result<ColumnarValue> {
+        let args = ColumnarValue::values_to_arrays(args)?;
+
+        if let Some(dict) = args[0].as_any_dictionary_opt() {
+            let stream_ids = as_binary_array(dict.values())?;
+            let ids = self.map_ids(stream_ids, number_rows)?;
+            Ok(ColumnarValue::Array(dict.with_values(Arc::new(ids))))
+        } else {
+            let stream_ids = as_binary_array(&args[0])?;
+            let ids = self.map_ids(stream_ids, number_rows)?;
+            Ok(ColumnarValue::Array(Arc::new(ids)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{str::FromStr as _, sync::Arc};
+
+    use arrow::{
+        array::{ArrayRef, BinaryDictionaryBuilder},
+        datatypes::Int32Type,
+        util::pretty::pretty_format_batches,
+    };
+    use arrow_schema::DataType;
+    use ceramic_core::{StreamId, StreamIdType};
+    use cid::Cid;
+    use datafusion::{
+        arrow::array::{BinaryBuilder, StructArray},
+        prelude::{cast, col, SessionContext},
+    };
+    use expect_test::expect;
+    use test_log::test;
+
+    use crate::cid_string::cid_string;
+
+    #[test(tokio::test)]
+    async fn stream_id_to_cid() -> anyhow::Result<()> {
+        let mut stream_ids = BinaryBuilder::new();
+        stream_ids.append_value(
+            StreamId {
+                r#type: StreamIdType::Model,
+                cid: Cid::from_str("baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u")?,
+            }
+            .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId {
+                r#type: StreamIdType::Model,
+                cid: Cid::from_str("baeabeigafqyw7xmnk2nzh3d6bp5q5ba6rdnwg4kf6qn3z5vjeyqdvjb5w4")?,
+            }
+            .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId {
+                r#type: StreamIdType::Model,
+                cid: Cid::from_str("baeabeibznwjbtkcon2waqbplr6tn5acuijknyhvwvgk2v3wpkd3zwyfmxi")?,
+            }
+            .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId {
+                r#type: StreamIdType::Model,
+                cid: Cid::from_str("baeabeibyadj7ljmkn7jk3inxoxw2quvbrdofygq3qsxgb4bro7yqbd522e")?,
+            }
+            .to_vec(),
+        );
+        stream_ids.append_value(
+            StreamId {
+                r#type: StreamIdType::Model,
+                cid: Cid::from_str("baeabeicpx4fgpnkizilh5j4ktex7lqrdduirxcw3ebrewicxhytqmmelqi")?,
+            }
+            .to_vec(),
+        );
+        let batch = StructArray::try_from(vec![(
+            "stream_id",
+            Arc::new(stream_ids.finish()) as ArrayRef,
+        )])?;
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![cid_string(super::stream_id_to_cid(col("stream_id")))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +-------------------------------------------------------------+
+            | cid_string(stream_id_string(?table?.stream_id))             |
+            +-------------------------------------------------------------+
+            | baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u |
+            | baeabeigafqyw7xmnk2nzh3d6bp5q5ba6rdnwg4kf6qn3z5vjeyqdvjb5w4 |
+            | baeabeibznwjbtkcon2waqbplr6tn5acuijknyhvwvgk2v3wpkd3zwyfmxi |
+            | baeabeibyadj7ljmkn7jk3inxoxw2quvbrdofygq3qsxgb4bro7yqbd522e |
+            | baeabeicpx4fgpnkizilh5j4ktex7lqrdduirxcw3ebrewicxhytqmmelqi |
+            +-------------------------------------------------------------+"#]]
+        .assert_eq(&output.to_string());
+        Ok(())
+    }
+    #[test(tokio::test)]
+    async fn stream_id_to_cid_dict() -> anyhow::Result<()> {
+        let mut stream_ids = BinaryDictionaryBuilder::<Int32Type>::new();
+        let q3u = StreamId {
+            r#type: StreamIdType::Model,
+            cid: Cid::from_str("baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u")?,
+        }
+        .to_vec();
+        let lqi = StreamId {
+            r#type: StreamIdType::Model,
+            cid: Cid::from_str("baeabeicpx4fgpnkizilh5j4ktex7lqrdduirxcw3ebrewicxhytqmmelqi")?,
+        }
+        .to_vec();
+        let mxi = StreamId {
+            r#type: StreamIdType::Model,
+            cid: Cid::from_str("baeabeibznwjbtkcon2waqbplr6tn5acuijknyhvwvgk2v3wpkd3zwyfmxi")?,
+        }
+        .to_vec();
+
+        stream_ids.append_value(q3u.clone());
+        stream_ids.append_value(lqi.clone());
+        stream_ids.append_value(lqi);
+        stream_ids.append_value(mxi);
+        stream_ids.append_value(q3u.clone());
+        stream_ids.append_value(q3u);
+
+        let batch = StructArray::try_from(vec![(
+            "stream_id",
+            Arc::new(stream_ids.finish()) as ArrayRef,
+        )])?;
+        let ctx = SessionContext::new();
+        let output = ctx
+            .read_batch(batch.into())?
+            .select(vec![cid_string(cast(
+                super::stream_id_to_cid(col("stream_id")),
+                DataType::Binary,
+            ))])?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&output)?;
+        expect![[r#"
+            +-------------------------------------------------------------+
+            | cid_string(stream_id_string(?table?.stream_id))             |
+            +-------------------------------------------------------------+
+            | baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u |
+            | baeabeicpx4fgpnkizilh5j4ktex7lqrdduirxcw3ebrewicxhytqmmelqi |
+            | baeabeicpx4fgpnkizilh5j4ktex7lqrdduirxcw3ebrewicxhytqmmelqi |
+            | baeabeibznwjbtkcon2waqbplr6tn5acuijknyhvwvgk2v3wpkd3zwyfmxi |
+            | baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u |
+            | baeabeiesm6etvlv3hwg7qamyqcqz2yzd3nrmkxjdsyn3nabdmmnvd3xq3u |
+            +-------------------------------------------------------------+"#]]
+        .assert_eq(&output.to_string());
+        Ok(())
+    }
+}


### PR DESCRIPTION
These UDFs do simple transformations on data. These are all used as part of schema validation. They are added separately to keep the set of changes smaller.