### PR TITLE
chore: version v0.55.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.55.1] - 2025-06-17
+
+### 🐛 Bug Fixes
+
+- Fetch unvalidated time proofs for conclusion events ([#723](https://github.com/ceramicnetwork/rust-ceramic/issues/723))
+
 ## [0.55.0] - 2025-05-26
 
 ### 🚀 Features
@@ -30,6 +36,7 @@ All notable changes to this project will be documented in this file.
 - *(sdk)* Version v0.8.0 ([#711](https://github.com/ceramicnetwork/rust-ceramic/issues/711))
 - *(sdk)* Version v0.9.0 ([#712](https://github.com/ceramicnetwork/rust-ceramic/issues/712))
 - *(sdk)* Version v0.10.0 ([#720](https://github.com/ceramicnetwork/rust-ceramic/issues/720))
+- Version v0.55.0 ([#722](https://github.com/ceramicnetwork/rust-ceramic/issues/722))
 
 ## [0.5.0] - 2025-03-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "async-trait",
  "ceramic-actor-macros",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor-macros"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "async-trait",
  "ceramic-actor",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2176,7 +2176,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2316,7 +2316,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2469,7 +2469,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "built",
  "serde",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6108,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6166,7 +6166,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9781,7 +9781,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10896,7 +10896,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shutdown"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.55.0"
+version = "0.55.1"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.55.0"
+version = "0.55.1"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.55.0
-- Build date: 2025-05-26T16:30:54.625348079Z[Etc/UTC]
+- API version: 0.55.1
+- Build date: 2025-06-17T17:37:16.638855454Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.55.0
+  version: 0.55.1
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.55.0";
+pub const API_VERSION: &str = "0.55.1";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.55.0
+  version: 0.55.1
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.55.0"
+version = "0.55.1"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.55.0
-- Build date: 2025-05-26T16:30:57.234587214Z[Etc/UTC]
+- API version: 0.55.1
+- Build date: 2025-06-17T17:37:19.423107208Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.55.0
+  version: 0.55.1
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.55.0";
+pub const API_VERSION: &str = "0.55.1";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.55.0
+  version: 0.55.1
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.55.1] - 2025-06-17

### 🐛 Bug Fixes

- Fetch unvalidated time proofs for conclusion events ([#723](https://github.com/ceramicnetwork/rust-ceramic/issues/723))