### PR TITLE
Fix: Ensure events from model instances are returned in chronological order

### DIFF
--- a/api-server/README.md
+++ b/api-server/README.md
@@ -15,7 +15,7 @@ To see how to make this your own, look here:
 [README]((https://openapi-generator.tech))
 
 - API version: 0.58.0
-- Build date: 2025-12-08T21:21:04.734650742Z[Etc/UTC]
+- Build date: 2025-12-10T10:02:01.541355-06:00[America/Chicago]
 
 
 

--- a/api-server/api/openapi.yaml
+++ b/api-server/api/openapi.yaml
@@ -675,12 +675,16 @@ components:
       description: A Ceramic event as part of a Ceramic Stream. Contains both the
         root CID used to identify the Event as well as the Event payload data.
       example:
+        offset: 0
         data: data
         id: id
       properties:
         id:
           description: Multibase encoding of event root CID bytes.
           type: string
+        offset:
+          description: Numeric offset of the event (monotonic index) used for resuming.
+          type: integer
         data:
           description: Multibase encoding of event data.
           type: string
@@ -705,9 +709,11 @@ components:
       example:
         resumeToken: resumeToken
         events:
-        - data: data
+        - offset: 0
+          data: data
           id: id
-        - data: data
+        - offset: 0
+          data: data
           id: id
       properties:
         events:
@@ -728,9 +734,11 @@ components:
       example:
         resumeOffset: 0
         events:
-        - data: data
+        - offset: 0
+          data: data
           id: id
-        - data: data
+        - offset: 0
+          data: data
           id: id
         isComplete: true
       properties:

--- a/api-server/docs/Event.md
+++ b/api-server/docs/Event.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **id** | **String** | Multibase encoding of event root CID bytes. | 
+**offset** | **i32** | Numeric offset of the event (monotonic index) used for resuming. | [optional] [default to None]
 **data** | **String** | Multibase encoding of event data. | [optional] [default to None]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/api/ceramic.yaml
+++ b/api/ceramic.yaml
@@ -626,6 +626,9 @@ components:
         id:
           type: string
           description: Multibase encoding of event root CID bytes.
+        offset:
+          type: integer
+          description: Numeric offset of the event (monotonic index) used for resuming.
         data:
           type: string
           description: Multibase encoding of event data.

--- a/api/src/tests.rs
+++ b/api/src/tests.rs
@@ -764,7 +764,7 @@ async fn get_events_for_interest_range() {
     r: Success(EventsGet { events: [Event { id: "fce0105ff012616e0f0c1e987ef0f772afbe2c7f05c50102bc800", data: "" }], resume_offset: 1, is_complete: false })
             */
     let mock_interest = MockAccessInterestStoreTest::new();
-    let expected = BuildResponse::event(cid, None);
+    let expected = BuildResponse::event(cid, None, Some(1));
     let mut mock_event_store = MockEventStoreTest::new();
     mock_event_store
         .expect_range_with_values()

--- a/event-svc/src/store/sql/query.rs
+++ b/event-svc/src/store/sql/query.rs
@@ -79,6 +79,8 @@ impl EventQuery {
                 ORDER BY key.order_key, eb.idx;"#
     }
 
+    // No delivered-specific grouped query; use `value_blocks_by_order_key_many` for ranges
+
     /// Find event CIDs that have not yet been delivered to the client
     /// Useful after a restart, or if the task managing delivery has availability to try old events
     /// Requires binding two parameters:

--- a/sdk/packages/http-client/src/__generated__/api.ts
+++ b/sdk/packages/http-client/src/__generated__/api.ts
@@ -1237,6 +1237,10 @@ export interface components {
        * Multibase encoding of event data.
        */
       data?: string
+      /**
+       * Numeric offset of the event (monotonic index) used for resuming.
+       */
+      offset?: number
     }
     /**
      * A Ceramic Event Data Payload


### PR DESCRIPTION
Currently, querying events from a specific model instance via:

`/experimental/events/model/{modelStreamId}`

returns events ordered lexicographically by event ID, not by creation time. This behavior makes it difficult to fetch only the most recent events. For example, using resumeOffset does not reliably return the latest events because the last item in the response may not be the newest chronologically.

In a test scenario with 20 events, generating a 21st event resulted in it being inserted in the middle of the response. If an offset of 20 had been used, it would not have returned the most recent event (following image):
<img width="1380" height="576" alt="image" src="https://github.com/user-attachments/assets/5826a48f-0e11-4ed9-9f03-4fb7cfce34f3" />


Proposed change:

- Modify the API to return events sorted by creation timestamp rather than lexicographically by event ID.
- This ensures that fetching events in chronological order is straightforward and resumeOffset works as expected.

Benefits:

- Clients can reliably fetch the latest events without additional sorting.
- Improves usability and correctness of event queries for model instances.

This image shows the result of the changes, where using offset 3 is properly used returning only future events:
<img width="2682" height="1254" alt="image" src="https://github.com/user-attachments/assets/81306890-f92d-4c6f-b84e-594be39c35ee" />

This PR would fix the following error:
https://github.com/ceramicnetwork/rust-ceramic/issues/751
