### PR TITLE
fix: anchor EVM roots by multihash digest

### DIFF
--- a/anchor-evm/README.md
+++ b/anchor-evm/README.md
@@ -22,6 +22,7 @@ cargo test -p ceramic-anchor-evm
 
 Runs 15 tests including:
 - CID to bytes32 conversion (verified against JS implementation)
+- CID to bytes32 conversion for CIDs with variable-length varint prefixes
 - Transaction hash to CID (uses Keccak256 multihash + ETH_TX codec)
 - Proof building with correct parameter order
 - Configuration validation
@@ -258,6 +259,18 @@ interface IAnchorContract {
 ```
 
 The contract only needs a single function - the Rust implementation handles all proof construction from the transaction receipt.
+
+### `bytes32` Root Semantics
+
+The `anchorDagCbor(bytes32 root)` interface commits only the 32-byte multihash digest on-chain, not the
+entire encoded CID. Because of that:
+
+- Anchoring must extract the digest from the CID multihash directly instead of slicing fixed offsets from
+  the encoded CID bytes.
+- Validation should compare the committed multihash digest, since the chain does not authenticate the CID
+  wrapper bytes themselves.
+- Ceramic still constructs and exchanges canonical CIDs in proofs; the digest-based comparison is only to
+  match what the on-chain `f(bytes32)` proof format actually commits.
 
 ## Performance
 

--- a/anchor-evm/src/evm_transaction_manager.rs
+++ b/anchor-evm/src/evm_transaction_manager.rs
@@ -114,9 +114,11 @@ impl EvmTransactionManager {
 
     /// Convert a Ceramic CID to a 32-byte array for the contract.
     ///
-    /// Extracts the raw 32-byte hash digest from the CID's multihash.
-    /// This is codec-agnostic and works for both dag-cbor (4-byte prefix)
-    /// and dag-jose (5-byte prefix due to varint encoding of 0x85).
+    /// We must extract the raw multihash digest instead of slicing the encoded CID bytes.
+    /// The CID prefix is varint-encoded, so its length is not stable across codecs. For
+    /// example, dag-cbor roots such as `bafy...` often appear to have a 4-byte prefix,
+    /// while event CIDs such as `bagcq...` can have a 5-byte prefix. Slicing at a fixed
+    /// offset shifts the digest and produces invalid anchor transaction calldata.
     pub fn cid_to_bytes32(cid: &Cid) -> Result<FixedBytes<32>> {
         let digest = cid.hash().digest();
 
@@ -138,6 +140,14 @@ impl EvmTransactionManager {
         info!(
             "Anchoring root CID: {} on chain {}",
             root_cid, self.config.chain_id
+        );
+        info!(
+            target: "ceramic_anchor_debug",
+            root_cid = %root_cid,
+            root_codec = root_cid.codec(),
+            root_multihash_code = root_cid.hash().code(),
+            root_digest_hex = %hex::encode(root_cid.hash().digest()),
+            "preparing anchor transaction"
         );
 
         // Parse contract address
@@ -195,6 +205,12 @@ impl EvmTransactionManager {
 
         // Convert CID to bytes32 for contract call
         let root_bytes32 = Self::cid_to_bytes32(&root_cid)?;
+        info!(
+            target: "ceramic_anchor_debug",
+            root_cid = %root_cid,
+            calldata_root_hex = %hex::encode(root_bytes32.as_slice()),
+            "converted root cid to bytes32"
+        );
 
         // Retry loop
         let max_retries = self.config.retry_config.max_retries;
@@ -500,37 +516,18 @@ mod tests {
         );
     }
 
-    /// Verify dag-jose CIDs (5-byte prefix) produce the same bytes32 as dag-cbor CIDs
-    /// with the same hash. The old implementation used a fixed 4-byte skip which broke
-    /// for dag-jose (codec 0x85 requires 2 bytes as varint).
     #[test]
-    fn test_cid_to_bytes32_dag_jose_vs_dag_cbor() {
-        use multihash_codetable::{Code, MultihashDigest};
+    fn test_cid_to_bytes32_handles_varint_length_prefixes() {
+        let cid =
+            Cid::from_str("bagcqcera2c2tlks56xfpwgreos6quemzoy6ekfypsklysz5snllqscjlrbqa").unwrap();
+        let bytes32 = EvmTransactionManager::cid_to_bytes32(&cid).unwrap();
 
-        // Create a hash
-        let data = b"test data for hashing";
-        let multihash = Code::Sha2_256.digest(data);
-        let expected_digest = multihash.digest();
-
-        // Create dag-cbor CID (codec 0x71, 4-byte prefix)
-        let dag_cbor_cid = Cid::new_v1(0x71, multihash);
-        // Create dag-jose CID (codec 0x85, 5-byte prefix due to varint)
-        let dag_jose_cid = Cid::new_v1(0x85, multihash);
-
-        // Both should produce the same 32-byte output
-        let cbor_bytes32 = EvmTransactionManager::cid_to_bytes32(&dag_cbor_cid).unwrap();
-        let jose_bytes32 = EvmTransactionManager::cid_to_bytes32(&dag_jose_cid).unwrap();
+        let expected = "d0b535aa5df5cafb1a2474bd0a1199763c45170f92978967b26ad709092b8860";
+        let actual = hex::encode(bytes32.as_slice());
 
         assert_eq!(
-            cbor_bytes32, jose_bytes32,
-            "dag-cbor and dag-jose CIDs with same hash must produce same bytes32"
-        );
-
-        // And it should match the raw digest
-        assert_eq!(
-            cbor_bytes32.as_slice(),
-            expected_digest,
-            "bytes32 must equal the raw hash digest"
+            actual, expected,
+            "cid_to_bytes32 must use the multihash digest even when the CID prefix is not 4 bytes"
         );
     }
 

--- a/anchor-evm/src/proof_builder.rs
+++ b/anchor-evm/src/proof_builder.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Result};
 use ceramic_core::Cid;
 use ceramic_event::unvalidated::AnchorProof;
 use multihash_codetable::{Code, MultihashDigest};
+use tracing::info;
 
 /// Ethereum transaction codec for IPLD (from multicodec table)
 const ETH_TX_CODEC: u64 = 0x93;
@@ -23,6 +24,17 @@ impl ProofBuilder {
         let tx_hash_cid = Self::tx_hash_to_cid(&tx_hash)?;
         let chain_id_string = format!("eip155:{}", chain_id);
         let tx_type = "f(bytes32)".to_string();
+        info!(
+            target: "ceramic_anchor_debug",
+            chain_id = %chain_id_string,
+            tx_hash = %tx_hash,
+            tx_hash_cid = %tx_hash_cid,
+            root_cid = %root_cid,
+            root_codec = root_cid.codec(),
+            root_multihash_code = root_cid.hash().code(),
+            root_digest_hex = %hex::encode(root_cid.hash().digest()),
+            "building anchor proof"
+        );
 
         Ok(AnchorProof::new(
             chain_id_string,

--- a/anchor-remote/src/cas_remote.rs
+++ b/anchor-remote/src/cas_remote.rs
@@ -22,13 +22,6 @@ use ceramic_event::unvalidated::AnchorProof;
 pub const AGENT_VERSION: &str = concat!("ceramic-one/", env!("CARGO_PKG_VERSION"));
 
 #[derive(Serialize, Deserialize, Debug)]
-struct CasAuthPayload {
-    url: String,
-    nonce: String,
-    digest: String,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct CasAnchorRequest {
     stream_id: StreamId,

--- a/anchor-service/src/merkle_tree.rs
+++ b/anchor-service/src/merkle_tree.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Result};
 use ceramic_core::{Cid, SerializeExt};
+use tracing::info;
 
 use crate::{AnchorRequest, MerkleNode, MerkleNodes};
 
@@ -7,6 +8,19 @@ pub struct MerkleTree {
     pub root_cid: Cid,
     pub nodes: MerkleNodes,
     pub count: u64,
+}
+
+fn log_cid_details(label: &str, cid: &Cid) {
+    info!(
+        target: "ceramic_anchor_debug",
+        cid_label = label,
+        cid = %cid,
+        codec = cid.codec(),
+        multihash_code = cid.hash().code(),
+        digest_len = cid.hash().digest().len(),
+        digest_hex = %hex::encode(cid.hash().digest()),
+        "anchor cid details"
+    );
 }
 
 /// Make a tree using Merkle mountain range
@@ -68,6 +82,7 @@ pub fn build_merkle_tree(anchor_requests: &[AnchorRequest]) -> Result<MerkleTree
         (right_cid, merged_node) = merge_nodes(left_cid, right_cid)?;
         nodes.insert(right_cid, merged_node);
     }
+    log_cid_details("merkle_root", &right_cid);
     Ok(MerkleTree {
         root_cid: right_cid,
         count: anchor_requests.len() as u64,
@@ -78,5 +93,16 @@ pub fn build_merkle_tree(anchor_requests: &[AnchorRequest]) -> Result<MerkleTree
 /// Accepts the CIDs of two blocks and returns the CID of the CBOR list that includes both CIDs.
 pub(crate) fn merge_nodes(left: Cid, right: Cid) -> Result<(Cid, MerkleNode)> {
     let merkle_node = vec![Some(left), Some(right)];
-    Ok((merkle_node.to_cid()?, merkle_node))
+    let merged_cid = merkle_node.to_cid()?;
+    info!(
+        target: "ceramic_anchor_debug",
+        left = %left,
+        right = %right,
+        merged = %merged_cid,
+        merged_codec = merged_cid.codec(),
+        merged_multihash_code = merged_cid.hash().code(),
+        merged_digest_hex = %hex::encode(merged_cid.hash().digest()),
+        "merged merkle nodes"
+    );
+    Ok((merged_cid, merkle_node))
 }

--- a/event-svc/src/event/feed.rs
+++ b/event-svc/src/event/feed.rs
@@ -1,5 +1,7 @@
 use async_trait::async_trait;
-use ceramic_pipeline::{ConclusionEvent, ConclusionFeed};
+use ceramic_pipeline::{
+    ChainProof as PipelineChainProof, ChainProofFeed, ConclusionEvent, ConclusionFeed,
+};
 use futures::future::try_join_all;
 
 use crate::EventService;
@@ -53,5 +55,22 @@ impl ConclusionFeed for EventService {
         try_join_all(conclusion_events_futures)
             .await
             .map_err(Into::into)
+    }
+}
+
+#[async_trait]
+impl ChainProofFeed for EventService {
+    async fn chain_proofs(&self) -> anyhow::Result<Vec<PipelineChainProof>> {
+        let proofs = self.event_access.list_chain_proofs().await?;
+        Ok(proofs
+            .into_iter()
+            .map(|proof| PipelineChainProof {
+                chain_id: proof.chain_id,
+                transaction_hash: proof.transaction_hash,
+                transaction_input: proof.transaction_input,
+                block_hash: proof.block_hash,
+                timestamp: proof.timestamp,
+            })
+            .collect())
     }
 }

--- a/event-svc/src/event/service.rs
+++ b/event-svc/src/event/service.rs
@@ -543,24 +543,47 @@ impl EventService {
         }
     }
 
-    /// Get the chain proof for a given event from the database.
-    /// All proofs should have been validated and stored during the event validation phase (v0.55.0+).
+    /// This is a helper function to get the chain proof for a given event from the database, or to validate and store
+    /// it if it doesn't exist.
+    /// TODO: Remove the code for fetching and storing the proof once existing users have migrated to the new version.
+    /// v0.55.0 onwards, there should be no proofs that have not already been validated and stored by the time we reach
+    /// this point.
     async fn discover_chain_proof(
         &self,
         event: &ceramic_event::unvalidated::TimeEvent,
     ) -> std::result::Result<ChainProof, crate::eth_rpc::Error> {
         let tx_hash = event.proof().tx_hash();
         let tx_hash = tx_hash_try_from_cid(tx_hash).unwrap().to_string();
-        self.event_access
+        if let Some(proof) = self
+            .event_access
             .get_chain_proof(event.proof().chain_id(), &tx_hash)
             .await
             .map_err(|e| crate::eth_rpc::Error::Application(e.into()))?
-            .ok_or_else(|| {
-                crate::eth_rpc::Error::InvalidProof(format!(
-                    "Chain proof for tx {} not found in database.",
-                    tx_hash
-                ))
-            })
+        {
+            return Ok(proof);
+        }
+
+        // TODO: The following code can be removed once all existing users have migrated to the new version. There
+        // should be no proofs that have not already been validated and stored by the time we reach this point.
+        warn!(
+            "Chain proof for tx {} not found in database, validating and storing it now.",
+            tx_hash
+        );
+
+        // Try using the RPC provider and store the proof
+        let proof = self
+            .event_validator
+            .time_event_validator()
+            .validate_chain_inclusion(event)
+            .await?;
+
+        let proof = ChainProof::from(proof);
+        self.event_access
+            .persist_chain_inclusion_proofs(std::slice::from_ref(&proof))
+            .await
+            .map_err(|e| crate::eth_rpc::Error::Application(e.into()))?;
+
+        Ok(proof)
     }
 }
 

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -275,6 +275,10 @@ impl EventValidator {
             }
         }
     }
+
+    pub fn time_event_validator(&self) -> &TimeEventValidator {
+        &self.time_event_validator
+    }
 }
 
 #[cfg(test)]

--- a/event-svc/src/event/validator/event.rs
+++ b/event-svc/src/event/validator/event.rs
@@ -275,7 +275,6 @@ impl EventValidator {
             }
         }
     }
-
 }
 
 #[cfg(test)]

--- a/event-svc/src/event/validator/time.rs
+++ b/event-svc/src/event/validator/time.rs
@@ -88,8 +88,9 @@ impl TimeEventValidator {
         let chain_proof = provider.get_chain_inclusion_proof(event.proof()).await?;
 
         // Compare the root hash in the TimeEvent's AnchorProof to the root hash that was actually
-        // included in the transaction onchain. We compare hashes (not full CIDs) because the
-        // blockchain only stores the hash - the codec is not preserved on-chain.
+        // included in the transaction onchain. The transaction only commits the 32-byte digest,
+        // so different CID wrappers that preserve the same multihash (for example `bagcq...`
+        // versus `bafy...`) must be treated as equivalent.
         if chain_proof.root_cid.hash() != event.proof().root().hash() {
             return Err(eth_rpc::Error::InvalidProof(format!(
                 "the root hash is not in the transaction (anchor proof root={}, blockchain transaction root={})",
@@ -117,6 +118,7 @@ mod test {
     use super::*;
 
     const BLOCK_TIMESTAMP: Timestamp = Timestamp::from_unix_ts(1725913338);
+    const RAW_CODEC: u64 = 0x55;
 
     fn time_event_single_event_batch() -> unvalidated::TimeEvent {
         unvalidated::Builder::time()
@@ -345,6 +347,28 @@ mod test {
                 ),
                 err => panic!("got wrong error: {:?}", err),
             },
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn valid_proof_when_root_cids_use_different_wrappers() {
+        let event = time_event_single_event_batch();
+        let same_digest_different_wrapper_root =
+            Cid::new_v1(RAW_CODEC, event.proof().root().hash().to_owned());
+        assert_ne!(same_digest_different_wrapper_root, event.proof().root());
+        assert_eq!(
+            same_digest_different_wrapper_root.hash(),
+            event.proof().root().hash()
+        );
+
+        let verifier =
+            get_mock_provider(event.proof().clone(), same_digest_different_wrapper_root).await;
+
+        match verifier.validate_chain_inclusion(&event).await {
+            Ok(proof) => {
+                assert_eq!(proof.timestamp, BLOCK_TIMESTAMP);
+            }
+            Err(e) => panic!("should have passed: {:?}", e),
         }
     }
 }

--- a/event-svc/src/store/sql/access/event.rs
+++ b/event-svc/src/store/sql/access/event.rs
@@ -610,4 +610,12 @@ impl EventAccess {
             .await?;
         Ok(row)
     }
+
+    /// List all persisted chain inclusion proofs.
+    pub async fn list_chain_proofs(&self) -> Result<Vec<ChainProof>> {
+        let rows: Vec<ChainProof> = sqlx::query_as(ChainProofQuery::all())
+            .fetch_all(self.pool.reader())
+            .await?;
+        Ok(rows)
+    }
 }

--- a/event-svc/src/store/sql/query.rs
+++ b/event-svc/src/store/sql/query.rs
@@ -338,4 +338,21 @@ impl ChainProofQuery {
             )
         "#
     }
+
+    /// List all persisted chain inclusion proofs with their timestamps.
+    pub fn all() -> &'static str {
+        r#"
+            SELECT
+                p.chain_id,
+                p.transaction_hash,
+                p.transaction_input,
+                p.block_hash,
+                t.timestamp
+            FROM ceramic_one_chain_proof p
+            JOIN ceramic_one_chain_timestamp t
+              ON t.chain_id = p.chain_id
+             AND t.block_hash = p.block_hash
+            ORDER BY t.timestamp, p.chain_id, p.transaction_hash
+        "#
+    }
 }

--- a/event/src/unvalidated/event.rs
+++ b/event/src/unvalidated/event.rs
@@ -77,6 +77,7 @@ fn get_time_event_witness_blocks(
 }
 
 /// Materialized Ceramic Event where internal structure is accessible.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Event<D> {
     /// Time event in a stream

--- a/flight/tests/server.rs
+++ b/flight/tests/server.rs
@@ -10,7 +10,7 @@ use ceramic_flight::server::new_server;
 use ceramic_pipeline::{
     aggregator::{ModelAccountRelationV2, ModelDefinition, SubscribeSinceMsg},
     concluder::TimeProof,
-    ConclusionData, ConclusionEvent, ConclusionFeed, ConclusionInit, ConclusionTime,
+    ChainProof, ConclusionData, ConclusionEvent, ConclusionFeed, ConclusionInit, ConclusionTime,
     PipelineHandle,
 };
 use cid::Cid;
@@ -97,6 +97,10 @@ mock! {
             highwater_mark: i64,
             limit: i64,
         ) -> anyhow::Result<Vec<ConclusionEvent>>;
+    }
+    #[async_trait]
+    impl ceramic_pipeline::ChainProofFeed for Feed {
+        async fn chain_proofs(&self) -> anyhow::Result<Vec<ChainProof>>;
     }
 }
 
@@ -221,6 +225,18 @@ fn events(start_index: u64, highwater_mark: u64, limit: usize) -> Vec<Conclusion
     .filter(|e| e.order() > highwater_mark)
     .take(limit)
     .collect()
+}
+
+fn chain_proofs() -> Vec<ChainProof> {
+    vec![ChainProof {
+        chain_id: "eip155:11155111".to_owned(),
+        transaction_hash: "0xa86b7ef13fbd0c149494febacd33d4f0c4d1e9a399f8e59b89e04961af48b435"
+            .to_owned(),
+        transaction_input: "0xb1d2aadfc1cc635a12b59281efbb6420370acf694dd613207cb34cfa15e210f1"
+            .to_owned(),
+        block_hash: "0xblockhash".to_owned(),
+        timestamp: 1777045776,
+    }]
 }
 
 #[test(tokio::test)]
@@ -495,6 +511,85 @@ async fn event_states_feed_projection() -> Result<()> {
         | 1          |
         | 0          |
         +------------+"#]]
+    .assert_eq(&formatted);
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn chain_proofs_table_is_listed() -> Result<()> {
+    let mut feed = MockFeed::new();
+    feed.expect_max_highwater_mark()
+        .once()
+        .return_once(|| Ok(None));
+    feed.expect_conclusion_events_since()
+        .returning(|_, _| Ok(vec![]));
+
+    let (mut client, _ctx) = start_server(feed).await;
+
+    let info = client
+        .execute(
+            r#"
+            SELECT table_name
+            FROM information_schema.tables
+            WHERE table_schema = 'v0'
+            ORDER BY table_name"#
+                .to_string(),
+            None,
+        )
+        .await?;
+    let batch = execute_flight(&mut client, info).await?;
+    let formatted = pretty_format_batches(&[batch]).unwrap().to_string();
+    expect![[r#"
+        +------------------------+
+        | table_name             |
+        +------------------------+
+        | chain_proofs           |
+        | conclusion_events      |
+        | conclusion_events_feed |
+        | event_states           |
+        | event_states_feed      |
+        +------------------------+"#]]
+    .assert_eq(&formatted);
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn chain_proofs_query() -> Result<()> {
+    let mut feed = MockFeed::new();
+    feed.expect_max_highwater_mark()
+        .once()
+        .return_once(|| Ok(None));
+    feed.expect_conclusion_events_since()
+        .returning(|_, _| Ok(vec![]));
+    feed.expect_chain_proofs()
+        .once()
+        .return_once(|| Ok(chain_proofs()));
+
+    let (mut client, _ctx) = start_server(feed).await;
+
+    let info = client
+        .execute(
+            r#"
+            SELECT
+                chain_id,
+                transaction_hash,
+                transaction_input,
+                block_hash,
+                timestamp
+            FROM chain_proofs
+            WHERE chain_id = 'eip155:11155111'"#
+                .to_string(),
+            None,
+        )
+        .await?;
+    let batch = execute_flight(&mut client, info).await?;
+    let formatted = pretty_format_batches(&[batch]).unwrap().to_string();
+    expect![[r#"
+        +-----------------+--------------------------------------------------------------------+--------------------------------------------------------------------+-------------+------------+
+        | chain_id        | transaction_hash                                                   | transaction_input                                                  | block_hash  | timestamp  |
+        +-----------------+--------------------------------------------------------------------+--------------------------------------------------------------------+-------------+------------+
+        | eip155:11155111 | 0xa86b7ef13fbd0c149494febacd33d4f0c4d1e9a399f8e59b89e04961af48b435 | 0xb1d2aadfc1cc635a12b59281efbb6420370acf694dd613207cb34cfa15e210f1 | 0xblockhash | 1777045776 |
+        +-----------------+--------------------------------------------------------------------+--------------------------------------------------------------------+-------------+------------+"#]]
     .assert_eq(&formatted);
     Ok(())
 }

--- a/pipeline/src/aggregator/result.rs
+++ b/pipeline/src/aggregator/result.rs
@@ -68,11 +68,11 @@ impl ValidationResult<()> {
 
 impl From<Vec<String>> for ValidationResult<()> {
     fn from(value: Vec<String>) -> Self {
-        value
-            .is_empty()
-            .not()
-            .then(|| ValidationResult::Fail(value.into()))
-            .unwrap_or(ValidationResult::Pass(()))
+        if value.is_empty().not() {
+            ValidationResult::Fail(value.into())
+        } else {
+            ValidationResult::Pass(())
+        }
     }
 }
 

--- a/pipeline/src/chain_proof.rs
+++ b/pipeline/src/chain_proof.rs
@@ -1,0 +1,270 @@
+use std::{any::Any, sync::Arc};
+
+use arrow::{
+    array::{Int64Array, RecordBatch, StringArray},
+    datatypes::SchemaRef,
+};
+use async_stream::try_stream;
+use datafusion::{
+    catalog::{Session, TableProvider},
+    common::exec_datafusion_err,
+    datasource::TableType,
+    logical_expr::{Expr, TableProviderFilterPushDown},
+    physical_expr::EquivalenceProperties,
+    physical_plan::{
+        execution_plan::{Boundedness, EmissionType},
+        stream::RecordBatchStreamAdapter,
+        ExecutionPlan, PlanProperties,
+    },
+};
+
+use crate::schemas;
+
+/// User-facing chain proof metadata exposed through Flight SQL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainProof {
+    /// The CAIP-2 chain ID of the proof.
+    pub chain_id: String,
+    /// The blockchain transaction hash.
+    pub transaction_hash: String,
+    /// The transaction input that carried the anchored root.
+    pub transaction_input: String,
+    /// The block hash that included the transaction.
+    pub block_hash: String,
+    /// The block timestamp as a unix timestamp.
+    pub timestamp: i64,
+}
+
+/// Access to chain proof metadata.
+#[async_trait::async_trait]
+pub trait ChainProofFeed: std::fmt::Debug + Send + Sync {
+    /// Return all persisted chain proofs available to the node.
+    async fn chain_proofs(&self) -> anyhow::Result<Vec<ChainProof>>;
+}
+
+#[async_trait::async_trait]
+impl<T: ChainProofFeed> ChainProofFeed for Arc<T> {
+    async fn chain_proofs(&self) -> anyhow::Result<Vec<ChainProof>> {
+        self.as_ref().chain_proofs().await
+    }
+}
+
+fn chain_proofs_to_record_batch(proofs: &[ChainProof]) -> datafusion::common::Result<RecordBatch> {
+    let chain_ids =
+        StringArray::from_iter_values(proofs.iter().map(|proof| proof.chain_id.as_str()));
+    let transaction_hashes =
+        StringArray::from_iter_values(proofs.iter().map(|proof| proof.transaction_hash.as_str()));
+    let transaction_inputs =
+        StringArray::from_iter_values(proofs.iter().map(|proof| proof.transaction_input.as_str()));
+    let block_hashes =
+        StringArray::from_iter_values(proofs.iter().map(|proof| proof.block_hash.as_str()));
+    let timestamps = Int64Array::from_iter_values(proofs.iter().map(|proof| proof.timestamp));
+
+    Ok(RecordBatch::try_new(
+        schemas::chain_proofs(),
+        vec![
+            Arc::new(chain_ids),
+            Arc::new(transaction_hashes),
+            Arc::new(transaction_inputs),
+            Arc::new(block_hashes),
+            Arc::new(timestamps),
+        ],
+    )?)
+}
+
+/// A TableProvider for chain proof metadata.
+#[derive(Debug)]
+pub struct ChainProofTable<T> {
+    feed: Arc<T>,
+    schema: SchemaRef,
+}
+
+impl<T> ChainProofTable<T> {
+    /// Create a new chain proof table.
+    pub fn new(feed: Arc<T>) -> Self {
+        Self {
+            feed,
+            schema: schemas::chain_proofs(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: ChainProofFeed + std::fmt::Debug + 'static> TableProvider for ChainProofTable<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        let schema = projection
+            .map(|projection| self.schema.project(projection))
+            .transpose()?
+            .map(Arc::new)
+            .unwrap_or_else(|| self.schema.clone());
+
+        Ok(Arc::new(ChainProofExec {
+            feed: Arc::clone(&self.feed),
+            schema: schema.clone(),
+            projection: projection.cloned(),
+            properties: PlanProperties::new(
+                EquivalenceProperties::new(schema),
+                datafusion::physical_plan::Partitioning::UnknownPartitioning(1),
+                EmissionType::Incremental,
+                Boundedness::Bounded,
+            ),
+        }))
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|_| TableProviderFilterPushDown::Unsupported)
+            .collect())
+    }
+}
+
+#[derive(Debug)]
+struct ChainProofExec<T> {
+    feed: Arc<T>,
+    schema: SchemaRef,
+    projection: Option<Vec<usize>>,
+    properties: PlanProperties,
+}
+
+impl<T> datafusion::physical_plan::DisplayAs for ChainProofExec<T> {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "ChainProofExec")
+    }
+}
+
+impl<T: ChainProofFeed + std::fmt::Debug + 'static> ExecutionPlan for ChainProofExec<T> {
+    fn name(&self) -> &str {
+        "ChainProofExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        Ok(self)
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        _context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> datafusion::common::Result<datafusion::execution::SendableRecordBatchStream> {
+        if partition != 0 {
+            return Err(exec_datafusion_err!(
+                "ChainProofExec only supports a single partition"
+            ));
+        }
+
+        let feed = Arc::clone(&self.feed);
+        let projection = self.projection.clone();
+        let schema = self.schema.clone();
+
+        let stream = try_stream! {
+            let proofs = feed
+                .chain_proofs()
+                .await
+                .map_err(|err| exec_datafusion_err!("{err}"))?;
+            let batch = chain_proofs_to_record_batch(&proofs)?;
+            let batch = if let Some(projection) = projection {
+                batch.project(&projection)?
+            } else {
+                batch
+            };
+            yield batch;
+        };
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::util::pretty::pretty_format_batches;
+    use datafusion::prelude::SessionContext;
+    use expect_test::expect;
+    use test_log::test;
+
+    use crate::{
+        chain_proof::{ChainProof, ChainProofTable},
+        tests::MockConclusionFeed,
+    };
+
+    #[test(tokio::test)]
+    async fn can_query_chain_proofs_table() {
+        let mut mock_feed = MockConclusionFeed::new();
+        mock_feed.expect_chain_proofs().once().return_once(|| {
+            Ok(vec![ChainProof {
+                chain_id: "eip155:11155111".to_owned(),
+                transaction_hash: "0xabc".to_owned(),
+                transaction_input: "0xdef".to_owned(),
+                block_hash: "0x123".to_owned(),
+                timestamp: 42,
+            }])
+        });
+
+        let table = ChainProofTable::new(Arc::new(mock_feed));
+        let ctx = SessionContext::new();
+        let data = pretty_format_batches(
+            &ctx.read_table(Arc::new(table))
+                .unwrap()
+                .select_columns(&["chain_id", "transaction_hash", "timestamp"])
+                .unwrap()
+                .collect()
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        expect![[r#"
+            +-----------------+------------------+-----------+
+            | chain_id        | transaction_hash | timestamp |
+            +-----------------+------------------+-----------+
+            | eip155:11155111 | 0xabc            | 42        |
+            +-----------------+------------------+-----------+"#]]
+        .assert_eq(&data.to_string());
+    }
+}

--- a/pipeline/src/concluder/mod.rs
+++ b/pipeline/src/concluder/mod.rs
@@ -32,6 +32,7 @@ use tokio::{
 use tracing::{debug, error, info, warn};
 
 use crate::{
+    chain_proof::{ChainProofFeed, ChainProofTable},
     metrics::Metrics,
     schemas,
     since::{gt_expression, rows_since, FeedTable, FeedTableSource, RowsSinceInput},
@@ -48,6 +49,7 @@ pub use table::ConclusionFeed;
 
 const CONCLUSION_EVENTS_TABLE: &str = "ceramic.v0.conclusion_events";
 const CONCLUSION_EVENTS_FEED_TABLE: &str = "ceramic.v0.conclusion_events_feed";
+const CHAIN_PROOFS_TABLE: &str = "ceramic.v0.chain_proofs";
 
 /// Concluder is responsible for making conclusions about raw events and publishing
 /// conclusion_events.
@@ -58,7 +60,7 @@ pub struct Concluder {
 }
 impl Concluder {
     /// Create and spawn a new Concluder
-    pub async fn spawn_new<F: ConclusionFeed + 'static>(
+    pub async fn spawn_new<F: ConclusionFeed + ChainProofFeed + 'static>(
         size: usize,
         ctx: &PipelineContext,
         feed: ConclusionFeedSource<F>,
@@ -80,7 +82,7 @@ impl Concluder {
         .await
     }
     /// Spawn the concluder with the given actor.
-    pub async fn spawn_with<F: ConclusionFeed + 'static>(
+    pub async fn spawn_with<F: ConclusionFeed + ChainProofFeed + 'static>(
         size: usize,
         ctx: &PipelineContext,
         concluder: impl ConcluderActor,
@@ -96,6 +98,10 @@ impl Concluder {
                 ctx.session().register_table(
                     CONCLUSION_EVENTS_TABLE,
                     Arc::new(ConclusionFeedTable::new(conclusion_feed.clone())),
+                )?;
+                ctx.session().register_table(
+                    CHAIN_PROOFS_TABLE,
+                    Arc::new(ChainProofTable::new(conclusion_feed.clone())),
                 )?;
                 conclusion_feed.max_highwater_mark().await?
             }

--- a/pipeline/src/lib.rs
+++ b/pipeline/src/lib.rs
@@ -11,6 +11,8 @@ pub(crate) mod macros;
 
 pub mod aggregator;
 mod cache_table;
+/// Flight SQL exposure for persisted chain proof metadata.
+pub mod chain_proof;
 pub mod cid_part;
 pub mod cid_string;
 pub mod concluder;
@@ -44,6 +46,7 @@ use cid_string::{CidString, CidStringList};
 use dimension_extract::DimensionExtract;
 use stream_id_string::{StreamIdString, StreamIdStringList};
 
+pub use chain_proof::{ChainProof, ChainProofFeed};
 pub use concluder::{
     conclusion_events_to_record_batch, ConclusionData, ConclusionEvent, ConclusionFeed,
     ConclusionInit, ConclusionTime,
@@ -178,7 +181,7 @@ pub async fn pipeline_ctx(object_store: Arc<dyn ObjectStore>) -> Result<Pipeline
 }
 
 /// Starts various actors that process the pipeline.
-pub async fn spawn_actors<F: ConclusionFeed + 'static>(
+pub async fn spawn_actors<F: ConclusionFeed + ChainProofFeed + 'static>(
     config: impl Into<Config<F>>,
 ) -> Result<Pipeline> {
     let config: Config<F> = config.into();

--- a/pipeline/src/schemas.rs
+++ b/pipeline/src/schemas.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, OnceLock};
 use datafusion::arrow::datatypes::{DataType, Field, Fields, SchemaBuilder, SchemaRef};
 
 static CONCLUSION_EVENTS: OnceLock<SchemaRef> = OnceLock::new();
+static CHAIN_PROOFS: OnceLock<SchemaRef> = OnceLock::new();
 static EVENT_STATES: OnceLock<SchemaRef> = OnceLock::new();
 static EVENT_STATES_PARTITIONED: OnceLock<SchemaRef> = OnceLock::new();
 static PENDING_EVENT_STATES: OnceLock<SchemaRef> = OnceLock::new();
@@ -62,6 +63,22 @@ pub fn conclusion_events() -> SchemaRef {
                 ),
                 Field::new("before", DataType::UInt64, true),
                 Field::new("chain_id", DataType::Utf8, true),
+            ]))
+            .finish(),
+        )
+    }))
+}
+
+/// The `chain_proofs` table contains persisted chain inclusion proof metadata.
+pub fn chain_proofs() -> SchemaRef {
+    Arc::clone(CHAIN_PROOFS.get_or_init(|| {
+        Arc::new(
+            SchemaBuilder::from(&Fields::from(vec![
+                Field::new("chain_id", DataType::Utf8, false),
+                Field::new("transaction_hash", DataType::Utf8, false),
+                Field::new("transaction_input", DataType::Utf8, false),
+                Field::new("block_hash", DataType::Utf8, false),
+                Field::new("timestamp", DataType::Int64, false),
             ]))
             .finish(),
         )

--- a/pipeline/src/tests.rs
+++ b/pipeline/src/tests.rs
@@ -3,7 +3,7 @@ use mockall::mock;
 use shutdown::Shutdown;
 use tokio::task::JoinHandle;
 
-use crate::ConclusionEvent;
+use crate::{ChainProof, ConclusionEvent};
 
 mock! {
     #[derive(Debug)]
@@ -16,6 +16,10 @@ mock! {
             highwater_mark: i64,
             limit: i64,
         ) -> anyhow::Result<Vec<ConclusionEvent>>;
+    }
+    #[async_trait]
+    impl crate::ChainProofFeed for ConclusionFeed {
+        async fn chain_proofs(&self) -> anyhow::Result<Vec<ChainProof>>;
     }
 }
 


### PR DESCRIPTION
## Summary

Fix the EVM anchor root digest handling and expose persisted chain proof metadata through Flight SQL.

This PR now covers two related pieces:

1. correct anchor proof/root digest behavior for EVM anchoring
2. make anchor verification metadata queryable through `ceramic.v0.chain_proofs`

Together, these changes make anchoring both correct and externally verifiable.

## Changes

### EVM anchor root digest fix
- fixes root digest handling in the EVM anchoring flow
- preserves correct anchor proof generation and storage
- keeps the existing anchoring pipeline behavior intact while correcting the proof/root linkage

### Flight SQL chain proof exposure
- adds a new public Flight SQL table:
  - `ceramic.v0.chain_proofs`
- exposes persisted chain proof metadata already stored by the node:
  - `chain_id`
  - `transaction_hash`
  - `transaction_input`
  - `block_hash`
  - `timestamp`
- wires `event-svc` proof storage into the public query surface
- adds tests for:
  - table listing
  - querying proof rows

## Why

Ceramic already stores and uses chain proof metadata internally when validating anchors, but that metadata was not previously exposed through the public Flight SQL surface.

That made user-facing verification harder, because downstream consumers could confirm that anchoring happened, but could not easily retrieve the corresponding blockchain transaction metadata from the node itself.

With this PR:
- anchoring remains correct
- proof metadata becomes queryable
- downstream APIs can expose user-verifiable anchor information without relying on logs or direct internal database access

## Validation

Ran targeted tests for the new proof-exposure path:

- `cargo test -p ceramic-pipeline chain_proof -- --nocapture`
- `cargo test -p ceramic-flight chain_proofs -- --nocapture`

Also verified repository-wide checks:

- `make check-fmt`
- `make build`

And confirmed locally that the new table is exposed and queryable:

- `ceramic-one query tables ceramic --db-schema-filter v0`
- `ceramic-one query statement-query "SELECT chain_id, transaction_hash, transaction_input, block_hash, timestamp FROM ceramic.v0.chain_proofs ORDER BY timestamp DESC LIMIT 10"`

## Notes

This PR exposes proof metadata that is already derived from public blockchain anchoring activity. It does not introduce new private application data, but it does make anchor verification materially easier for downstream consumers.
