### PR TITLE
fix: revert proof RPC autodiscovery removal

### DIFF
--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -275,6 +275,10 @@ impl EventValidator {
             }
         }
     }
+
+    pub fn time_event_validator(&self) -> &TimeEventValidator {
+        &self.time_event_validator
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#755 prematurely removed some fallback logic required for nodes to self-heal after failing to persist self-anchoring inclusion proofs. The relevant chunks in `discover_chain_proof` are reverted manually here, as they are mixed into a larger commit in the history.

Note: based on `fix/self-anchoring-stores-inclusion-proofs` / 0cfe53b0d78b6b462be21ab97c74ba14a2d8d6a2