### PR TITLE
chore: version v0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.57.0] - 2025-11-26
+## [0.58.0] - 2025-12-08
+
+### 🚀 Features
+
+- *(anchor-evm)* Add CLI options for EVM self-anchoring ([#748](https://github.com/ceramicnetwork/rust-ceramic/issues/748))
+
+## [0.57.0] - 2025-11-28
 
 ### 🚀 Features
 
 - Add anchor-evm crate for EVM-based anchoring ([#742](https://github.com/ceramicnetwork/rust-ceramic/issues/742))
+
+### ⚙️ Miscellaneous Tasks
+
+- Version v0.57.0 ([#746](https://github.com/ceramicnetwork/rust-ceramic/issues/746))
 
 ## [0.56.2] - 2025-10-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-trait",
  "ceramic-actor-macros",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-actor-macros"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-trait",
  "ceramic-actor",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-evm"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-remote"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-anchor-service"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2273,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-api-server"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-car"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "cid 0.11.1",
  "futures",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2353,7 +2353,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-event-svc"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-flight"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-interest-svc"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2495,7 +2495,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-kubo-rpc-server"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metadata"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "built",
  "serde",
@@ -2567,7 +2567,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-metrics"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "console-subscriber",
  "lazy_static",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-one"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-p2p"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-peer-svc"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-pipeline"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-sql"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "sqlx",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "ceramic-validation"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -6174,7 +6174,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-bitswap"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-client"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -6232,7 +6232,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-rpc-types"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytes 1.7.2",
@@ -6247,7 +6247,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "cid 0.11.1",
  "multihash-codetable",
@@ -9847,7 +9847,7 @@ dependencies = [
 
 [[package]]
 name = "recon"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -10962,7 +10962,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shutdown"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "futures",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,7 @@ zeroize = "1.4"
 
 
 [workspace.package]
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 authors = [
     "Danny Browning <dbrowning@3box.io>",

--- a/api-server/Cargo.toml
+++ b/api-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-api-server"
-version = "0.57.0"
+version = "0.58.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Ceramic API for working with streams and events "
 license = "MIT"

--- a/api-server/README.md
+++ b/api-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.57.0
-- Build date: 2025-11-26T20:42:09.837612539Z[Etc/UTC]
+- API version: 0.58.0
+- Build date: 2025-12-08T21:21:04.734650742Z[Etc/UTC]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Ceramic API
-  version: 0.57.0
+  version: 0.58.0
 servers:
 - url: /ceramic
 paths:

--- a/api-server/src/lib.rs
+++ b/api-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/ceramic";
-pub const API_VERSION: &str = "0.57.0";
+pub const API_VERSION: &str = "0.58.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum ConfigNetworkGetResponse {

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
   description: >
     This is the Ceramic API for working with streams and events
-  version: 0.57.0
+  version: 0.58.0
   title: Ceramic API
   #license:
   #  name: Apache 2.0

--- a/kubo-rpc-server/Cargo.toml
+++ b/kubo-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ceramic-kubo-rpc-server"
-version = "0.57.0"
+version = "0.58.0"
 authors = ["OpenAPI Generator team and contributors"]
 description = "This is the Kubo RPC API for working with IPLD data on IPFS This API only defines a small subset of the official API. "
 license = "MIT"

--- a/kubo-rpc-server/README.md
+++ b/kubo-rpc-server/README.md
@@ -14,8 +14,8 @@ To see how to make this your own, look here:
 
 [README]((https://openapi-generator.tech))
 
-- API version: 0.57.0
-- Build date: 2025-11-26T20:42:12.498897767Z[Etc/UTC]
+- API version: 0.58.0
+- Build date: 2025-12-08T21:21:07.440026047Z[Etc/UTC]
 
 
 

--- a/kubo-rpc-server/api/openapi.yaml
+++ b/kubo-rpc-server/api/openapi.yaml
@@ -6,7 +6,7 @@ info:
     name: MIT
     url: https://mit-license.org/
   title: Kubo RPC API
-  version: 0.57.0
+  version: 0.58.0
 servers:
 - url: /api/v0
 paths:

--- a/kubo-rpc-server/src/lib.rs
+++ b/kubo-rpc-server/src/lib.rs
@@ -21,7 +21,7 @@ use swagger::{ApiError, ContextWrapper};
 type ServiceError = Box<dyn Error + Send + Sync + 'static>;
 
 pub const BASE_PATH: &str = "/api/v0";
-pub const API_VERSION: &str = "0.57.0";
+pub const API_VERSION: &str = "0.58.0";
 
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]

--- a/kubo-rpc/kubo-rpc.yaml
+++ b/kubo-rpc/kubo-rpc.yaml
@@ -3,7 +3,7 @@ info:
   description: >
     This is the Kubo RPC API for working with IPLD data on IPFS
     This API only defines a small subset of the official API.
-  version: 0.57.0
+  version: 0.58.0
   title: Kubo RPC API
   license:
     name: MIT


### PR DESCRIPTION
## [0.58.0] - 2025-12-08

### 🚀 Features

- *(anchor-evm)* Add CLI options for EVM self-anchoring ([#748](https://github.com/ceramicnetwork/rust-ceramic/issues/748))