### PR TITLE
chore: use different gnosis rpc url

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -127,8 +127,8 @@ impl Network {
                 anyhow::bail!("no Ethereum RPC URLs specified for Mainnet")
             }
             Network::TestnetClay => {
-                info!("no Ethereum RPC URLs specified for Clay Testnet, defaulting to https://rpc.gnosis.gateway.fm/");
-                Ok(vec!["https://rpc.gnosis.gateway.fm/".to_string()])
+                info!("no Ethereum RPC URLs specified for Clay Testnet, defaulting to https://gnosis-mainnet.public.blastapi.io");
+                Ok(vec!["https://gnosis-mainnet.public.blastapi.io".to_string()])
             }
             Network::DevUnstable => {
                 info!("no Ethereum RPC URLs specified for dev-unstable network, defaulting to https://ethereum-sepolia-rpc.publicnode.com");


### PR DESCRIPTION
Of the ones found on https://docs.gnosischain.com/tools/RPC%20Providers/ this is the only one that doesn't error when looking up transactions by hash. All the other would occasionally report that the transaction was not found causing sync to fail.