### PR TITLE
feat: allow configuring daemon with extra interests

### DIFF
--- a/one/src/lib.rs
+++ b/one/src/lib.rs
@@ -8,6 +8,7 @@ mod metrics;
 mod migrations;
 mod network;
 mod query;
+mod startup;
 
 use anyhow::{anyhow, bail, Result};
 use ceramic_core::ssi::caip2::ChainId;

--- a/one/src/startup.rs
+++ b/one/src/startup.rs
@@ -1,0 +1,191 @@
+//! Startup utilities for the Ceramic One daemon.
+
+use anyhow::{anyhow, Result};
+use ceramic_api::InterestService as InterestServiceTrait;
+use ceramic_core::{EventId, Interest, NodeId, StreamId};
+use ceramic_interest_svc::InterestService;
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Process initial interests by registering them with the interest service
+pub async fn process_extra_interests(
+    extra_interests: &[String],
+    interest_svc: &Arc<InterestService>,
+    network: &ceramic_core::Network,
+    node_id: &NodeId,
+) -> Result<()> {
+    if extra_interests.is_empty() {
+        return Ok(());
+    }
+
+    info!("Processing {} extra interests", extra_interests.len());
+
+    for stream_id_str in extra_interests {
+        let stream_id_str = stream_id_str.trim();
+        if stream_id_str.is_empty() {
+            continue;
+        }
+
+        // Validate that the model stream ID is parseable
+        let _stream_id = StreamId::from_str(stream_id_str)
+            .map_err(|e| anyhow!("Invalid model ID '{}': {}", stream_id_str, e))?;
+
+        // Create an interest for the "model" separator key covering the full range for this stream
+        // This follows the same pattern as the API endpoint /ceramic/interests/model/{stream_id}
+        let stream_id_bytes = multibase::decode(stream_id_str)
+            .map_err(|e| anyhow!("Failed to decode stream ID '{}': {}", stream_id_str, e))?
+            .1;
+        let start = EventId::builder()
+            .with_network(network)
+            .with_sep("model", &stream_id_bytes)
+            .with_min_controller()
+            .with_min_init()
+            .with_min_event()
+            .build_fencepost();
+        let stop = EventId::builder()
+            .with_network(network)
+            .with_sep("model", &stream_id_bytes)
+            .with_max_controller()
+            .with_max_init()
+            .with_max_event()
+            .build_fencepost();
+
+        let interest = Interest::builder()
+            .with_sep_key("model")
+            .with_peer_id(&node_id.peer_id())
+            .with_range((start.as_slice(), stop.as_slice()))
+            .with_not_after(0)
+            .build();
+
+        match interest_svc.insert(interest).await {
+            Ok(was_inserted) => {
+                if was_inserted {
+                    info!(
+                        "Successfully registered extra interest for model: {}",
+                        stream_id_str
+                    );
+                } else {
+                    debug!(
+                        "Interest for model {} was already registered",
+                        stream_id_str
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to register initial interest for model {}: {}",
+                    stream_id_str, e
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ceramic_core::Network;
+    use ceramic_sql::sqlite::SqlitePool;
+    use recon::Store;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_process_extra_interests_empty() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        let interest_svc = Arc::new(InterestService::new(pool));
+        let network = Network::InMemory;
+        let node_key = ceramic_core::NodeKey::random();
+        let node_id = node_key.id();
+
+        // Test with empty interests
+        let result = process_extra_interests(&[], &interest_svc, &network, &node_id).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_process_extra_interests_invalid_stream_id() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        let interest_svc = Arc::new(InterestService::new(pool));
+        let network = Network::InMemory;
+        let node_key = ceramic_core::NodeKey::random();
+        let node_id = node_key.id();
+
+        // Invalid stream ID - tests daemon-specific stream ID parsing and error handling
+        let stream_ids = vec!["invalid-stream-id".to_string()];
+
+        let result = process_extra_interests(&stream_ids, &interest_svc, &network, &node_id).await;
+        assert!(result.is_err());
+
+        // Verify the error message contains information about the invalid stream ID
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("invalid-stream-id"));
+    }
+
+    #[tokio::test]
+    async fn test_process_extra_interests_mixed_valid_invalid() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        let interest_svc = Arc::new(InterestService::new(pool));
+        let network = Network::InMemory;
+        let node_key = ceramic_core::NodeKey::random();
+        let node_id = node_key.id();
+
+        // Mix of valid and invalid stream IDs - tests early failure behavior
+        let stream_ids = vec![
+            "k2t6wz4ylx0qr6v7dvbczbxqy7pqjb0879qx930c1e27gacg3r8sllonqt4xx9".to_string(), // Valid
+            "invalid-stream-id".to_string(),                                              // Invalid
+        ];
+
+        let result = process_extra_interests(&stream_ids, &interest_svc, &network, &node_id).await;
+        // Should fail on the first invalid ID
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_process_extra_interests_whitespace_handling() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        let interest_svc = Arc::new(InterestService::new(pool));
+        let network = Network::InMemory;
+        let node_key = ceramic_core::NodeKey::random();
+        let node_id = node_key.id();
+
+        // Test daemon-specific input sanitization logic
+        let stream_ids = vec![
+            "  k2t6wz4ylx0qr6v7dvbczbxqy7pqjb0879qx930c1e27gacg3r8sllonqt4xx9  ".to_string(), // Valid with whitespace
+            "".to_string(),    // Empty string
+            "   ".to_string(), // Only whitespace
+        ];
+
+        let result = process_extra_interests(&stream_ids, &interest_svc, &network, &node_id).await;
+
+        // Should succeed and handle whitespace correctly
+        assert!(result.is_ok());
+
+        let registered_interests = interest_svc.full_range().await.unwrap();
+        assert_eq!(registered_interests.count(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_process_extra_interests_multibase_decoding() {
+        let pool = SqlitePool::connect_in_memory().await.unwrap();
+        let interest_svc = Arc::new(InterestService::new(pool));
+        let network = Network::InMemory;
+        let node_key = ceramic_core::NodeKey::random();
+        let node_id = node_key.id();
+
+        // Test daemon-specific multibase decoding logic
+        let stream_ids = vec![
+            "k2t6wz4ylx0qr6v7dvbczbxqy7pqjb0879qx930c1e27gacg3r8sllonqt4xx9".to_string(), // Valid multibase-encoded stream ID
+        ];
+
+        let result = process_extra_interests(&stream_ids, &interest_svc, &network, &node_id).await;
+
+        // Should succeed with proper multibase decoding
+        assert!(result.is_ok());
+
+        let registered_interests = interest_svc.full_range().await.unwrap();
+        assert_eq!(registered_interests.count(), 1);
+    }
+}


### PR DESCRIPTION
This PR implements a new CLI flag `--extra-interests` (and envvar `CERAMIC_ONE_EXTRA_INTERESTS`) to automatically register node interests when starting the daemon, eliminating the need for manual API calls after startup.

# Changes

- New CLI argument `--extra-interests`, accepting comma-separated stream/model IDs
- New startup module `one/src/startup.rs` to orchestrate daemon configuration tasks tangential to the startup process
- Integration:
  - Uses the existing `InterestService`
  - Uses the same pattern as the `/ceramic/interests` API handler
  - Processes interests early in daemon startup, after services init but before P2P setup

# Safety & backward compatibility

- Optional flag with empty default
- Stream ID format and multibase decoding validation
- Descriptive errors for invalid inputs + handling of failures
- Logging for registration status and debugging
- Idempotent: Handles already-registered interests without errors

# Usage

## Flag
```bash
ceramic-one daemon --extra-interests model1,model2
```

## Envvar
```bash
export CERAMIC_ONE_EXTRA_INTERESTS="model1,model2"
ceramic-one daemon
```

## Tests

Test suite added to `one/src/startup.rs`, can be run with the C1 crate:
```bash
> cargo test --locked --release -p ceramic-one
[ build logs ]

running 8 tests
test http::test::expected_prom_cardinality_replacement ... ok
test http::test::should_not_replace_extra_parts ... ok
test http::test::should_not_replace_wrong_method ... ok
test startup::tests::test_process_extra_interests_invalid_stream_id ... ok
test startup::tests::test_process_extra_interests_empty ... ok
test startup::tests::test_process_extra_interests_multibase_decoding ... ok
test startup::tests::test_process_extra_interests_mixed_valid_invalid ... ok
test startup::tests::test_process_extra_interests_whitespace_handling ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

# Other notes
It seems to work, but I can't say I fully understand what's going on with the interest builder EventID fencepost ranges. Probably a good spot to focus a review :eyes: 

Closes #707 