### PR TITLE
feat: allow blocking bad peers & enforce backoff on inbound syncs

### DIFF
--- a/recon/src/libp2p/tests.rs
+++ b/recon/src/libp2p/tests.rs
@@ -137,6 +137,7 @@ macro_rules! setup_test {
             per_peer_sync_delay: std::time::Duration::from_millis(10),
             per_peer_sync_backoff: 100.0,
             per_peer_maximum_sync_delay: std::time::Duration::from_millis(1000),
+            blocked_peers: std::collections::HashSet::new(),
         };
         let swarm1 = Swarm::new_ephemeral(|_| {
             crate::libp2p::Behaviour::new(alice_peer, alice, config.clone())
@@ -351,6 +352,264 @@ fn into_peer_event(ev: crate::libp2p::Event) -> PeerEvent {
     match ev {
         super::Event::PeerEvent(p) => p,
     }
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn blocked_peer_connection_rejected() {
+    // First create Bob's swarm to get his PeerId
+    let bob_peer = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+    let bob = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+
+    let bob_config = crate::libp2p::Config {
+        per_peer_sync_delay: std::time::Duration::from_millis(10),
+        per_peer_sync_backoff: 100.0,
+        per_peer_maximum_sync_delay: std::time::Duration::from_millis(1000),
+        blocked_peers: std::collections::HashSet::new(),
+    };
+
+    let mut swarm2 =
+        Swarm::new_ephemeral(|_| crate::libp2p::Behaviour::new(bob_peer, bob, bob_config));
+
+    // Get Bob's peer ID and create Alice with Bob blocked
+    let bob_peer_id = *swarm2.local_peer_id();
+
+    let alice_peer = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+    let alice = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+
+    let mut blocked_peers = std::collections::HashSet::new();
+    blocked_peers.insert(bob_peer_id);
+
+    let alice_config = crate::libp2p::Config {
+        per_peer_sync_delay: std::time::Duration::from_millis(10),
+        per_peer_sync_backoff: 100.0,
+        per_peer_maximum_sync_delay: std::time::Duration::from_millis(1000),
+        blocked_peers,
+    };
+
+    let mut swarm1 =
+        Swarm::new_ephemeral(|_| crate::libp2p::Behaviour::new(alice_peer, alice, alice_config));
+
+    // Alice listens, Bob tries to connect
+    swarm1.listen().with_memory_addr_external().await;
+
+    // Bob connects to Alice - the connection should be denied
+    let alice_addr = swarm1.external_addresses().next().unwrap().clone();
+    swarm2.dial(alice_addr).unwrap();
+
+    // Drive the swarms - when Alice blocks Bob, the connection is established at the transport
+    // level but immediately closed when handle_established_inbound_connection returns ConnectionDenied.
+    // We verify this by checking that Bob sees ConnectionClosed right after ConnectionEstablished.
+    let result = tokio::time::timeout(std::time::Duration::from_millis(1000), async {
+        let mut connection_established = false;
+        loop {
+            tokio::select! {
+                _e = swarm1.next_swarm_event() => {
+                    // Alice processes events
+                }
+                e = swarm2.next_swarm_event() => {
+                    match e {
+                        libp2p::swarm::SwarmEvent::ConnectionEstablished { .. } => {
+                            connection_established = true;
+                        }
+                        libp2p::swarm::SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                            // Connection was closed - this happens when Alice blocks Bob
+                            if connection_established && peer_id == *swarm1.local_peer_id() {
+                                return true;
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    })
+    .await;
+
+    // Verify the connection was established then immediately closed (blocked peer behavior)
+    assert!(
+        result.is_ok() && result.unwrap(),
+        "Expected connection to be established then closed due to blocking"
+    );
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn inbound_sync_rejected_during_backoff() {
+    // This test verifies that after sync failures, the backoff mechanism prevents syncs.
+    // We set up a scenario where:
+    // 1. Bob's model store fails repeatedly, causing sync failures
+    // 2. Due to the large backoff multiplier (100x), model syncs are eventually skipped
+    // 3. We observe that by the third sync cycle, model syncs are skipped entirely
+    //
+    // The backoff progression is: 10ms -> 1000ms (after second fail)
+    // This means the second model sync still happens (backoff not yet active),
+    // but by the third cycle, the backoff has taken effect and model syncs are skipped.
+
+    let mut bob_model_store = BTreeStoreErrors::default();
+    bob_model_store.set_error(Error::new_transient(anyhow::anyhow!(
+        "transient error to trigger backoff"
+    )));
+
+    let (mut swarm1, mut swarm2) = setup_test!(
+        BTreeStoreErrors::default(),
+        BTreeStoreErrors::default(),
+        BTreeStoreErrors::default(),
+        bob_model_store,
+        BTreeStoreErrors::default(),
+        BTreeStoreErrors::default(),
+    );
+
+    swarm1.listen().with_memory_addr_external().await;
+    swarm2.connect(&mut swarm1).await;
+
+    // Drive through three sync cycles to observe backoff behavior
+    // Cycle 1 (events 0-3): Peer sync, Model sync (fails)
+    // Cycle 2 (events 4-7): Peer sync, Model sync (fails again, backoff increases)
+    // Cycle 3 (events 8-11): Peer sync, Peer sync (model skipped due to long backoff)
+    let (p1_events, p2_events): ([crate::libp2p::Event; 12], [crate::libp2p::Event; 12]) =
+        libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await;
+
+    // Verify Bob saw model sync failures in the first two cycles
+    assert_eq!(
+        into_peer_event(p2_events[3].clone()).status,
+        PeerStatus::Failed {
+            stream_set: StreamSet::Model
+        },
+        "Expected Bob to see first Model sync failure"
+    );
+    assert_eq!(
+        into_peer_event(p2_events[7].clone()).status,
+        PeerStatus::Failed {
+            stream_set: StreamSet::Model
+        },
+        "Expected Bob to see second Model sync failure"
+    );
+
+    // Verify that in the third cycle (events 8-11), only peer syncs occur
+    // because the model sync backoff (1000ms) now exceeds the peer sync delay (10ms)
+    let third_cycle_stream_sets: Vec<_> = p1_events[8..12]
+        .iter()
+        .map(|ev| {
+            let crate::libp2p::Event::PeerEvent(PeerEvent { status, .. }) = ev;
+            match status {
+                PeerStatus::Started { stream_set }
+                | PeerStatus::Synchronized { stream_set, .. }
+                | PeerStatus::Failed { stream_set } => Some(*stream_set),
+                _ => None,
+            }
+        })
+        .collect();
+
+    // In the third cycle, backoff has kicked in - we should see only peer syncs
+    assert!(
+        third_cycle_stream_sets
+            .iter()
+            .all(|s| *s == Some(StreamSet::Peer)),
+        "Expected only Peer syncs in third cycle after backoff kicked in, got: {:?}",
+        third_cycle_stream_sets
+    );
+}
+
+#[test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn backoff_registry_expires() {
+    // This test verifies that backoff entries expire and allow syncs to resume.
+    // We configure a short backoff (10ms) and verify:
+    // 1. Initial sync fails, triggering backoff
+    // 2. After backoff expires, model syncs resume (they may fail again, but they're attempted)
+    //
+    // The key observation is that with a short backoff, we should see model sync attempts
+    // resume after the backoff period, unlike in inbound_sync_rejected_during_backoff where
+    // the large backoff (1000ms) prevents model syncs from occurring.
+
+    let mut bob_model_store = BTreeStoreErrors::default();
+    bob_model_store.set_error(Error::new_transient(anyhow::anyhow!(
+        "transient error to trigger backoff"
+    )));
+
+    // Create swarms with very short backoff times so they expire quickly
+    let alice = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+    let alice_peer = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+    let bob_peer = Recon::new(
+        BTreeStoreErrors::default(),
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+    let bob = Recon::new(
+        bob_model_store,
+        FullInterests::default(),
+        Metrics::register(&mut Registry::default()),
+    );
+
+    // Use very short backoff (5ms * 2 = 10ms) that will expire before the next peer sync cycle
+    let config = crate::libp2p::Config {
+        per_peer_sync_delay: std::time::Duration::from_millis(5),
+        per_peer_sync_backoff: 2.0,
+        per_peer_maximum_sync_delay: std::time::Duration::from_millis(50),
+        blocked_peers: std::collections::HashSet::new(),
+    };
+
+    let mut swarm1 =
+        Swarm::new_ephemeral(|_| crate::libp2p::Behaviour::new(alice_peer, alice, config.clone()));
+    let mut swarm2 = Swarm::new_ephemeral(|_| crate::libp2p::Behaviour::new(bob_peer, bob, config));
+
+    swarm1.listen().with_memory_addr_external().await;
+    swarm2.connect(&mut swarm1).await;
+
+    // Drive through multiple sync cycles
+    // With short backoff (10ms), model syncs should resume after the backoff expires
+    // We expect to see model sync attempts (failures) interspersed with peer syncs
+    let (p1_events, _p2_events): ([crate::libp2p::Event; 12], [crate::libp2p::Event; 12]) =
+        libp2p_swarm_test::drive(&mut swarm1, &mut swarm2).await;
+
+    // Count how many model sync events we see
+    let model_sync_count = p1_events
+        .iter()
+        .filter(|ev| {
+            let crate::libp2p::Event::PeerEvent(PeerEvent { status, .. }) = ev;
+            matches!(
+                status,
+                PeerStatus::Started {
+                    stream_set: StreamSet::Model
+                } | PeerStatus::Synchronized {
+                    stream_set: StreamSet::Model,
+                    ..
+                } | PeerStatus::Failed {
+                    stream_set: StreamSet::Model
+                }
+            )
+        })
+        .count();
+
+    // With short backoff, we should see multiple model sync attempts (they fail but are retried)
+    // This proves the backoff expires and allows new sync attempts
+    assert!(
+        model_sync_count >= 2,
+        "Expected at least 2 model sync events (proving backoff expired and syncs resumed), got: {}",
+        model_sync_count
+    );
 }
 
 fn assert_in_sync(id: PeerId, events: [crate::libp2p::Event; 4]) {


### PR DESCRIPTION
# :warning:  WIP - early feedback requested

This PR adds two peer filtering features to the Recon libp2p behaviour:

1. **Permanent peer blocking** - Operators can configure a set of PeerIds to block entirely, if they are consistently syncing bad data
2. **Inbound sync rejection during backoff** - When we're backing off from a peer due to failures, we now also reject their incoming sync attempts. Something we keep seeing is our node correctly sets a `sync_delay` after failed inbound syncs, but it's only enforced on _outbound_ syncs. The result is that a bad peer will initiate a new inbound sync after 1 second, causing pretty severe log spam.

### How it works

**Peer blocking** is most straightforward - added `blocked_peers: HashSet<PeerId>` to Config, checked in `handle_established_inbound_connection`/`handle_established_outbound_connection`. Returns `ConnectionDenied` which closes the connection after transport establishment but before protocol negotiation.

**Inbound rejection** was trickier. The main challenge was that backoff state lived in the `peers` map which gets cleared on disconnect - so if a bad peer reconnected, the fresh handler wouldn't know to reject them.

Solution: Added a separate `backoff_registry: BTreeMap<PeerId, Instant>` that persists across disconnections. Handlers receive initial state via constructor, plus `UpdateRejectUntil` messages for updates during the connection lifetime. On `FullyNegotiatedInbound`, the handler checks if we're in backoff and drops the stream if so.

Expired entries are lazily cleaned in `poll()`. No need for timers since we don't care about exact timing that much.

### Tradeoffs

- **No protocol changes** - We just drop the inbound stream, so remote peers see a normal failure. They don't need updates.
- **Handler constructor + message pattern**
  - Could have done message-only, but that has a race condition window on reconnection (i.e., we might start a sync before the handler is informed that the peer should be blocked)
  - Constructor-only wouldn't handle backoff changes during a connection, and we don't disconnect a peer after a failed sync. Combined approach covers both needs, I think.
- **Separate registry vs reusing peers map** - The peers map has other lifecycle expectations and gets cleared on disconnect. Separate registry is cleaner even if slightly redundant. It'd probably be possible to use the backoff map for both in and outbound syncs, but that refactor seemed a bit riskier.

### New metrics

- `blocked_connection_count`
- `inbound_sync_rejected_count`

### Tests
Honestly not too sure about these tests tbh, it's a tricky pattern to test for.

- `blocked_peer_connection_rejected` - verifies connection is closed for blocked peers
- `inbound_sync_rejected_during_backoff` - verifies model syncs get skipped after backoff kicks in (third cycle with 100x multiplier)
- `backoff_registry_expires` - verifies syncs resume after short backoff expires