### PR TITLE
chore: version v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.53.0] - 2025-03-10
+
+### 🚀 Features
+
+- Make ceramic-sdk part of the repo, promote flight sql and aggregator ([#669](https://github.com/ceramicnetwork/rust-ceramic/issues/669))
+
+### ⚙️ Miscellaneous Tasks
+
+- Migrates ceramic-tests to this repo ([#668](https://github.com/ceramicnetwork/rust-ceramic/issues/668))
+
 ## [0.52.0] - 2025-02-24
 
 ### 🚀 Features
 
 - Schema validation ([#663](https://github.com/ceramicnetwork/rust-ceramic/issues/663))
+
+### ⚙️ Miscellaneous Tasks
+
+- Version v0.52.0 ([#667](https://github.com/ceramicnetwork/rust-ceramic/issues/667))
 
 ## [0.51.0] - 2025-02-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "async-trait",
  "ceramic-actor-macros",
@@ -2112,7 +2112,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor-macros"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "async-trait",
  "ceramic-actor",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2149,7 +2149,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2252,7 +2252,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2288,7 +2288,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2314,7 +2314,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2425,7 +2425,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2489,7 +2489,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "built",
  "serde",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2581,7 +2581,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2706,7 +2706,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6134,7 +6134,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -6149,7 +6149,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9711,7 +9711,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10823,7 +10823,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shutdown"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -252,7 +252,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.52.0"
+version = "0.53.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.52.0
-- Build date: 2025-02-24T18:07:18.331130859Z[Etc/UTC]
+- API version: 0.53.0
+- Build date: 2025-03-10T18:52:11.525050960Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.52.0
+  version: 0.53.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.52.0";
+pub const API_VERSION: &str = "0.53.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.52.0
+  version: 0.53.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.52.0"
+version = "0.53.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.52.0
-- Build date: 2025-02-24T18:07:20.918982326Z[Etc/UTC]
+- API version: 0.53.0
+- Build date: 2025-03-10T18:52:14.196569655Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.52.0
+  version: 0.53.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.52.0";
+pub const API_VERSION: &str = "0.53.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.52.0
+  version: 0.53.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.53.0] - 2025-03-10

### 🚀 Features

- Make ceramic-sdk part of the repo, promote flight sql and aggregator ([#669](https://github.com/ceramicnetwork/rust-ceramic/issues/669))

### ⚙️ Miscellaneous Tasks

- Migrates ceramic-tests to this repo ([#668](https://github.com/ceramicnetwork/rust-ceramic/issues/668))