### PR TITLE
Improved docs and logging for `migrations from-ipfs`

### DIFF
--- a/one/src/daemon.rs
+++ b/one/src/daemon.rs
@@ -240,6 +240,8 @@ pub struct DaemonOpts {
     anchor_poll_retry_count: u64,
 
     /// Ethereum RPC URLs used for time events validation. Required when connecting to mainnet and uses fallback URLs if not specified for other networks.
+    /// 
+    /// Note: only the first valid RPC URL will be used by the time event validator
     #[arg(
         long,
         use_value_delimiter = true,

--- a/one/src/migrations.rs
+++ b/one/src/migrations.rs
@@ -13,7 +13,7 @@ use clap::{Args, Subcommand};
 use futures::{stream::BoxStream, StreamExt};
 use multihash_codetable::{Code, Multihash, MultihashDigest};
 use tokio::io::AsyncBufReadExt;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::{default_directory, DBOpts, Info, LogOpts};
 
@@ -66,13 +66,14 @@ pub struct FromIpfsOpts {
     #[command(flatten)]
     log_opts: LogOpts,
 
-    /// Path of file containing list of newline-delimited file paths to migrate.
+    /// Path of file containing list of newline-delimited paths to blocks to migrate. The paths must either be absolute,
+    /// or relative to the current directory where the migration command is run.
     ///
     /// See below for example usage when running a migration for a live IPFS node. Multiple migration runs using lists
     /// of files that have changed between runs is useful for incremental migrations. This method can also be used for
     /// a final migration after shutting down the IPFS node so that all inflight blocks are migrated to the new C1 node.
     ///
-    /// # Get list of files in sorted order
+    /// # Get list of absolute file paths to blocks, in sorted order
     ///
     /// find ~/.ipfs/blocks -type f | sort > first_run_files.txt
     ///
@@ -95,6 +96,8 @@ pub struct FromIpfsOpts {
     input_file_list_path: Option<PathBuf>,
 
     /// Offset within the input files to start from
+    ///
+    /// Note: this is useful for resuming a migration from a previous run that was interrupted.
     #[clap(
         long,
         short = 's',
@@ -109,6 +112,9 @@ pub struct FromIpfsOpts {
 
     /// Optional list of model stream ids. Only events from these models will be migrated.
     /// If the list is empty all events are migrated.
+    ///
+    /// Note: if filtering, you likely also want to include the metamodel stream id
+    /// (kh4q0ozorrgaq2mezktnrmdwleo1d), so the actual model streams are also included in the migration.
     #[clap(long, value_delimiter = ',', env = "CERAMIC_ONE_MODEL_FILTER")]
     model_filter: Vec<String>,
 
@@ -118,7 +124,10 @@ pub struct FromIpfsOpts {
     validate_signatures: bool,
 
     /// Whether to validate the chain of time events.
-    /// Events with invalid chains will be skipped and counted as errors.
+    ///
+    /// Events with proofs from invalid chains will be skipped and counted as errors.
+    /// For example if some blocks being imported were anchored against an inmemory
+    /// store or a different network than configured with the `--network` option.
     #[clap(long, env = "CERAMIC_ONE_VALIDATE_CHAINS")]
     validate_chain: bool,
 }
@@ -322,17 +331,26 @@ impl FSBlockStore {
 
 async fn block_from_path(block_path: PathBuf) -> Result<Option<(Cid, Vec<u8>)>> {
     if !block_path.is_file() {
+        if block_path.is_absolute() {
+            warn!(
+                path = %block_path.display(),
+                "block file not found, skipping");
+        } else {
+            warn!(
+                path = %block_path.display(),
+                "block file not found at relative path, skipping");
+        }
         return Ok(None);
     }
 
     let Ok((_base, hash_bytes)) =
         multibase::decode("B".to_string() + block_path.file_stem().unwrap().to_str().unwrap())
     else {
-        debug!(path = %block_path.display(), "block filename is not valid base32upper");
+        warn!(path = %block_path.display(), "block filename is not valid base32upper, skipping");
         return Ok(None);
     };
     let Ok(hash) = Multihash::from_bytes(&hash_bytes) else {
-        debug!(path = %block_path.display(), "block filename is not a valid multihash");
+        warn!(path = %block_path.display(), "block filename is not a valid multihash, skipping");
         return Ok(None);
     };
     let blob = tokio::fs::read(&block_path).await?;


### PR DESCRIPTION
Heya :wave: 

 I did a pass over the docs and logging to make it a bit easier to understand what's going on, after being confused more times than I care to admit with failing block imports (mostly related to incorrect paths in the `input_file_list` causing silent skips of the entire block set).

Took a swing at explaining some of the new validation options as well, LMK if something is factually incorrect!

Additionally, I got bitten by the fact that the `--ethereum_rpc_urls` flag/var seems to accept multiple endpoints, but in reality [ignores everything after the first valid one](https://github.com/ceramicnetwork/rust-ceramic/blob/main/event-svc/src/event/validator/time.rs#L46-L55). That's now made clear in the docs too :cupcake: 