### PR TITLE
fix: aggregator cache flush on shutdown

### DIFF
--- a/actor/src/lib.rs
+++ b/actor/src/lib.rs
@@ -61,6 +61,16 @@ pub trait Actor {
     }
 }
 
+/// Optional trait for actors that need to perform cleanup operations during shutdown.
+/// Only actors that need cleanup should implement this trait.
+#[async_trait]
+pub trait Shutdown {
+    /// Called when the actor is shutting down to allow for cleanup operations.
+    /// This method is called after all pending messages have been processed
+    /// but before the actor loop exits.
+    async fn shutdown(&mut self);
+}
+
 /// Wrapper of any T with its tracing span context.
 #[derive(Debug)]
 pub struct Traced<T> {

--- a/pipeline/src/aggregator/mock.rs
+++ b/pipeline/src/aggregator/mock.rs
@@ -1,6 +1,6 @@
 //! Provides a mock implmentation of the aggregator actor.
 use async_trait::async_trait;
-use ceramic_actor::{Actor, Handler, Message};
+use ceramic_actor::{Actor, Handler, Message, Shutdown};
 use mockall::mock;
 use prometheus_client::registry::Registry;
 
@@ -68,6 +68,13 @@ impl Actor for MockAggregator {
     type Envelope = AggregatorEnvelope;
 }
 impl AggregatorActor for MockAggregator {}
+
+#[async_trait]
+impl Shutdown for MockAggregator {
+    async fn shutdown(&mut self) {
+        // Mock implementation - no cleanup needed
+    }
+}
 
 impl MockAggregator {
     /// Spawn a mock aggregator actor.


### PR DESCRIPTION
Adds an optional shutdown actor trait that is used in the aggregator to flush the inmemory tables to the on-disk parquet storage, using the same logic as when it happens automatically when the inmemory tables goes over the 10k event limit.

Resolves #728 